### PR TITLE
Bluetooth devices on the menu, without a Connect button that cannot work

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -226,7 +226,17 @@ config :mayonnaios, :programs, [
   # It takes hci0 for as long as it runs, so it cannot be up at the same time
   # as anything else that wants the Bluetooth controller. That is why it is
   # here as a menu entry and not in the boot supervision tree.
-  %{name: "Bluetooth controller", app: MayonnaiOS.Controller}
+  %{name: "Bluetooth controller", app: MayonnaiOS.Controller},
+  # The other direction, and it takes hci0 for the same reason, so these two
+  # are mutually exclusive and the launcher's one-app-at-a-time rule is what
+  # enforces it.
+  #
+  # Named "devices" rather than "pairing" deliberately. What it does is list
+  # what is nearby and manage the pairings this device already has; it cannot
+  # connect headphones, because that is A2DP over BR/EDR and there is no
+  # BR/EDR host in this firmware. `MayonnaiOS.Pairing` has the full account,
+  # and the screen says it in the first line rather than in a footnote.
+  %{name: "Bluetooth devices", app: MayonnaiOS.Pairing}
 ]
 
 # The name a host shows in its pairing list, and the icon it draws next to it

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -26,7 +26,7 @@ defmodule MayonnaiOS.Application do
         [{Scenic, [Application.get_env(:mayonnaios, :viewport)]}]
       else
         []
-      end ++ [controller_sessions()] ++ target_children()
+      end ++ [controller_sessions(), pairing_sessions()] ++ target_children()
 
     # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
@@ -40,6 +40,15 @@ defmodule MayonnaiOS.Application do
   # laptop with the bind error rather than with "no such supervisor", which is
   # a much less interesting thing to be told.
   defp controller_sessions, do: MayonnaiOS.Controller.sessions()
+
+  # The same arrangement for the Bluetooth devices app, and a second empty
+  # DynamicSupervisor rather than a shared one on purpose: the two apps want
+  # hci0 and cannot both have it, and a single supervisor holding both would
+  # make that collision look like a supervision decision instead of what it
+  # is -- one radio. Starting the second while the first runs fails on
+  # `MayonnaiOS.Bluetooth.Host`'s registered name, which is a reason the panel
+  # can print.
+  defp pairing_sessions, do: MayonnaiOS.Pairing.sessions()
 
   # List all child processes to be supervised
   if Mix.target() == :host do

--- a/lib/mayonnaios/bluetooth/bonds.ex
+++ b/lib/mayonnaios/bluetooth/bonds.ex
@@ -23,11 +23,25 @@ defmodule MayonnaiOS.Bluetooth.Bonds do
 
   ## Why a term file and not a database
 
-  Two keys, sixteen bytes each, written when someone pairs. `:erlang.term_to_binary`
-  and a rename over the top is the whole implementation, and a rename is
-  atomic on ext4, so a power cut during a write leaves the previous file
-  rather than half of a new one -- which matters on a handheld that is turned
-  off by pulling the power.
+  Two keys, sixteen bytes each, written when someone pairs. `:erlang.term_to_binary`,
+  an fsync, and a rename over the top is the whole implementation.
+
+  ## The fsync is the whole point of the file
+
+  A rename being atomic says the file will not be half a new bond. It says
+  nothing about the bytes reaching the card, and on this device that is the
+  part that bites: there is no `sync` in the image -- not the binary, not a
+  busybox applet -- so anything written and left to the page cache is gone
+  after a power cut, which is how this handheld is switched off. That has
+  already eaten a set of ROMs once on this board.
+
+  So `write/1` opens the temporary file, writes, calls `:file.sync/1`, closes
+  and only then renames. The rename itself is not fsynced -- there is no
+  portable way to fsync a directory from Erlang -- so a power cut in the gap
+  between the sync and the rename leaves the *previous* file intact, which is
+  the same outcome as the write never having happened and costs one
+  re-pairing. Losing the new bond is survivable; writing a bond, reporting
+  success, and having it vanish is the failure this project keeps making.
 
   The file has no format version. When the shape here changes, a file that
   does not decode is treated as no bonds at all: re-pairing is a known, small
@@ -88,6 +102,18 @@ defmodule MayonnaiOS.Bluetooth.Bonds do
   @spec clear() :: :ok
   def clear, do: GenServer.call(__MODULE__, :clear)
 
+  @doc """
+  Forget one host, named by the peer address a `list/0` entry carries.
+
+  One at a time rather than only all at once, because the thing someone
+  actually wants to do is drop the laptop they were testing against and keep
+  the machine they play on. Returns `:ok` whether or not anything matched:
+  the panel re-reads the list after every press, so a bond that was already
+  gone is not an error to report, it is a row that is no longer there.
+  """
+  @spec forget({0..1, binary()}) :: :ok
+  def forget(peer), do: GenServer.call(__MODULE__, {:forget, peer})
+
   @impl true
   def init(_opts) do
     {:ok, %{bonds: read()}}
@@ -106,6 +132,17 @@ defmodule MayonnaiOS.Bluetooth.Bonds do
     # and pair again would otherwise leave a key nothing can ever use.
     bonds = [bond | Enum.reject(state.bonds, &(&1.peer == bond.peer))]
     write(bonds)
+    {:reply, :ok, %{state | bonds: bonds}}
+  end
+
+  def handle_call({:forget, peer}, _from, state) do
+    bonds = Enum.reject(state.bonds, &(&1.peer == peer))
+
+    # Only write when something changed. The file is on the writable partition
+    # and every write is an fsync; answering a press on a row that is already
+    # gone with a flash write is a small waste that would happen on repeat.
+    if bonds != state.bonds, do: write(bonds)
+
     {:reply, :ok, %{state | bonds: bonds}}
   end
 
@@ -142,12 +179,33 @@ defmodule MayonnaiOS.Bluetooth.Bonds do
     temporary = path <> ".new"
 
     with :ok <- File.mkdir_p(Path.dirname(path)),
-         :ok <- File.write(temporary, :erlang.term_to_binary(bonds)),
+         :ok <- durable_write(temporary, :erlang.term_to_binary(bonds)),
          :ok <- File.rename(temporary, path) do
       :ok
     else
       error ->
         Logger.error("[bonds] could not write #{path}: #{inspect(error)}")
+        error
+    end
+  end
+
+  # Write, fsync, close. `File.write/2` on its own is the version of this that
+  # looks right and loses the bond; see the moduledoc on why the sync is the
+  # only part of the durability story this device actually gets.
+  defp durable_write(path, contents) do
+    case :file.open(path, [:write, :binary, :raw]) do
+      {:ok, handle} ->
+        result =
+          with :ok <- :file.write(handle, contents) do
+            :file.sync(handle)
+          end
+
+        # Closed whatever happened. A leaked handle on the writable partition
+        # outlives the app and there is no lsof here to find it with.
+        :file.close(handle)
+        result
+
+      error ->
         error
     end
   end

--- a/lib/mayonnaios/bluetooth/hci.ex
+++ b/lib/mayonnaios/bluetooth/hci.ex
@@ -54,6 +54,7 @@ defmodule MayonnaiOS.Bluetooth.HCI do
 
   # LE meta subevents.
   @le_connection_complete 0x01
+  @le_advertising_report 0x02
   @le_connection_update_complete 0x03
   @le_read_remote_features_complete 0x04
   @le_long_term_key_request 0x05
@@ -74,6 +75,8 @@ defmodule MayonnaiOS.Bluetooth.HCI do
   @op_le_set_advertising_data 0x2008
   @op_le_set_scan_response_data 0x2009
   @op_le_set_advertise_enable 0x200A
+  @op_le_set_scan_parameters 0x200B
+  @op_le_set_scan_enable 0x200C
   @op_le_long_term_key_request_reply 0x201A
   @op_le_long_term_key_request_negative_reply 0x201B
 
@@ -93,6 +96,8 @@ defmodule MayonnaiOS.Bluetooth.HCI do
   def opcode(:le_set_advertising_data), do: @op_le_set_advertising_data
   def opcode(:le_set_scan_response_data), do: @op_le_set_scan_response_data
   def opcode(:le_set_advertise_enable), do: @op_le_set_advertise_enable
+  def opcode(:le_set_scan_parameters), do: @op_le_set_scan_parameters
+  def opcode(:le_set_scan_enable), do: @op_le_set_scan_enable
   def opcode(:le_long_term_key_request_reply), do: @op_le_long_term_key_request_reply
 
   def opcode(:le_long_term_key_request_negative_reply),
@@ -122,6 +127,8 @@ defmodule MayonnaiOS.Bluetooth.HCI do
       :le_set_advertising_data,
       :le_set_scan_response_data,
       :le_set_advertise_enable,
+      :le_set_scan_parameters,
+      :le_set_scan_enable,
       :le_long_term_key_request_reply,
       :le_long_term_key_request_negative_reply
     ]
@@ -259,6 +266,59 @@ defmodule MayonnaiOS.Bluetooth.HCI do
   @spec le_set_scan_response_data(binary()) :: binary()
   def le_set_scan_response_data(data) when byte_size(data) <= 31 do
     command(:le_set_scan_response_data, <<byte_size(data), pad(data, 31)::binary>>)
+  end
+
+  @doc """
+  Scan parameters: active scanning, so scan responses come back too.
+
+  Active (0x01) rather than passive because a passive scan sees only the
+  advertisement, and most devices keep their name in the *scan response* --
+  this project's own peripheral does, because the name did not fit in the
+  31-byte advertisement. A passive scan of a room therefore produces a list
+  of addresses with no names in it, which is indistinguishable from a scan
+  that is not working.
+
+  Interval and window are in units of 0.625 ms. 37.5 ms interval with a
+  30 ms window is an 80% duty cycle: high enough that a device advertising
+  at the slow end of the usual range turns up in a second or two, and not
+  continuous, which would leave the radio no gaps at all.
+  """
+  @spec le_set_scan_parameters(keyword()) :: binary()
+  def le_set_scan_parameters(opts \\ []) do
+    # 0x01 = active. 0x00 would be passive.
+    type = Keyword.get(opts, :type, 0x01)
+    interval = Keyword.get(opts, :interval, 0x0060)
+    window = Keyword.get(opts, :window, 0x0030)
+    # 0x00 = the controller's public address, the same choice advertising
+    # makes: this device has a real one from the Realtek part.
+    own_address_type = Keyword.get(opts, :own_address_type, 0x00)
+    # 0x00 = accept every advertisement. There is no accept list to filter
+    # against, and filtering is what a scan screen exists not to do.
+    filter_policy = Keyword.get(opts, :filter_policy, 0x00)
+
+    command(
+      :le_set_scan_parameters,
+      <<type, interval::16-little, window::16-little, own_address_type, filter_policy>>
+    )
+  end
+
+  @doc """
+  Start or stop scanning.
+
+  `filter_duplicates` defaults to **false**, which is the opposite of what
+  most examples do, and it is deliberate. With duplicate filtering on, the
+  controller reports each address once and then goes quiet, so a device that
+  has been switched off or carried out of range stays on the screen forever
+  with nothing to say it is gone. With it off, every advertisement arrives,
+  which is what lets the list carry an age and an RSSI that mean something.
+
+  The cost is one event per advertising interval per device -- tens per
+  second in a busy room. That is a handful of small binaries to decode, and
+  cheaper than a list that lies.
+  """
+  @spec le_set_scan_enable(boolean(), boolean()) :: binary()
+  def le_set_scan_enable(enabled, filter_duplicates \\ false) do
+    command(:le_set_scan_enable, <<bool(enabled), bool(filter_duplicates)>>)
   end
 
   @doc "Start or stop advertising."
@@ -432,6 +492,24 @@ defmodule MayonnaiOS.Bluetooth.HCI do
      }}
   end
 
+  # The reports are interleaved, not columnar, and that is the trap.
+  #
+  # The specification writes this event's parameters as parallel arrays --
+  # Event_Type[i], Address_Type[i], Address[i], Data_Length[i], Data[i],
+  # RSSI[i] -- which reads as six arrays laid end to end. It is not: each
+  # report is a complete record and they follow one another. The reference
+  # for that reading is the kernel's own, `struct hci_ev_le_advertising_info`
+  # in `include/net/bluetooth/hci.h` -- type, bdaddr_type, bdaddr, length,
+  # data[] -- with the RSSI taken as the byte after the data, which is how
+  # the kernel's LE advertising report handler walks the buffer.
+  #
+  # Num_Reports is 0x01 on every controller anyone has met, so the columnar
+  # reading parses the common case correctly and falls apart only in a busy
+  # room -- which is the worst possible time to find out.
+  defp le_meta(@le_advertising_report, <<count, rest::binary>>) do
+    {:event, :le_advertising_report, %{reports: advertising_reports(rest, count, [])}}
+  end
+
   defp le_meta(
          @le_connection_update_complete,
          <<status, handle::16-little, interval::16-little, latency::16-little,
@@ -462,6 +540,44 @@ defmodule MayonnaiOS.Bluetooth.HCI do
   end
 
   defp le_meta(subevent, params), do: {:event, {:le_meta, subevent}, %{params: params}}
+
+  defp advertising_reports(_rest, 0, acc), do: Enum.reverse(acc)
+
+  defp advertising_reports(
+         <<event_type, address_type, peer::binary-6, length, data::binary-size(length),
+           rssi::signed-8, rest::binary>>,
+         count,
+         acc
+       ) do
+    report = %{
+      event_type: advertising_event_type(event_type),
+      address_type: address_type,
+      address: address(peer),
+      address_bytes: peer,
+      data: data,
+      # 127 is the specification's "not available", and it is a real value a
+      # controller sends. Reported as nil rather than as an absurdly strong
+      # signal, because +127 dBm sorted to the top of a list would be the
+      # loudest thing in the room.
+      rssi: if(rssi == 127, do: nil, else: rssi)
+    }
+
+    advertising_reports(rest, count - 1, [report | acc])
+  end
+
+  # A truncated or malformed run: keep the reports that did parse. The
+  # alternative is a function clause error inside the socket reader, which
+  # would take the whole stack down over one bad event.
+  defp advertising_reports(_rest, _count, acc), do: Enum.reverse(acc)
+
+  # ADV_IND and ADV_DIRECT_IND are the connectable ones; SCAN_RSP is the
+  # answer to an active scan and is where names usually live.
+  defp advertising_event_type(0x00), do: :adv_ind
+  defp advertising_event_type(0x01), do: :adv_direct_ind
+  defp advertising_event_type(0x02), do: :adv_scan_ind
+  defp advertising_event_type(0x03), do: :adv_nonconn_ind
+  defp advertising_event_type(0x04), do: :scan_rsp
+  defp advertising_event_type(other), do: other
 
   defp completed(<<>>, _count, acc), do: Enum.reverse(acc)
 

--- a/lib/mayonnaios/bluetooth/scan.ex
+++ b/lib/mayonnaios/bluetooth/scan.ex
@@ -1,0 +1,265 @@
+defmodule MayonnaiOS.Bluetooth.Scan do
+  @moduledoc """
+  A list of what is advertising nearby, built up out of HCI reports.
+
+  Pure functions over `MayonnaiOS.Bluetooth.HCI` advertising reports, in the
+  same spirit as the rest of this stack: the socket needs the handheld, but
+  everything that can be *wrong* about turning a burst of reports into a
+  screenful of devices is a fold over binaries and can be checked on a
+  laptop. `MayonnaiOS.Bluetooth.Scanner` is the process that feeds this.
+
+  ## One device is several reports, and that is the whole problem
+
+  An active scan produces at least two reports per device: the
+  advertisement, and the scan response that answers the scan request. They
+  arrive as separate events, they carry different fields, and only one of
+  them usually has the name in it. So merging is not an optimisation here --
+  without it, a scan of one pair of headphones produces two rows, one of
+  which is nameless.
+
+  Merging is per field, and a field is only overwritten when the new report
+  actually carries it. A device that sends a name in its scan response and
+  then advertises again without one must not lose the name it already showed;
+  `merge/2` therefore takes the new value only when it is not nil. Getting
+  that backwards produces a name that flickers on and off at the advertising
+  interval, which reads as a radio problem rather than a fold problem.
+
+  ## Ordering is by when it was first seen, never by signal strength
+
+  Sorting by RSSI is the obvious thing and it is wrong for this device. The
+  cursor is a D-pad and the list refreshes twice a second; sorting by a
+  number that moves means the row under the cursor changes between deciding
+  to press A and pressing it. First-seen order is arbitrary but stable, so
+  the list only ever grows downwards and a selection stays where it was put.
+
+  ## What "BR/EDR" in the flags is doing here
+
+  Every advertisement may carry a Flags structure, and bit 2 of it is
+  "BR/EDR Not Supported" -- the same bit `MayonnaiOS.Bluetooth.Advertising`
+  sets on the way out, for the same reason in reverse. Clear, it means the
+  device also speaks the classic transport.
+
+  That bit is the honest answer to "why can I see my headphones and not
+  connect to them". Bluetooth audio is A2DP, A2DP is BR/EDR, and this
+  firmware has no BR/EDR host at all: no BlueZ in the image, and the L2CAP
+  here is the three fixed LE channels with no connection-oriented channels
+  to carry AVDTP over. So a device advertising with that bit clear is
+  reachable-looking and not reachable, and `dual_mode?/1` is what lets the
+  screen say so on the row rather than in a footnote.
+  """
+
+  import Bitwise
+
+  alias MayonnaiOS.Bluetooth.Advertising
+
+  # Common Data Types, the ones worth reading off a scan. The same numbers
+  # Advertising encodes; named again here rather than imported because that
+  # module's map is about what this device sends.
+  @ad_flags 0x01
+  @ad_incomplete_uuid16 0x02
+  @ad_complete_uuid16 0x03
+  @ad_short_name 0x08
+  @ad_complete_name 0x09
+  @ad_appearance 0x19
+
+  # Flags bit 2: BR/EDR Not Supported.
+  @flag_no_bredr 0x04
+
+  @typedoc "One device, as far as its reports say."
+  @type device :: %{
+          address: String.t(),
+          address_type: 0..3,
+          name: String.t() | nil,
+          shortened_name?: boolean(),
+          flags: non_neg_integer() | nil,
+          appearance: non_neg_integer() | nil,
+          services: [non_neg_integer()],
+          connectable?: boolean(),
+          rssi: integer() | nil,
+          reports: pos_integer(),
+          first_seen: integer(),
+          last_seen: integer(),
+          sequence: non_neg_integer()
+        }
+
+  @typedoc "The accumulated scan."
+  @type t :: %__MODULE__{
+          devices: %{optional({0..3, String.t()}) => device()},
+          next: non_neg_integer()
+        }
+
+  defstruct devices: %{}, next: 0
+
+  @doc "An empty scan."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Fold one report in.
+
+  `now` is a monotonic millisecond reading, passed in rather than taken here
+  so that a test can advance time without sleeping and so that two reports
+  from the same event share one timestamp.
+  """
+  @spec observe(t(), map(), integer()) :: t()
+  def observe(%__MODULE__{} = scan, report, now) do
+    key = {report.address_type, report.address}
+    fresh = describe(report, now, scan.next)
+
+    case Map.fetch(scan.devices, key) do
+      {:ok, existing} ->
+        %{scan | devices: Map.put(scan.devices, key, merge(existing, fresh))}
+
+      :error ->
+        %{scan | devices: Map.put(scan.devices, key, fresh), next: scan.next + 1}
+    end
+  end
+
+  @doc "Every device seen, in the order they were first seen."
+  @spec list(t()) :: [device()]
+  def list(%__MODULE__{devices: devices}) do
+    devices |> Map.values() |> Enum.sort_by(& &1.sequence)
+  end
+
+  @doc "How many devices are in the list."
+  @spec count(t()) :: non_neg_integer()
+  def count(%__MODULE__{devices: devices}), do: map_size(devices)
+
+  @doc """
+  Drop devices that have not advertised for `stale_ms`.
+
+  Not called on a timer by default. It exists because duplicate filtering is
+  off (see `MayonnaiOS.Bluetooth.HCI.le_set_scan_enable/2`), so a device that
+  has gone away stops producing reports and its age is the evidence -- and a
+  screen is a better place to show that age than to hide it behind a
+  disappearing row.
+  """
+  @spec forget_stale(t(), integer(), pos_integer()) :: t()
+  def forget_stale(%__MODULE__{devices: devices} = scan, now, stale_ms) do
+    kept = Map.reject(devices, fn {_key, device} -> now - device.last_seen > stale_ms end)
+    %{scan | devices: kept}
+  end
+
+  @doc """
+  Whether this device also speaks the classic transport.
+
+  True when a Flags structure was seen and its "BR/EDR Not Supported" bit is
+  clear. `nil` when no Flags structure has arrived yet, which is a different
+  thing from "LE only" and is why this is not a boolean: a scan response on
+  its own carries no flags, and answering false there would label a pair of
+  headphones as LE-only for as long as it took the next advertisement to
+  arrive.
+  """
+  @spec dual_mode?(device()) :: boolean() | nil
+  def dual_mode?(%{flags: nil}), do: nil
+  def dual_mode?(%{flags: flags}), do: band(flags, @flag_no_bredr) == 0
+
+  @doc "How long ago this device last advertised, in milliseconds."
+  @spec age(device(), integer()) :: non_neg_integer()
+  def age(device, now), do: max(now - device.last_seen, 0)
+
+  @doc """
+  Something to show when a device has no name.
+
+  The address, not "(unknown)": two nameless devices are then still two
+  distinguishable rows, and the address is the thing to type into a search
+  engine when one of them turns out to be interesting.
+  """
+  @spec label(device()) :: String.t()
+  def label(%{name: nil, address: address}), do: address
+  def label(%{name: name}), do: name
+
+  # -- turning one report into one device -------------------------------------
+
+  defp describe(report, now, sequence) do
+    structures = Advertising.decode(report.data)
+
+    %{
+      address: report.address,
+      address_type: report.address_type,
+      name: name_of(structures),
+      shortened_name?:
+        has?(structures, @ad_short_name) and not has?(structures, @ad_complete_name),
+      flags: first_byte(structures, @ad_flags),
+      appearance: uuid16(structures, @ad_appearance),
+      services: services(structures),
+      connectable?: report.event_type in [:adv_ind, :adv_direct_ind],
+      rssi: report.rssi,
+      reports: 1,
+      first_seen: now,
+      last_seen: now,
+      sequence: sequence
+    }
+  end
+
+  # The merge rule, stated once: identity and firsts come from the old
+  # record, counters accumulate, and every descriptive field is taken from
+  # the new one only if the new one has it.
+  defp merge(old, new) do
+    %{
+      old
+      | name: new.name || old.name,
+        shortened_name?: if(new.name, do: new.shortened_name?, else: old.shortened_name?),
+        flags: new.flags || old.flags,
+        appearance: new.appearance || old.appearance,
+        services: if(new.services == [], do: old.services, else: new.services),
+        # Connectability is sticky in one direction. A scan response is
+        # reported with its own event type, so a device that advertised
+        # ADV_IND and then answered a scan request would otherwise be
+        # downgraded to unconnectable by its own reply.
+        connectable?: old.connectable? or new.connectable?,
+        rssi: new.rssi || old.rssi,
+        reports: old.reports + 1,
+        last_seen: new.last_seen
+    }
+  end
+
+  # A complete name wins over a shortened one when both are somehow present.
+  defp name_of(structures) do
+    with nil <- value(structures, @ad_complete_name),
+         nil <- value(structures, @ad_short_name) do
+      nil
+    else
+      # Names are UTF-8 on the wire and a device is free to send something
+      # that is not. Printing raw bytes into a Scenic text primitive is how a
+      # scene crashes on a stranger's kettle, so anything invalid is dropped
+      # back to nil and the row falls through to showing the address.
+      name -> if String.valid?(name), do: name
+    end
+  end
+
+  defp services(structures) do
+    (list16(structures, @ad_complete_uuid16) ++ list16(structures, @ad_incomplete_uuid16))
+    |> Enum.uniq()
+  end
+
+  defp value(structures, type) do
+    Enum.find_value(structures, fn
+      {^type, value} -> value
+      _ -> nil
+    end)
+  end
+
+  defp has?(structures, type), do: value(structures, type) != nil
+
+  defp first_byte(structures, type) do
+    case value(structures, type) do
+      <<byte, _rest::binary>> -> byte
+      _ -> nil
+    end
+  end
+
+  defp uuid16(structures, type) do
+    case value(structures, type) do
+      <<uuid::16-little>> -> uuid
+      _ -> nil
+    end
+  end
+
+  defp list16(structures, type) do
+    case value(structures, type) do
+      nil -> []
+      binary -> for <<uuid::16-little <- binary>>, do: uuid
+    end
+  end
+end

--- a/lib/mayonnaios/bluetooth/scanner.ex
+++ b/lib/mayonnaios/bluetooth/scanner.ex
@@ -1,0 +1,176 @@
+defmodule MayonnaiOS.Bluetooth.Scanner do
+  @moduledoc """
+  The handheld as a scanner: what is advertising, and how strongly.
+
+  The other direction from `MayonnaiOS.Bluetooth.Peripheral`. That process
+  puts this device on the air and waits to be found; this one listens and
+  builds a list. Both need `MayonnaiOS.Bluetooth.Host` and therefore hci0, so
+  both cannot run at once -- which is why each belongs to an app the launcher
+  starts one at a time rather than to the boot supervision tree.
+
+  ## Setup is the same four commands, and then two more
+
+  Reset, the event mask, the LE event mask, LE host support: identical to the
+  peripheral's, and for the same reasons. The LE event mask default of `0x1F`
+  already has bit 1 set, which is the Advertising Report event, so nothing
+  extra is needed there -- worth saying because a scanner that sets scan
+  parameters and enable and then hears nothing is exactly what a missing mask
+  bit looks like.
+
+  What is added is scan parameters and scan enable. Buffer sizes are not read:
+  a scan never sends an ACL packet, so there is no credit accounting to do.
+
+  ## Failing to start is reported, not retried
+
+  A setup that fails leaves this process alive with `started?: false` and the
+  reason in `status/0`, exactly as the peripheral does. The panel is the only
+  place anyone can read this on a handheld, and a supervisor restarting the
+  process every second would keep the radio busy and the reason off the
+  screen.
+
+  ## What this is not
+
+  It is not a client. There is no `connect/1` here, and the omission is the
+  point rather than an unfinished edge: this stack has no GATT client, no
+  BR/EDR at all, and no A2DP, so a connection made from here would be an
+  encrypted link with nothing to say over it. `MayonnaiOS.Bluetooth.Scan`
+  carries the flags that let the screen say which devices would need the
+  transport this firmware does not have.
+  """
+
+  use GenServer
+  require Logger
+
+  alias MayonnaiOS.Bluetooth.{HCI, Host, Scan}
+
+  # Twice a second is enough for a screen that refreshes twice a second, and
+  # it keeps the sweep off the path of the reports themselves.
+  @sweep_ms 1_000
+
+  # A device that has not advertised for this long is dropped. Long enough to
+  # ride out a slow advertiser (the 10.24 s worst case in the specification is
+  # for a directed advertiser; connectable devices sit far below it) and short
+  # enough that switching headphones off is visible while still holding them.
+  @stale_ms 30_000
+
+  defstruct scan: nil, started?: false, error: nil, dropped: 0
+
+  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc "Every device seen, first seen first, with an age against the clock now."
+  @spec devices() :: [map()]
+  def devices, do: GenServer.call(__MODULE__, :devices)
+
+  @doc """
+  Whether the scan is on the air, and the reason if it is not.
+  """
+  @spec status() :: map()
+  def status, do: GenServer.call(__MODULE__, :status)
+
+  @impl true
+  def init(opts) do
+    # Trapping exits is what makes `terminate/2` run at all: a GenServer taken
+    # down by its supervisor's shutdown signal skips terminate unless it traps,
+    # and terminate is where the scan is switched off. Without this the radio
+    # keeps scanning between two runs of the app, which costs battery and is
+    # invisible.
+    Process.flag(:trap_exit, true)
+
+    {:ok, %__MODULE__{scan: Scan.new()}, {:continue, {:setup, opts}}}
+  end
+
+  @impl true
+  def handle_continue({:setup, opts}, state) do
+    :ok = Host.attach(self())
+
+    with {:ok, _} <- Host.command(HCI.reset()),
+         {:ok, _} <- Host.command(HCI.set_event_mask()),
+         {:ok, _} <- Host.command(HCI.le_set_event_mask()),
+         {:ok, _} <- Host.command(HCI.write_le_host_support()),
+         {:ok, _} <- Host.command(HCI.le_set_scan_parameters(Keyword.take(opts, [:type]))),
+         {:ok, _} <- Host.command(HCI.le_set_scan_enable(true)) do
+      Logger.info("[scanner] scanning")
+      :timer.send_interval(@sweep_ms, :sweep)
+      {:noreply, %{state | started?: true}}
+    else
+      {:error, reason} ->
+        Logger.error("[scanner] setup failed: #{inspect(reason)}")
+        {:noreply, %{state | started?: false, error: reason}}
+    end
+  end
+
+  @impl true
+  def handle_call(:devices, _from, state) do
+    now = now()
+
+    devices =
+      state.scan
+      |> Scan.list()
+      |> Enum.map(fn device ->
+        device
+        |> Map.put(:age_ms, Scan.age(device, now))
+        |> Map.put(:dual_mode?, Scan.dual_mode?(device))
+        |> Map.put(:label, Scan.label(device))
+      end)
+
+    {:reply, devices, state}
+  end
+
+  def handle_call(:status, _from, state) do
+    {:reply,
+     %{
+       scanning: state.started?,
+       error: state.error,
+       devices: Scan.count(state.scan),
+       # Reports that decoded to nothing. Zero is the expected value; anything
+       # else means the report walk above disagrees with what this controller
+       # sends, which is the one part of this that has never met the hardware.
+       undecodable: state.dropped
+     }, state}
+  end
+
+  @impl true
+  def handle_info({:hci, {:event, :le_advertising_report, %{reports: []}}}, state) do
+    {:noreply, %{state | dropped: state.dropped + 1}}
+  end
+
+  def handle_info({:hci, {:event, :le_advertising_report, %{reports: reports}}}, state) do
+    now = now()
+    scan = Enum.reduce(reports, state.scan, &Scan.observe(&2, &1, now))
+    {:noreply, %{state | scan: scan}}
+  end
+
+  # Everything else off the controller. Logged at debug rather than dropped
+  # silently: a scan that produces nothing while the controller is sending
+  # events of some other shape is a different fault from a silent radio.
+  def handle_info({:hci, packet}, state) do
+    Logger.debug("[scanner] ignoring #{inspect(packet)}")
+    {:noreply, state}
+  end
+
+  def handle_info(:sweep, state) do
+    {:noreply, %{state | scan: Scan.forget_stale(state.scan, now(), @stale_ms)}}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, %{started?: true}) do
+    # Stop the scan before the socket goes. Closing hci0 would stop it too --
+    # the kernel closes the device with the user channel -- but this app can be
+    # stopped and started repeatedly from the menu, and leaving the controller
+    # scanning between runs would cost battery for nothing.
+    Host.command(HCI.le_set_scan_enable(false))
+    :ok
+  rescue
+    # Host may already be gone: this is a `:one_for_all` tree and the socket
+    # dying is one of the ways this process is asked to stop.
+    _ -> :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  defp now, do: System.monotonic_time(:millisecond)
+end

--- a/lib/mayonnaios/pairing.ex
+++ b/lib/mayonnaios/pairing.ex
@@ -1,0 +1,239 @@
+defmodule MayonnaiOS.Pairing do
+  @moduledoc """
+  The Bluetooth devices app: what is nearby, what is paired, and what this
+  firmware can actually do with either.
+
+      iex> MayonnaiOS.Pairing.start()
+      iex> MayonnaiOS.Pairing.status()
+      iex> MayonnaiOS.Pairing.stop()
+
+  An app rather than a program, on the same terms as `MayonnaiOS.Controller`:
+  a module in this firmware, started in this VM, with a scene of its own and
+  no external process. It takes hci0 for as long as it runs, so it and the
+  controller app cannot both be up -- which is why both are menu entries and
+  neither is in the boot supervision tree.
+
+  ## Headphones do not work, and this screen says so on purpose
+
+  This app was asked for as "a UI for pairing and connecting Bluetooth
+  devices like headphones". It does not connect headphones, and it is built so
+  that nobody can spend an evening finding that out.
+
+  Bluetooth audio is A2DP. A2DP runs over BR/EDR -- the classic transport --
+  and needs, in order: BR/EDR HCI (inquiry, create connection, link keys,
+  Secure Simple Pairing), connection-oriented L2CAP channels, an SDP client,
+  AVDTP signalling, an SBC encoder, and something to route the audio a game
+  is producing into that stream. None of those exist here:
+
+    * There is no BlueZ in the image. Checked on the device rather than
+      inferred -- no `/usr/lib/bluetooth`, no `/etc/bluetooth`, no
+      `bluetoothctl`, `hciconfig`, `btmon` or `sdptool` anywhere on `$PATH`
+      -- and no `BR2_PACKAGE_BLUEZ5_UTILS` in the system's `nerves_defconfig`
+      to put one there.
+    * `MayonnaiOS.Bluetooth.HCI` implements no BR/EDR command at all, and
+      `MayonnaiOS.Bluetooth.L2CAP` is the three fixed LE channels with no
+      connection-oriented channel to carry AVDTP over.
+    * There is no PulseAudio, PipeWire or `bluez-alsa` in the image either,
+      so even a working A2DP source in this VM would have no way to be handed
+      RetroArch's audio.
+
+    The first and last of those are Buildroot options, so getting there is a
+    2-3 hour system rebuild before any of the Elixir exists. That is why this
+    app scans and lists rather than offering a Connect button: a button that
+    can never produce sound is this project's characteristic failure written
+    into the UI.
+
+  So the screen names the missing piece, and `MayonnaiOS.Bluetooth.Scan`
+  reads the BR/EDR flag out of each advertisement so that the row for a pair
+  of headphones says which transport it would need. Adding audio later is a
+  profile under `MayonnaiOS.Bluetooth` and a row action in
+  `MayonnaiOS.Scene.Pairing`; nothing else here has to move.
+
+  ## What it does do
+
+      scan          active LE scan, names and signal strength, ages out
+      paired hosts  the LE bonds from the controller app, listed
+      forget        drop one bond, fsynced, survives a power cut
+
+  Forgetting a bond has until now been an IEx call, which means the only way
+  to undo a pairing on a handheld with no keyboard was over SSH.
+
+  ## What starting it takes over
+
+      MayonnaiOS.Bluetooth.Bonds     the keys paired hosts come back with
+      MayonnaiOS.Bluetooth.Host      hci0, held open for as long as this runs
+      MayonnaiOS.Bluetooth.Scanner   scan parameters, scan enable, the list
+      MayonnaiOS.Pairing.Cursor      the D-pad, and which row A acts on
+
+  `:one_for_all`, because a scanner holding a list built through a socket that
+  has died would go on showing devices that stopped advertising minutes ago.
+  """
+
+  use Supervisor
+
+  alias MayonnaiOS.Bluetooth.{Bonds, HCI, Host, Scanner}
+  alias MayonnaiOS.Pairing.Cursor
+
+  @sessions MayonnaiOS.Pairing.Sessions
+
+  @doc """
+  Start the app.
+
+  The failure reasons are the bind errors in
+  `MayonnaiOS.Bluetooth.HCISocket`, plus `{:already_started, pid}` from `Host`
+  when the controller app has hci0. Nothing retries; the reason goes to the
+  panel.
+  """
+  @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(opts \\ []) do
+    case DynamicSupervisor.start_child(@sessions, {__MODULE__, opts}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:error, {:already_started, pid}}
+      {:error, reason} -> {:error, unwrap(reason)}
+    end
+  end
+
+  @doc "Stop the app and give hci0 back."
+  @spec stop() :: :ok
+  def stop do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(@sessions, pid)
+    end
+  end
+
+  @doc "Whether the app is running."
+  @spec active?() :: boolean()
+  def active?, do: Process.whereis(__MODULE__) != nil
+
+  @doc """
+  Forward an evdev report to the cursor.
+
+  Called by `MayonnaiOS.Launcher` while this app has the buttons. Menu never
+  reaches here -- the launcher keeps that one for itself as the way out --
+  and everything else this app does not use is dropped by the cursor.
+  """
+  @spec input([tuple()]) :: :ok
+  def input(events) do
+    if Process.whereis(Cursor), do: Cursor.input(events), else: :ok
+  end
+
+  @doc "The scene the launcher shows while this app has the buttons."
+  @spec scene() :: module()
+  def scene, do: MayonnaiOS.Scene.Pairing
+
+  @doc """
+  Everything the screen draws, in one call.
+
+  Assembled here rather than in the scene so that the scene has no opinion
+  about where any of it comes from, and so that a console can read the whole
+  screen as a term. Returns `:stopped` when there is nothing to report, which
+  is a state the scene renders rather than crashes on.
+
+  The test is for the scanner rather than for this supervisor, and that is on
+  purpose: the scanner is the part that holds the radio, so its absence is the
+  thing that makes the screen meaningless. It also means the pieces can be
+  stood up individually against a fake controller and this function still
+  answers, which is how the screen is tested on a machine with no
+  `AF_BLUETOOTH` at all.
+  """
+  @spec status() :: map() | :stopped
+  def status do
+    if Process.whereis(Scanner) do
+      cursor = cursor_state()
+      bonds = list_bonds()
+
+      %{
+        scan: Scanner.status(),
+        devices: Scanner.devices(),
+        bonds: bonds,
+        # Bounded here rather than trusted, for the same reason
+        # `MayonnaiOS.Programs.at/2` does it: the list is re-read on every
+        # refresh and a bond forgotten a moment ago would otherwise leave the
+        # cursor pointing past the end.
+        selected: bounded(cursor.selected, length(bonds)),
+        armed: cursor.armed
+      }
+    else
+      :stopped
+    end
+  end
+
+  @doc """
+  The paired hosts, in the shape the screen wants them.
+
+  The bond store keys on EDIV and Rand, which are the right thing to look a
+  key up by and useless to show anyone. The peer address is what a person can
+  match against the machine in front of them, so that is what comes out here.
+  """
+  @spec list_bonds() :: [map()]
+  def list_bonds do
+    Enum.map(bonds(), fn bond ->
+      {type, address} = bond.peer
+
+      %{
+        peer: bond.peer,
+        address: HCI.address(address),
+        # 0x01 is a random address. Windows connects from a resolvable
+        # private one that changes every fifteen minutes, so a random address
+        # here is not something to match against a sticker on a laptop -- it
+        # is worth saying on the row rather than letting someone try.
+        random?: type == 0x01,
+        key_size: bond.key_size
+      }
+    end)
+  end
+
+  @doc "The DynamicSupervisor the session runs under, for the application tree."
+  @spec sessions() :: Supervisor.child_spec()
+  def sessions do
+    %{
+      id: @sessions,
+      start: {DynamicSupervisor, :start_link, [[name: @sessions, strategy: :one_for_one]]},
+      type: :supervisor
+    }
+  end
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor,
+      # As with the controller app: a session that could not open the radio
+      # will not open it on a retry either, and the reason belongs on the
+      # panel rather than in a restart loop.
+      restart: :temporary
+    }
+  end
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    children = [
+      Bonds,
+      {Host, Keyword.take(opts, [:dev])},
+      {Scanner, Keyword.take(opts, [:type])},
+      Cursor
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  defp bonds do
+    if Process.whereis(Bonds), do: Bonds.list(), else: []
+  end
+
+  defp cursor_state do
+    if Process.whereis(Cursor), do: Cursor.state(), else: %{selected: 0, armed: false}
+  end
+
+  defp bounded(_selected, 0), do: 0
+  defp bounded(selected, count), do: Integer.mod(selected, count)
+
+  defp unwrap({:shutdown, {:failed_to_start_child, _child, reason}}), do: unwrap(reason)
+  defp unwrap(reason), do: reason
+end

--- a/lib/mayonnaios/pairing/cursor.ex
+++ b/lib/mayonnaios/pairing/cursor.ex
@@ -1,0 +1,130 @@
+defmodule MayonnaiOS.Pairing.Cursor do
+  @moduledoc """
+  Which row of the paired-hosts list A acts on, and whether it is armed.
+
+  The cursor lives in a process rather than in the scene for the same two
+  reasons `MayonnaiOS.Launcher` keeps the menu cursor: the cairo-fb driver
+  delivers no input, so a Scenic scene on this hardware can never receive a
+  D-pad press, and `Scenic.ViewPort.set_root/3` replaces the scene process, so
+  anything a scene remembered would be lost on the next repaint.
+
+  ## Only the bonds are selectable
+
+  The screen has two lists. The nearby devices are informational -- there is
+  nothing this firmware can do with one, and a cursor that could land on a row
+  where A does nothing is worse than a list with no cursor at all. So the
+  cursor ranges over the paired hosts, and the one action is forgetting one.
+
+  ## A twice, not a chord
+
+  Forgetting a bond is not free: the host on the other side still has its key,
+  reconnects, fails to encrypt, and reports a broken device until someone
+  removes it there too. So the first A arms the selected row and the second
+  one does it, which is a confirmation built out of the binding that already
+  means "confirm" rather than a new chord nobody would discover.
+
+  Moving the cursor disarms. Anything else -- a stray button, a direction on
+  the analog stick -- leaves the arming alone, because a confirmation that can
+  be cancelled by pressing a button that does nothing else is a confirmation
+  someone will lose to a twitch.
+
+  ## The index is a number, not a reference to a row
+
+  It is taken modulo the list length wherever it is used and never clamped
+  against a remembered list. Bonds appear while this screen is up -- the
+  controller app is not running, so not often, but the file is shared and a
+  console can write it -- and an index bounded at read time cannot point off
+  the end of a list it has not seen.
+  """
+
+  use GenServer
+  require Logger
+
+  alias MayonnaiOS.Bluetooth.Bonds
+
+  # The buttons, as printed on the shell. These atoms name the opposite
+  # button; see MayonnaiOS.Launcher for the device tree that lies about it.
+  # :btn_b is physical A.
+  @confirm_button :btn_b
+  @up_button :btn_dpad_up
+  @down_button :btn_dpad_down
+
+  defstruct selected: 0, armed: false
+
+  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc """
+  Hand over one evdev report.
+
+  A call rather than a cast, so that a console -- or a test that has just
+  synthesised a press -- can read the cursor immediately afterwards and get
+  the state that press produced.
+  """
+  @spec input([tuple()]) :: :ok
+  def input(events), do: GenServer.call(__MODULE__, {:input, events})
+
+  @doc "Where the cursor is, and whether A is armed."
+  @spec state() :: %{selected: non_neg_integer(), armed: boolean()}
+  def state, do: GenServer.call(__MODULE__, :state)
+
+  @impl true
+  def init(_opts), do: {:ok, %__MODULE__{}}
+
+  @impl true
+  def handle_call({:input, events}, _from, state) do
+    {:reply, :ok, Enum.reduce(events, state, &press(&2, &1))}
+  end
+
+  def handle_call(:state, _from, state) do
+    {:reply, %{selected: state.selected, armed: state.armed}, state}
+  end
+
+  # Value 1 is a press. 2 is autorepeat and is dropped, as it is in the
+  # launcher: each move is a scene rebuild, and holding a direction down would
+  # queue one per repeat.
+  defp press(state, {:ev_key, @up_button, 1}), do: move(state, -1)
+  defp press(state, {:ev_key, @down_button, 1}), do: move(state, +1)
+  defp press(state, {:ev_key, @confirm_button, 1}), do: confirm(state)
+  defp press(state, _event), do: state
+
+  defp move(state, delta) do
+    case count() do
+      0 ->
+        %{state | selected: 0, armed: false}
+
+      count ->
+        %{state | selected: Integer.mod(state.selected + delta, count), armed: false}
+    end
+  end
+
+  # First A arms, second A forgets. Arming an empty list is not a state worth
+  # having: there is nothing to confirm and the screen would say "A again to
+  # forget" over a list with no rows in it.
+  defp confirm(%{armed: false} = state) do
+    if count() == 0, do: state, else: %{state | armed: true}
+  end
+
+  defp confirm(state) do
+    case Enum.at(bonds(), Integer.mod(state.selected, max(count(), 1))) do
+      nil ->
+        %{state | armed: false}
+
+      bond ->
+        Logger.info("[pairing] forgetting the bond for #{inspect(bond.peer)}")
+        Bonds.forget(bond.peer)
+
+        # The cursor stays where it is rather than following the bond that was
+        # just dropped. The list is one row shorter, so the row now under the
+        # cursor is the one that was below -- which is what a list that shrinks
+        # under a fixed cursor does everywhere else, and better than jumping to
+        # the top.
+        %{state | armed: false}
+    end
+  end
+
+  defp bonds do
+    if Process.whereis(Bonds), do: Bonds.list(), else: []
+  end
+
+  defp count, do: length(bonds())
+end

--- a/lib/mayonnaios/scene/pairing.ex
+++ b/lib/mayonnaios/scene/pairing.ex
@@ -1,0 +1,378 @@
+defmodule MayonnaiOS.Scene.Pairing do
+  @moduledoc """
+  What the panel shows while the Bluetooth devices app has the buttons.
+
+  Two lists side by side, and a line at the top saying what the screen cannot
+  do. The two lists are deliberately not the same kind of thing:
+
+      Paired hosts   the LE bonds. Selectable; A forgets one.
+      Nearby         what is advertising. Informational, no cursor.
+
+  ## The notice is at the top, not in a footnote
+
+  Someone opening this screen is looking for their headphones. They are not
+  going to be found, because Bluetooth audio is A2DP over BR/EDR and this
+  firmware has no BR/EDR host at all -- see `MayonnaiOS.Pairing` for the full
+  list of what is missing and why it starts with a Buildroot rebuild. A screen
+  that puts that at the bottom, in grey, is a screen that has technically said
+  it.
+
+  So it is the first thing under the rule, in amber, and every nearby row that
+  advertises BR/EDR support carries `needs BR/EDR` where a Connect button
+  would otherwise be. That tag is read out of the advertisement's own Flags
+  byte rather than guessed from the name.
+
+  ## A device with no name is a row with an address on it
+
+  Not "(unknown)". Two nameless devices are then two distinguishable rows, and
+  a scan that produces nothing but addresses is a scan running passively or a
+  room full of beacons -- both of which are visible from the rows themselves
+  rather than needing a log.
+
+  ## Building the graph is a pure function
+
+  `graph/1` takes the map `MayonnaiOS.Pairing.status/0` returns and needs no
+  viewport, no driver and no framebuffer, which is what lets the host tests
+  assert on the empty list, a bond armed for deletion, and a scan that failed
+  to start -- three states that would otherwise only be findable by holding
+  the device.
+  """
+
+  use Scenic.Scene
+
+  alias MayonnaiOS.Pairing
+  alias Scenic.Graph
+
+  import Scenic.Primitives
+
+  @width 640
+  @height 480
+
+  # The palette every other screen on this device uses.
+  @bg {12, 14, 22}
+  @title {235, 238, 245}
+  @head {90, 170, 255}
+  @label {150, 165, 195}
+  @pass {120, 220, 150}
+  @fail {245, 110, 120}
+  @wait {235, 190, 90}
+  @dim {110, 125, 155}
+  @row_bg {26, 34, 52}
+
+  @top 148
+  @pitch 34
+  @visible 8
+
+  @left 20
+  @right 330
+  @column_width 290
+
+  @refresh_ms 500
+
+  @impl Scenic.Scene
+  def init(scene, param, _opts) do
+    :timer.send_interval(@refresh_ms, :refresh)
+    error = if is_map(param), do: Map.get(param, :error), else: nil
+
+    {:ok, scene |> assign(error: error) |> refresh()}
+  end
+
+  @impl GenServer
+  def handle_info(:refresh, scene), do: {:noreply, refresh(scene)}
+  def handle_info(_message, scene), do: {:noreply, scene}
+
+  defp refresh(scene), do: push_graph(scene, graph(status(), scene.assigns[:error]))
+
+  # The app not running has to render rather than crash: it is what the
+  # launcher shows when starting failed, and the reason is the only useful
+  # thing on the panel at that moment.
+  defp status do
+    Pairing.status()
+  rescue
+    _ -> :stopped
+  catch
+    :exit, _ -> :stopped
+  end
+
+  @doc """
+  Build the graph for one `MayonnaiOS.Pairing.status/0` reading.
+
+  Public because it is the tested surface. `:stopped` and an error reason are
+  a valid pair of arguments and render the "not running" page.
+  """
+  @spec graph(map() | :stopped, term()) :: Scenic.Graph.t()
+  def graph(status, error \\ nil)
+
+  def graph(:stopped, error) do
+    base()
+    |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, 90})
+    |> text(reason(error), font_size: 16, fill: {:color, @label}, translate: {20, 120})
+    |> column(20, 160, explain(error))
+    |> footer("Menu goes back.")
+  end
+
+  def graph(status, _error) do
+    base()
+    |> notice()
+    |> heading(@left, "Paired hosts", count(status.bonds))
+    |> heading(@right, "Nearby", nearby_count(status))
+    |> bonds(status)
+    |> nearby(status)
+    |> footer(bindings(status))
+  end
+
+  defp base do
+    Graph.build(font: :roboto, font_size: 14)
+    |> rect({@width, @height}, fill: {:color, @bg})
+    |> text("Bluetooth devices", font_size: 20, fill: {:color, @title}, translate: {20, 28})
+    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, 38})
+  end
+
+  # The one thing this screen exists to be honest about.
+  defp notice(graph) do
+    graph
+    |> text("Headphones cannot be connected from here.",
+      font_size: 18,
+      fill: {:color, @wait},
+      translate: {20, 66}
+    )
+    |> text("Audio is A2DP over BR/EDR, and this firmware has no BR/EDR host at all.",
+      font_size: 13,
+      fill: {:color, @label},
+      translate: {20, 88}
+    )
+    |> text("What works: seeing what is nearby, and managing pairings made as a gamepad.",
+      font_size: 13,
+      fill: {:color, @dim},
+      translate: {20, 106}
+    )
+  end
+
+  defp heading(graph, x, title, count) do
+    graph
+    |> text("#{title} (#{count})", font_size: 15, fill: {:color, @head}, translate: {x, 132})
+    |> rect({@column_width, 1}, fill: {:color, @dim}, translate: {x, 138})
+  end
+
+  # -- the bonds, which are the only selectable thing here --------------------
+
+  defp bonds(graph, %{bonds: []}) do
+    text(graph, "Nothing paired.", font_size: 15, fill: {:color, @dim}, translate: {@left, @top})
+  end
+
+  defp bonds(graph, status) do
+    {start, rows} = window(status.bonds, status.selected)
+
+    rows
+    |> Enum.with_index(start)
+    |> Enum.reduce(graph, fn {bond, index}, acc ->
+      selected? = index == status.selected
+      y = @top + (index - start) * @pitch
+
+      acc
+      |> highlight(y, selected?)
+      |> text(bond.address,
+        font_size: 17,
+        fill: {:color, if(selected?, do: @title, else: @label)},
+        translate: {@left + 16, y + 4}
+      )
+      |> text(bond_note(bond, selected? and status.armed),
+        font_size: 12,
+        fill: {:color, bond_note_colour(selected? and status.armed)},
+        translate: {@left + 16, y + 19}
+      )
+    end)
+    |> more(@left, start, length(status.bonds))
+  end
+
+  # Armed is the loudest thing on the row, because the next A is the one that
+  # does it and the row is otherwise indistinguishable from a selected one.
+  defp bond_note(_bond, true), do: "press A again to forget"
+  defp bond_note(bond, _armed), do: "#{address_kind(bond)}, #{key_size(bond.key_size)}"
+
+  # A resolvable private address changes every fifteen minutes on the host
+  # that generated it, so it is not something to match against a machine in
+  # front of you -- worth saying on the row rather than letting someone try.
+  defp address_kind(%{random?: true}), do: "random address"
+  defp address_kind(_bond), do: "public address"
+
+  # The negotiated key size, in bits. Shown because a short one is the visible
+  # end of a pairing that was downgraded, and 16 bytes is what this stack asks
+  # for every time.
+  defp key_size(size) when is_integer(size), do: "#{size * 8}-bit key"
+  defp key_size(_size), do: "key size unknown"
+
+  defp bond_note_colour(true), do: @fail
+  defp bond_note_colour(_), do: @dim
+
+  # -- what is on the air -----------------------------------------------------
+
+  defp nearby(graph, %{scan: %{scanning: false} = scan}) do
+    graph
+    |> text("Scan did not start.",
+      font_size: 15,
+      fill: {:color, @fail},
+      translate: {@right, @top}
+    )
+    |> text(reason(scan.error),
+      font_size: 12,
+      fill: {:color, @label},
+      translate: {@right, @top + 18}
+    )
+  end
+
+  defp nearby(graph, %{devices: []}) do
+    graph
+    |> text("Scanning...", font_size: 15, fill: {:color, @wait}, translate: {@right, @top})
+    |> text("Nothing has advertised yet.",
+      font_size: 12,
+      fill: {:color, @dim},
+      translate: {@right, @top + 18}
+    )
+  end
+
+  defp nearby(graph, %{devices: devices}) do
+    shown = Enum.take(devices, @visible)
+
+    shown
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {device, index}, acc ->
+      y = @top + index * @pitch
+
+      acc
+      |> text(clip(device.label),
+        font_size: 17,
+        fill: {:color, name_colour(device)},
+        translate: {@right, y + 4}
+      )
+      |> text(device_note(device),
+        font_size: 12,
+        fill: {:color, note_colour(device)},
+        translate: {@right, y + 19}
+      )
+    end)
+    |> more(@right, 0, length(devices))
+  end
+
+  # Signal, age, and the transport. The transport is the part that matters:
+  # "needs BR/EDR" is where a Connect button would be on a screen that could
+  # honestly offer one.
+  defp device_note(device) do
+    [signal(device.rssi), transport(device.dual_mode?), age(device.age_ms)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("  ")
+  end
+
+  defp signal(nil), do: nil
+  defp signal(rssi), do: "#{rssi} dBm"
+
+  defp transport(true), do: "needs BR/EDR"
+  defp transport(false), do: "LE only"
+  # No Flags structure has arrived yet, which is not the same as LE-only and
+  # is not worth guessing about on a row that refreshes twice a second.
+  defp transport(nil), do: nil
+
+  # Only once it is worth saying. Everything in a live scan is a second old.
+  defp age(age_ms) when age_ms < 5_000, do: nil
+  defp age(age_ms), do: "#{div(age_ms, 1000)}s ago"
+
+  defp name_colour(%{name: nil}), do: @dim
+  defp name_colour(_device), do: @label
+
+  defp note_colour(%{dual_mode?: true}), do: @wait
+  defp note_colour(%{dual_mode?: false}), do: @pass
+  defp note_colour(_device), do: @dim
+
+  # -- shared furniture -------------------------------------------------------
+
+  defp highlight(graph, _y, false), do: graph
+
+  defp highlight(graph, y, true) do
+    graph
+    |> rect({@column_width, @pitch - 4}, fill: {:color, @row_bg}, translate: {@left, y - 12})
+    |> rect({4, @pitch - 4}, fill: {:color, @head}, translate: {@left, y - 12})
+  end
+
+  # Window the rows so a selection past the eighth entry is still on screen.
+  defp window(rows, selected) do
+    count = length(rows)
+    start = min(max(0, selected - @visible + 1), max(0, count - @visible))
+    {start, Enum.slice(rows, start, @visible)}
+  end
+
+  defp more(graph, _x, _start, count) when count <= @visible, do: graph
+
+  defp more(graph, x, start, count) do
+    text(graph, "#{start + 1}-#{min(start + @visible, count)} of #{count}",
+      font_size: 12,
+      fill: {:color, @dim},
+      translate: {x, @top + @visible * @pitch}
+    )
+  end
+
+  defp bindings(%{bonds: []}), do: "Menu goes back."
+  defp bindings(%{armed: true}), do: "A forgets this pairing. Any direction cancels. Menu leaves."
+  defp bindings(_status), do: "D-pad picks a pairing, A forgets it. Menu goes back."
+
+  defp footer(graph, message) do
+    graph
+    |> rect({@width - 40, 1}, fill: {:color, @dim}, translate: {20, @height - 44})
+    |> text(message, font_size: 14, fill: {:color, @dim}, translate: {20, @height - 24})
+  end
+
+  defp count(list), do: length(list)
+
+  defp nearby_count(%{scan: %{devices: n}}), do: n
+
+  # A 31-byte name at font size 17 runs off the panel and Scenic will happily
+  # draw it over the footer.
+  defp clip(text) when byte_size(text) <= 22, do: text
+  defp clip(text), do: binary_part(text, 0, 21) <> "…"
+
+  defp reason(nil), do: ""
+  defp reason(reason), do: inspect(reason)
+
+  defp explain(:eusers) do
+    [
+      {"", "Something else already has hci0.", @label},
+      {"", "The controller app holds it while it", @dim},
+      {"", "runs; stop it and try again.", @dim}
+    ]
+  end
+
+  defp explain({:already_started, _pid}) do
+    [
+      {"", "The Bluetooth stack is already up.", @label},
+      {"", "The controller app is running.", @dim}
+    ]
+  end
+
+  defp explain(:enodev) do
+    [
+      {"", "There is no hci0 at all.", @label},
+      {"", "The Realtek firmware did not load;", @dim},
+      {"", "dmesg at boot says why.", @dim}
+    ]
+  end
+
+  defp explain(:eafnosupport) do
+    [{"", "This machine has no Bluetooth sockets.", @label}]
+  end
+
+  defp explain(nil), do: [{"", "The app is not running.", @label}]
+  defp explain(_other), do: [{"", "See the log: RingLogger.next", @dim}]
+
+  # The same value/label column the controller and diagnostics screens use, so
+  # the three read as one device.
+  defp column(graph, x, y, rows) do
+    rows
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {{value, label, colour}, index}, acc ->
+      top = y + index * @pitch
+
+      acc
+      |> text(value, font_size: 18, fill: {:color, colour}, translate: {x, top})
+      |> text(label, font_size: 12, fill: {:color, colour}, translate: {x, top + 15})
+    end)
+  end
+end

--- a/test/bluetooth/bonds_test.exs
+++ b/test/bluetooth/bonds_test.exs
@@ -1,0 +1,110 @@
+defmodule MayonnaiOS.Bluetooth.BondsTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Bluetooth.Bonds
+
+  @laptop {0x00, <<0xA6, 0xA5, 0xA4, 0xA3, 0xA2, 0xA1>>}
+  @windows {0x01, <<0xB6, 0xB5, 0xB4, 0xB3, 0xB2, 0xB1>>}
+
+  setup do
+    path = Path.join(System.tmp_dir!(), "bonds-#{System.unique_integer([:positive])}/bonds.bin")
+    Application.put_env(:mayonnaios, :bond_path, path)
+
+    on_exit(fn ->
+      Application.delete_env(:mayonnaios, :bond_path)
+      File.rm_rf!(Path.dirname(path))
+    end)
+
+    start_supervised!(Bonds)
+    %{path: path}
+  end
+
+  defp bond(peer, ediv) do
+    %{
+      ltk: :crypto.strong_rand_bytes(16),
+      ediv: ediv,
+      rand: :crypto.strong_rand_bytes(8),
+      peer: peer,
+      key_size: 16
+    }
+  end
+
+  describe "forgetting one host" do
+    test "drops the named bond and keeps the others" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+      Bonds.put(bond(@windows, <<2, 0>>))
+
+      :ok = Bonds.forget(@laptop)
+
+      assert [%{peer: @windows}] = Bonds.list()
+    end
+
+    test "the key really is gone, not just hidden from the list" do
+      %{ediv: ediv, rand: rand} = stored = bond(@laptop, <<3, 0>>)
+      Bonds.put(stored)
+
+      assert Bonds.find(ediv, rand) != nil
+
+      :ok = Bonds.forget(@laptop)
+
+      # This is the assertion that matters: a bond dropped from the list but
+      # still answering a lookup would let a host that has been "forgotten"
+      # keep reconnecting silently.
+      assert Bonds.find(ediv, rand) == nil
+    end
+
+    test "forgetting something that is not there is not an error" do
+      Bonds.put(bond(@laptop, <<4, 0>>))
+
+      assert :ok = Bonds.forget(@windows)
+      assert [%{peer: @laptop}] = Bonds.list()
+    end
+
+    test "survives a restart, which is the only thing the file is for", %{path: path} do
+      Bonds.put(bond(@laptop, <<5, 0>>))
+      Bonds.put(bond(@windows, <<6, 0>>))
+      :ok = Bonds.forget(@laptop)
+
+      :ok = stop_supervised(Bonds)
+      start_supervised!(Bonds)
+
+      assert [%{peer: @windows}] = Bonds.list()
+      assert File.exists?(path)
+    end
+  end
+
+  describe "writing the file" do
+    test "leaves no temporary behind", %{path: path} do
+      Bonds.put(bond(@laptop, <<7, 0>>))
+
+      refute File.exists?(path <> ".new")
+      assert File.exists?(path)
+    end
+
+    test "creates the directory it was pointed at", %{path: path} do
+      refute File.exists?(Path.dirname(path))
+
+      Bonds.put(bond(@laptop, <<8, 0>>))
+
+      assert File.dir?(Path.dirname(path))
+    end
+
+    test "the file on disk is what a fresh reader gets", %{path: path} do
+      Bonds.put(bond(@laptop, <<9, 0>>))
+
+      # Read the bytes rather than the process: an fsync that never happened
+      # is invisible from in here, but a write that never happened is not, and
+      # this is the half that can be checked on a laptop.
+      assert {:ok, binary} = File.read(path)
+      assert [%{peer: @laptop}] = :erlang.binary_to_term(binary, [:safe])
+    end
+
+    test "clearing writes an empty list rather than removing the file", %{path: path} do
+      Bonds.put(bond(@laptop, <<10, 0>>))
+      :ok = Bonds.clear()
+
+      assert {:ok, binary} = File.read(path)
+      assert [] = :erlang.binary_to_term(binary, [:safe])
+    end
+  end
+end

--- a/test/bluetooth/peripheral_test.exs
+++ b/test/bluetooth/peripheral_test.exs
@@ -11,52 +11,15 @@ defmodule MayonnaiOS.Bluetooth.PeripheralTest do
   # under it -- a process registered under the name the real one uses -- and
   # plays a whole central: connect, discover, pair, subscribe, press a button.
   #
-  # What that buys is the part that is otherwise only testable on the device
-  # with a Windows machine in the other hand. What it does not prove is that
-  # the controller behaves as the fake one does; the fake answers every
-  # command with success, and the real one has opinions.
+  # The fake itself lives in `test/support/fake_controller.exs`, because
+  # `MayonnaiOS.Bluetooth.ScannerTest` needs exactly the same seam and two
+  # doubles that drift apart are worse than one that is slightly more general
+  # than either caller.
+  alias MayonnaiOS.Bluetooth.FakeController
 
   @handle 0x0040
   @central {0x01, <<0xA6, 0xA5, 0xA4, 0xA3, 0xA2, 0xA1>>}
   @peripheral_address <<0xB6, 0xB5, 0xB4, 0xB3, 0xB2, 0xB1>>
-
-  # A controller that says yes to everything and forwards what it is asked to
-  # transmit to the test process.
-  defmodule FakeController do
-    use GenServer
-
-    def start_link(test),
-      do: GenServer.start_link(__MODULE__, test, name: MayonnaiOS.Bluetooth.Host)
-
-    @impl true
-    def init(test), do: {:ok, %{test: test, commands: []}}
-
-    @impl true
-    def handle_call({:attach, _pid}, _from, state), do: {:reply, :ok, state}
-
-    def handle_call(
-          {:command, <<0x01, opcode::16-little, _len, params::binary>>, _t},
-          _from,
-          state
-        ) do
-      send(state.test, {:command, opcode, params})
-      {:reply, {:ok, return_params(opcode)}, %{state | commands: [opcode | state.commands]}}
-    end
-
-    def handle_call({:acl, packets}, _from, state) do
-      send(state.test, {:acl, packets})
-      {:reply, :ok, state}
-    end
-
-    def handle_call({:buffers, _length, _count}, _from, state), do: {:reply, :ok, state}
-    def handle_call(:packet_length, _from, state), do: {:reply, 27, state}
-
-    # LE Read Buffer Size: four packets of 27 bytes, which is a realistic
-    # answer and small enough that a report descriptor read has to fragment.
-    defp return_params(0x2002), do: <<27::16-little, 4>>
-    defp return_params(0x1009), do: <<0xB6, 0xB5, 0xB4, 0xB3, 0xB2, 0xB1>>
-    defp return_params(_other), do: <<>>
-  end
 
   setup do
     start_supervised!({FakeController, self()})

--- a/test/bluetooth/scan_test.exs
+++ b/test/bluetooth/scan_test.exs
@@ -1,0 +1,231 @@
+defmodule MayonnaiOS.Bluetooth.ScanTest do
+  use ExUnit.Case, async: true
+
+  alias MayonnaiOS.Bluetooth.{Advertising, HCI, Scan}
+
+  # A real advertising report, built the way the controller sends one: one
+  # report, interleaved fields, RSSI last.
+  defp report(opts) do
+    data = Keyword.get(opts, :data, <<>>)
+    address = Keyword.get(opts, :address, <<0xF6, 0xE5, 0xD4, 0xC3, 0xB2, 0xA1>>)
+    event_type = Keyword.get(opts, :event_type, 0x00)
+    address_type = Keyword.get(opts, :address_type, 0x00)
+    rssi = Keyword.get(opts, :rssi, -60)
+
+    params =
+      <<0x01, event_type, address_type, address::binary, byte_size(data), data::binary,
+        rssi::signed-8>>
+
+    <<0x04, 0x3E, byte_size(params) + 1, 0x02, params::binary>>
+  end
+
+  defp decode_one(opts) do
+    {:event, :le_advertising_report, %{reports: [report]}} = HCI.decode(report(opts))
+    report
+  end
+
+  describe "decoding an advertising report" do
+    test "one report comes back with its address in printed order" do
+      report = decode_one([])
+
+      assert report.address == "A1:B2:C3:D4:E5:F6"
+      assert report.event_type == :adv_ind
+      assert report.rssi == -60
+    end
+
+    test "several reports in one event are read as records, not as columns" do
+      # The columnar reading of the specification parses a single report
+      # correctly and mangles two, so this is the test that distinguishes them.
+      first = <<0x00, 0x00, 1, 2, 3, 4, 5, 6, 0x00, -50::signed-8>>
+      second = <<0x04, 0x01, 7, 8, 9, 10, 11, 12, 0x00, -90::signed-8>>
+      params = <<0x02, first::binary, second::binary>>
+      packet = <<0x04, 0x3E, byte_size(params) + 1, 0x02, params::binary>>
+
+      {:event, :le_advertising_report, %{reports: [one, two]}} = HCI.decode(packet)
+
+      assert one.address == "06:05:04:03:02:01"
+      assert one.rssi == -50
+      assert one.event_type == :adv_ind
+      assert two.address == "0C:0B:0A:09:08:07"
+      assert two.rssi == -90
+      assert two.event_type == :scan_rsp
+      assert two.address_type == 0x01
+    end
+
+    test "an RSSI of 127 is 'not available', not the strongest signal in the room" do
+      assert decode_one(rssi: 127).rssi == nil
+    end
+
+    test "a truncated run keeps the reports that parsed" do
+      good = <<0x00, 0x00, 1, 2, 3, 4, 5, 6, 0x00, -50::signed-8>>
+      params = <<0x02, good::binary, 0x00, 0x00, 1, 2>>
+      packet = <<0x04, 0x3E, byte_size(params) + 1, 0x02, params::binary>>
+
+      {:event, :le_advertising_report, %{reports: reports}} = HCI.decode(packet)
+
+      assert length(reports) == 1
+    end
+
+    test "the event survives a report count of zero" do
+      packet = <<0x04, 0x3E, 0x02, 0x02, 0x00>>
+      assert {:event, :le_advertising_report, %{reports: []}} = HCI.decode(packet)
+    end
+  end
+
+  describe "the scan commands" do
+    test "scan parameters are active by default, seven bytes of them" do
+      assert <<0x01, 0x0B, 0x20, 7, 0x01, 0x60, 0x00, 0x30, 0x00, 0x00, 0x00>> =
+               HCI.le_set_scan_parameters()
+    end
+
+    test "a passive scan is the same command with the first byte cleared" do
+      assert <<0x01, 0x0B, 0x20, 7, 0x00, _rest::binary>> =
+               HCI.le_set_scan_parameters(type: 0x00)
+    end
+
+    test "scan enable does not filter duplicates unless asked" do
+      assert <<0x01, 0x0C, 0x20, 2, 0x01, 0x00>> == HCI.le_set_scan_enable(true)
+      assert <<0x01, 0x0C, 0x20, 2, 0x00, 0x00>> == HCI.le_set_scan_enable(false)
+      assert <<0x01, 0x0C, 0x20, 2, 0x01, 0x01>> == HCI.le_set_scan_enable(true, true)
+    end
+  end
+
+  describe "building the list" do
+    test "an advertisement and its scan response are one device" do
+      types = Advertising.types()
+      flags = Advertising.encode([{types.flags, <<0x06>>}])
+      name = Advertising.encode([{types.complete_name, "Headphones"}])
+
+      scan =
+        Scan.new()
+        |> Scan.observe(decode_one(data: flags), 0)
+        |> Scan.observe(decode_one(data: name, event_type: 0x04, rssi: -70), 10)
+
+      assert [device] = Scan.list(scan)
+      assert device.name == "Headphones"
+      assert device.flags == 0x06
+      assert device.reports == 2
+      assert device.last_seen == 10
+      assert device.first_seen == 0
+    end
+
+    test "a later nameless advertisement does not wipe the name" do
+      types = Advertising.types()
+      name = Advertising.encode([{types.complete_name, "Pad"}])
+
+      scan =
+        Scan.new()
+        |> Scan.observe(decode_one(data: name), 0)
+        |> Scan.observe(decode_one(data: <<>>), 100)
+
+      assert [%{name: "Pad", reports: 2}] = Scan.list(scan)
+    end
+
+    test "a scan response does not downgrade a connectable device" do
+      scan =
+        Scan.new()
+        |> Scan.observe(decode_one(event_type: 0x00), 0)
+        |> Scan.observe(decode_one(event_type: 0x04), 5)
+
+      assert [%{connectable?: true}] = Scan.list(scan)
+    end
+
+    test "an unconnectable beacon stays unconnectable" do
+      scan = Scan.observe(Scan.new(), decode_one(event_type: 0x03), 0)
+      assert [%{connectable?: false}] = Scan.list(scan)
+    end
+
+    test "the same address with a different address type is a different device" do
+      scan =
+        Scan.new()
+        |> Scan.observe(decode_one(address_type: 0x00), 0)
+        |> Scan.observe(decode_one(address_type: 0x01), 0)
+
+      assert Scan.count(scan) == 2
+    end
+
+    test "the order is first seen first, and a stronger signal does not jump the queue" do
+      first = <<1, 1, 1, 1, 1, 1>>
+      second = <<2, 2, 2, 2, 2, 2>>
+
+      scan =
+        Scan.new()
+        |> Scan.observe(decode_one(address: first, rssi: -95), 0)
+        |> Scan.observe(decode_one(address: second, rssi: -30), 1)
+        |> Scan.observe(decode_one(address: first, rssi: -20), 2)
+
+      assert Scan.list(scan) |> Enum.map(& &1.sequence) == [0, 1]
+      assert Scan.list(scan) |> Enum.map(& &1.address) |> hd() == "01:01:01:01:01:01"
+    end
+
+    test "a device that stops advertising ages out" do
+      scan = Scan.observe(Scan.new(), decode_one([]), 0)
+
+      assert Scan.count(Scan.forget_stale(scan, 10_000, 30_000)) == 1
+      assert Scan.count(Scan.forget_stale(scan, 40_000, 30_000)) == 0
+    end
+
+    test "age never goes negative on a clock that has not moved" do
+      scan = Scan.observe(Scan.new(), decode_one([]), 500)
+      [device] = Scan.list(scan)
+
+      assert Scan.age(device, 400) == 0
+      assert Scan.age(device, 900) == 400
+    end
+  end
+
+  describe "reading the advertisement" do
+    test "flags with BR/EDR Not Supported clear mean a dual-mode device" do
+      types = Advertising.types()
+      # 0x02 is General Discoverable with bit 2 clear: it also does classic.
+      dual = Advertising.encode([{types.flags, <<0x02>>}])
+      scan = Scan.observe(Scan.new(), decode_one(data: dual), 0)
+
+      assert [device] = Scan.list(scan)
+      assert Scan.dual_mode?(device) == true
+    end
+
+    test "this project's own advertisement reads back as LE only" do
+      # Advertising.data/0 is what the controller app puts on the air, and it
+      # sets BR/EDR Not Supported. Round-tripping it through the scanner is
+      # the cheapest available check that the flag is being read off the same
+      # bit it is written to.
+      scan = Scan.observe(Scan.new(), decode_one(data: Advertising.data()), 0)
+
+      assert [device] = Scan.list(scan)
+      assert Scan.dual_mode?(device) == false
+      assert device.appearance == Advertising.appearance()
+      assert 0x1812 in device.services
+    end
+
+    test "no flags yet is nil, which is not the same as LE only" do
+      scan = Scan.observe(Scan.new(), decode_one(data: <<>>), 0)
+      assert [device] = Scan.list(scan)
+      assert Scan.dual_mode?(device) == nil
+    end
+
+    test "a shortened name is flagged as one" do
+      types = Advertising.types()
+      data = Advertising.encode([{types.short_name, "Sony WH"}])
+      scan = Scan.observe(Scan.new(), decode_one(data: data), 0)
+
+      assert [%{name: "Sony WH", shortened_name?: true}] = Scan.list(scan)
+    end
+
+    test "a name that is not valid UTF-8 is dropped rather than drawn" do
+      types = Advertising.types()
+      data = Advertising.encode([{types.complete_name, <<0xFF, 0xFE>>}])
+      scan = Scan.observe(Scan.new(), decode_one(data: data), 0)
+
+      assert [device] = Scan.list(scan)
+      assert device.name == nil
+      assert Scan.label(device) == "A1:B2:C3:D4:E5:F6"
+    end
+
+    test "a nameless device is labelled by its address" do
+      scan = Scan.observe(Scan.new(), decode_one(data: <<>>), 0)
+      assert [device] = Scan.list(scan)
+      assert Scan.label(device) == "A1:B2:C3:D4:E5:F6"
+    end
+  end
+end

--- a/test/bluetooth/scanner_test.exs
+++ b/test/bluetooth/scanner_test.exs
@@ -1,0 +1,97 @@
+defmodule MayonnaiOS.Bluetooth.ScannerTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Bluetooth.{Advertising, FakeController, HCI, Scanner}
+
+  setup do
+    start_supervised!({FakeController, self()})
+    start_supervised!(Scanner)
+
+    # Setup runs in a handle_continue, which is executed before any call this
+    # test makes, so one call is enough to know it has finished.
+    Scanner.status()
+    :ok
+  end
+
+  defp advertise(opts) do
+    data = Keyword.get(opts, :data, <<>>)
+    address = Keyword.get(opts, :address, <<0xF6, 0xE5, 0xD4, 0xC3, 0xB2, 0xA1>>)
+    event_type = Keyword.get(opts, :event_type, 0x00)
+    rssi = Keyword.get(opts, :rssi, -55)
+
+    params =
+      <<0x01, event_type, 0x00, address::binary, byte_size(data), data::binary, rssi::signed-8>>
+
+    packet = <<0x04, 0x3E, byte_size(params) + 1, 0x02, params::binary>>
+    FakeController.emit(HCI.decode(packet))
+  end
+
+  test "setup resets, masks, and turns the scan on, in that order" do
+    assert_received {:command, 0x0C03, _}
+    assert_received {:command, 0x0C01, _}
+    assert_received {:command, 0x2001, _}
+    assert_received {:command, 0x0C6D, _}
+    assert_received {:command, 0x200B, _}
+    assert_received {:command, 0x200C, <<0x01, 0x00>>}
+
+    assert %{scanning: true, error: nil, devices: 0} = Scanner.status()
+  end
+
+  test "no buffer sizes are read, because a scan sends nothing" do
+    refute_received {:command, 0x2002, _}
+    refute_received {:command, 0x1005, _}
+  end
+
+  test "an advertisement becomes a device" do
+    advertise([])
+
+    assert [device] = Scanner.devices()
+    assert device.address == "A1:B2:C3:D4:E5:F6"
+    assert device.label == "A1:B2:C3:D4:E5:F6"
+    assert device.rssi == -55
+    assert %{devices: 1} = Scanner.status()
+  end
+
+  test "a device carries the tag the screen puts where Connect would be" do
+    # BR/EDR Not Supported clear: this is a dual-mode device, which is what a
+    # pair of headphones looks like from an LE scan.
+    types = Advertising.types()
+    data = Advertising.encode([{types.flags, <<0x02>>}, {types.complete_name, "Headphones"}])
+
+    advertise(data: data)
+
+    assert [%{label: "Headphones", dual_mode?: true}] = Scanner.devices()
+  end
+
+  test "this device's own advertisement reads back as LE only" do
+    advertise(data: Advertising.data())
+    assert [%{dual_mode?: false}] = Scanner.devices()
+  end
+
+  test "an age comes back with every device" do
+    advertise([])
+    assert [%{age_ms: age}] = Scanner.devices()
+    assert age >= 0
+  end
+
+  test "an event with no reports in it is counted rather than dropped silently" do
+    FakeController.emit({:event, :le_advertising_report, %{reports: []}})
+
+    assert %{undecodable: 1, devices: 0} = Scanner.status()
+  end
+
+  test "an event this process does not handle does not take it down" do
+    pid = Process.whereis(Scanner)
+    FakeController.emit({:event, :disconnection_complete, %{status: 0, handle: 1, reason: 0x13}})
+    FakeController.emit({:acl, 0x0040, :start, <<1, 2, 3>>})
+
+    assert %{scanning: true} = Scanner.status()
+    assert Process.whereis(Scanner) == pid
+  end
+
+  test "stopping the scanner turns the scan off rather than leaving the radio busy" do
+    :ok = stop_supervised(Scanner)
+
+    assert_received {:command, 0x200C, <<0x00, 0x00>>}
+  end
+end

--- a/test/pairing_test.exs
+++ b/test/pairing_test.exs
@@ -1,0 +1,374 @@
+defmodule MayonnaiOS.PairingTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Bluetooth.{Advertising, Bonds, FakeController, HCI, Scanner}
+  alias MayonnaiOS.Pairing
+  alias MayonnaiOS.Pairing.Cursor
+  alias MayonnaiOS.Scene.Pairing, as: Scene
+
+  @laptop {0x00, <<0xA6, 0xA5, 0xA4, 0xA3, 0xA2, 0xA1>>}
+  @windows {0x01, <<0xB6, 0xB5, 0xB4, 0xB3, 0xB2, 0xB1>>}
+
+  # The buttons, as the launcher forwards them. :btn_b is physical A; see
+  # MayonnaiOS.Launcher for the device tree that lies about it.
+  @a {:ev_key, :btn_b, 1}
+  @up {:ev_key, :btn_dpad_up, 1}
+  @down {:ev_key, :btn_dpad_down, 1}
+
+  setup do
+    path = Path.join(System.tmp_dir!(), "pairing-#{System.unique_integer([:positive])}/bonds.bin")
+    Application.put_env(:mayonnaios, :bond_path, path)
+
+    on_exit(fn ->
+      Application.delete_env(:mayonnaios, :bond_path)
+      File.rm_rf!(Path.dirname(path))
+    end)
+
+    :ok
+  end
+
+  defp bond(peer, ediv) do
+    %{
+      ltk: :crypto.strong_rand_bytes(16),
+      ediv: ediv,
+      rand: :crypto.strong_rand_bytes(8),
+      peer: peer,
+      key_size: 16
+    }
+  end
+
+  # The app's own supervisor cannot start here: it wants the real Host, and
+  # this machine has no AF_BLUETOOTH. So the pieces above the socket are
+  # started against the shared fake, which is the same seam the peripheral
+  # tests use, and `Pairing.status/0` is then exercised for real.
+  defp start_session do
+    start_supervised!({FakeController, self()})
+    start_supervised!(Bonds)
+    start_supervised!(Scanner)
+    start_supervised!(Cursor)
+    Scanner.status()
+    :ok
+  end
+
+  defp advertise(name, flags) do
+    types = Advertising.types()
+    data = Advertising.encode([{types.flags, <<flags>>}, {types.complete_name, name}])
+
+    params = <<0x01, 0x00, 0x00, 1, 2, 3, 4, 5, 6, byte_size(data), data::binary, -55::signed-8>>
+    packet = <<0x04, 0x3E, byte_size(params) + 1, 0x02, params::binary>>
+    FakeController.emit(HCI.decode(packet))
+  end
+
+  describe "the app that is not running" do
+    test "status says so rather than raising" do
+      assert Pairing.status() == :stopped
+    end
+
+    test "input goes nowhere rather than crashing the launcher" do
+      assert Pairing.input([@a]) == :ok
+    end
+
+    test "the launcher can ask for the scene without the app being up" do
+      assert Pairing.scene() == MayonnaiOS.Scene.Pairing
+      refute Pairing.active?()
+    end
+
+    test "it satisfies the whole contract the launcher calls on an app" do
+      # `MayonnaiOS.Launcher.start_program/2` calls start/0, then stop/0 and
+      # input/1 and scene/0. A menu entry missing one of these is a
+      # FunctionClauseError inside the process that owns the buttons, which
+      # takes the gamepad away from the whole device.
+      for {function, arity} <- [start: 0, start: 1, stop: 0, input: 1, scene: 0] do
+        assert function_exported?(Pairing, function, arity),
+               "MayonnaiOS.Pairing.#{function}/#{arity} is missing"
+      end
+    end
+
+    test "it normalises as an app in the menu, not as a missing binary" do
+      assert [program] =
+               MayonnaiOS.Programs.list([%{name: "Bluetooth devices", app: Pairing}])
+
+      assert program.installed?
+      assert program.app == Pairing
+      assert program.path == nil
+    end
+  end
+
+  describe "what the screen is handed" do
+    setup do
+      start_session()
+      :ok
+    end
+
+    test "bonds come out with a printable address rather than an EDIV" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+
+      assert [entry] = Pairing.list_bonds()
+      assert entry.address == "A1:A2:A3:A4:A5:A6"
+      assert entry.random? == false
+      assert entry.key_size == 16
+    end
+
+    test "a random peer address is marked as one" do
+      Bonds.put(bond(@windows, <<2, 0>>))
+      assert [%{random?: true}] = Pairing.list_bonds()
+    end
+  end
+
+  describe "the cursor" do
+    setup do
+      start_session()
+      :ok
+    end
+
+    test "starts at the top and stays there with nothing paired" do
+      assert %{selected: 0, armed: false} = Cursor.state()
+
+      Cursor.input([@down])
+
+      assert %{selected: 0, armed: false} = Cursor.state()
+    end
+
+    test "A cannot arm an empty list" do
+      Cursor.input([@a])
+      assert %{armed: false} = Cursor.state()
+    end
+
+    test "moves over the paired hosts and wraps" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+      Bonds.put(bond(@windows, <<2, 0>>))
+
+      Cursor.input([@down])
+      assert %{selected: 1} = Cursor.state()
+
+      Cursor.input([@down])
+      assert %{selected: 0} = Cursor.state()
+
+      Cursor.input([@up])
+      assert %{selected: 1} = Cursor.state()
+    end
+
+    test "the first A arms and the second one forgets" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+      Bonds.put(bond(@windows, <<2, 0>>))
+
+      Cursor.input([@a])
+      assert %{armed: true, selected: 0} = Cursor.state()
+      assert length(Bonds.list()) == 2
+
+      Cursor.input([@a])
+      assert %{armed: false} = Cursor.state()
+
+      # Newest first, so index 0 is the Windows bond that was put last.
+      assert [%{peer: @laptop}] = Bonds.list()
+    end
+
+    test "moving cancels an armed row" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+      Bonds.put(bond(@windows, <<2, 0>>))
+
+      Cursor.input([@a])
+      Cursor.input([@down])
+
+      assert %{armed: false, selected: 1} = Cursor.state()
+      assert length(Bonds.list()) == 2
+    end
+
+    test "an unbound button leaves an armed row armed" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+
+      Cursor.input([@a])
+      # Y, which is deliberately unbound everywhere on this device.
+      Cursor.input([{:ev_key, :btn_x, 1}])
+
+      assert %{armed: true} = Cursor.state()
+    end
+
+    test "autorepeat is ignored, so holding A does not forget a second bond" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+      Bonds.put(bond(@windows, <<2, 0>>))
+
+      Cursor.input([@a])
+      Cursor.input([{:ev_key, :btn_b, 2}])
+      Cursor.input([{:ev_key, :btn_b, 2}])
+
+      assert length(Bonds.list()) == 2
+      assert %{armed: true} = Cursor.state()
+    end
+
+    test "forgetting the last row leaves the cursor inside the shorter list" do
+      Bonds.put(bond(@laptop, <<1, 0>>))
+      Bonds.put(bond(@windows, <<2, 0>>))
+
+      Cursor.input([@down])
+      Cursor.input([@a])
+      Cursor.input([@a])
+
+      assert length(Bonds.list()) == 1
+      # The index is bounded where it is used rather than clamped here, so the
+      # screen never asks for a row that is not in the list.
+      assert %{selected: 1} = Cursor.state()
+      assert %{selected: 0} = Pairing.status()
+    end
+  end
+
+  describe "the screen" do
+    test "renders the not-running page with the reason on it" do
+      texts = texts(Scene.graph(:stopped, :eusers))
+
+      assert "Not running" in texts
+      assert ":eusers" in texts
+      assert "Something else already has hci0." in texts
+    end
+
+    test "names the controller app when it already has the stack" do
+      texts = texts(Scene.graph(:stopped, {:already_started, self()}))
+      assert "The controller app is running." in texts
+    end
+
+    test "says headphones do not work before it says anything else" do
+      start_session()
+
+      texts = texts(Scene.graph(Pairing.status()))
+
+      assert "Headphones cannot be connected from here." in texts
+
+      assert "Audio is A2DP over BR/EDR, and this firmware has no BR/EDR host at all." in texts
+    end
+
+    test "offers no action at all when nothing is paired" do
+      start_session()
+
+      texts = texts(Scene.graph(Pairing.status()))
+
+      assert "Nothing paired." in texts
+      assert "Menu goes back." in texts
+      refute Enum.any?(texts, &String.contains?(&1, "A forgets"))
+    end
+
+    test "a dual-mode device is tagged where a Connect button would be" do
+      start_session()
+      advertise("Headphones", 0x02)
+
+      texts = texts(Scene.graph(Pairing.status()))
+
+      assert "Headphones" in texts
+      assert Enum.any?(texts, &String.contains?(&1, "needs BR/EDR"))
+      refute Enum.any?(texts, &String.contains?(&1, "Connect"))
+    end
+
+    test "an LE-only device is not tagged as needing a transport we lack" do
+      start_session()
+      advertise("Beacon", 0x06)
+
+      texts = texts(Scene.graph(Pairing.status()))
+
+      assert Enum.any?(texts, &String.contains?(&1, "LE only"))
+      refute Enum.any?(texts, &String.contains?(&1, "needs BR/EDR"))
+    end
+
+    test "an armed row says which press does it" do
+      start_session()
+      Bonds.put(bond(@laptop, <<1, 0>>))
+      Cursor.input([{:ev_key, :btn_b, 1}])
+
+      texts = texts(Scene.graph(Pairing.status()))
+
+      assert "press A again to forget" in texts
+      assert "A forgets this pairing. Any direction cancels. Menu leaves." in texts
+    end
+
+    test "an unarmed row says what the buttons do" do
+      start_session()
+      Bonds.put(bond(@laptop, <<1, 0>>))
+
+      texts = texts(Scene.graph(Pairing.status()))
+
+      assert "A1:A2:A3:A4:A5:A6" in texts
+      assert "public address, 128-bit key" in texts
+      assert "D-pad picks a pairing, A forgets it. Menu goes back." in texts
+    end
+
+    test "a scan that never started says so instead of showing an empty room" do
+      status = %{
+        scan: %{scanning: false, error: :eusers, devices: 0, undecodable: 0},
+        devices: [],
+        bonds: [],
+        selected: 0,
+        armed: false
+      }
+
+      texts = texts(Scene.graph(status))
+
+      assert "Scan did not start." in texts
+      refute "Scanning..." in texts
+    end
+
+    test "a scan with nothing in it yet is different from a scan that failed" do
+      start_session()
+
+      texts = texts(Scene.graph(Pairing.status()))
+
+      assert "Scanning..." in texts
+      assert "Nothing has advertised yet." in texts
+    end
+
+    test "windows the paired hosts so a selection past the eighth is still drawn" do
+      bonds =
+        for i <- 1..12 do
+          %{
+            peer: {0x00, <<i, i, i, i, i, i>>},
+            address: "0#{i}:00:00:00:00:00",
+            random?: false,
+            key_size: 16
+          }
+        end
+
+      status = %{
+        scan: %{scanning: true, error: nil, devices: 0, undecodable: 0},
+        devices: [],
+        bonds: bonds,
+        selected: 11,
+        armed: false
+      }
+
+      texts = texts(Scene.graph(status))
+
+      assert "012:00:00:00:00:00" in texts
+      refute "01:00:00:00:00:00" in texts
+      assert "5-12 of 12" in texts
+    end
+
+    test "a long name is clipped rather than drawn over the footer" do
+      status = %{
+        scan: %{scanning: true, error: nil, devices: 1, undecodable: 0},
+        devices: [
+          %{
+            label: "A Very Long Bluetooth Device Name Indeed",
+            name: "A Very Long Bluetooth Device Name Indeed",
+            rssi: -40,
+            age_ms: 0,
+            dual_mode?: false
+          }
+        ],
+        bonds: [],
+        selected: 0,
+        armed: false
+      }
+
+      texts = texts(Scene.graph(status))
+
+      assert Enum.any?(texts, &String.starts_with?(&1, "A Very Long Bluetooth"))
+      refute "A Very Long Bluetooth Device Name Indeed" in texts
+    end
+  end
+
+  # Every text primitive's string, the same helper the launcher tests use, so
+  # a test can assert what the panel says rather than only that it built.
+  defp texts(graph) do
+    Scenic.Graph.reduce(graph, [], fn
+      %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+      _primitive, acc -> acc
+    end)
+  end
+end

--- a/test/support/fake_controller.exs
+++ b/test/support/fake_controller.exs
@@ -1,0 +1,86 @@
+defmodule MayonnaiOS.Bluetooth.FakeController do
+  @moduledoc """
+  A Bluetooth controller that says yes to everything, for the tests.
+
+  Registered under the name the real `MayonnaiOS.Bluetooth.Host` uses, so
+  anything above the socket -- the peripheral, the scanner -- can be started
+  against it unchanged. Commands are forwarded to the test process as
+  `{:command, opcode, params}` and ACL packets as `{:acl, packets}`.
+
+  This started life inside `MayonnaiOS.Bluetooth.PeripheralTest`, which is
+  where the reasoning for it belongs and still lives: the pieces of this stack
+  that are worth testing this way are the ones whose bugs are interactions
+  between four protocols rather than a wrong byte. It moved out here when the
+  scanner needed the same seam, because two fake controllers that drift apart
+  are worse than one that is a little more general than either caller needs.
+
+  What it buys is the part that is otherwise only testable on the device with
+  another machine in the other hand. What it does not prove is that the real
+  controller behaves this way; this one answers every command with success,
+  and the Realtek part has opinions.
+
+  ## Pushing events back
+
+  `emit/1` sends a decoded packet to whoever last called `attach/1`, in the
+  `{:hci, packet}` shape the real host uses. That is how a test plays a
+  connection, or a room full of advertisers, without a radio.
+  """
+
+  use GenServer
+
+  @doc """
+  Start the fake under the real host's name.
+
+  `test` is the process that receives the command and ACL notifications.
+  """
+  def start_link(test) when is_pid(test), do: start_link(test: test)
+
+  def start_link(opts) when is_list(opts) do
+    GenServer.start_link(__MODULE__, opts, name: MayonnaiOS.Bluetooth.Host)
+  end
+
+  @doc "Send one decoded packet to the attached process, as the host would."
+  def emit(packet), do: GenServer.call(MayonnaiOS.Bluetooth.Host, {:emit, packet})
+
+  @doc "Every opcode this fake has been asked for, most recent first."
+  def commands, do: GenServer.call(MayonnaiOS.Bluetooth.Host, :commands)
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %{
+       test: Keyword.fetch!(opts, :test),
+       address: Keyword.get(opts, :address, <<0xB6, 0xB5, 0xB4, 0xB3, 0xB2, 0xB1>>),
+       owner: nil,
+       commands: []
+     }}
+  end
+
+  @impl true
+  def handle_call({:attach, pid}, _from, state), do: {:reply, :ok, %{state | owner: pid}}
+
+  def handle_call({:command, <<0x01, opcode::16-little, _len, params::binary>>, _t}, _from, state) do
+    send(state.test, {:command, opcode, params})
+    {:reply, {:ok, return_params(opcode, state)}, %{state | commands: [opcode | state.commands]}}
+  end
+
+  def handle_call({:acl, packets}, _from, state) do
+    send(state.test, {:acl, packets})
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:buffers, _length, _count}, _from, state), do: {:reply, :ok, state}
+  def handle_call(:packet_length, _from, state), do: {:reply, 27, state}
+  def handle_call(:commands, _from, state), do: {:reply, state.commands, state}
+
+  def handle_call({:emit, packet}, _from, state) do
+    if state.owner, do: send(state.owner, {:hci, packet})
+    {:reply, :ok, state}
+  end
+
+  # LE Read Buffer Size: four packets of 27 bytes, which is a realistic answer
+  # and small enough that a report descriptor read has to fragment.
+  defp return_params(0x2002, _state), do: <<27::16-little, 4>>
+  defp return_params(0x1009, state), do: state.address
+  defp return_params(_other, _state), do: <<>>
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
+# Shared test doubles. Required here rather than compiled through
+# `elixirc_paths` so that nothing in `test/support` can end up in the release
+# by way of a mix.exs change nobody remembers making.
+Code.require_file("support/fake_controller.exs", __DIR__)
+
 ExUnit.start()


### PR DESCRIPTION
## Summary

This was asked for as "a UI for pairing/connecting Bluetooth devices like headphones". **Headphones cannot work on this firmware, and the answer is not close.** So this ships option (b): the screen does what the stack can actually do — scan, list what is nearby, list the pairings this device has made, forget one — and it names the missing piece in its first line rather than offering a Connect button that could never produce sound.

## The feasibility answer, with the evidence

A2DP over BR/EDR is **not** reachable without a Buildroot rebuild. Every check below was run, not inferred:

- **No BlueZ in the image.** On the device: no `/usr/lib/bluetooth`, no `/usr/libexec/bluetooth`, no `/etc/bluetooth`, and a grep of `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin` for `bluetoothctl|hciconfig|btmon|sdptool|l2ping|rfcomm` returns nothing. In `nerves_system_rg40xxv/nerves_defconfig`, a case-insensitive grep for `bluez|pulseaudio|pipewire|sbc` matches **zero** lines. `HCISocket`'s moduledoc already said this; it is now confirmed rather than inherited.
- **No audio path either.** No PulseAudio, PipeWire or `bluez-alsa`. The image has `BR2_PACKAGE_ALSA_UTILS` and nothing that can present a Bluetooth sink, so even a working A2DP source in the BEAM would have no way to be handed RetroArch's audio. That is the part that makes this a rebuild rather than an Elixir problem.
- **No BR/EDR host in this codebase.** `Bluetooth.HCI` has no inquiry, no create-connection, no link-key or SSP commands; `Bluetooth.L2CAP` is documented and implemented as the three fixed LE channels with no connection-oriented channel to carry AVDTP; `Bluetooth.SMP` is LE SMP and `Bonds` is keyed on EDIV/Rand, which BR/EDR link keys do not have. There is no SDP client, no AVDTP, no SBC encoder.
- **The radio itself is almost certainly fine, and that is not the constraint.** `dmesg`: `RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8821`, firmware `0x75b8f098` loaded, and the kernel registered the SCO socket layer — a BR/EDR-only thing. `# CONFIG_BT_LE is not set` is a red herring for the same reason `HCISocket` documents: the user channel bypasses the kernel host entirely.

**Explicitly unverified:** I did not read the controller's Supported Features to prove BR/EDR, because doing that means opening an HCI user channel and taking `hci0`, which I was told not to do on a shared box. So "the controller does BR/EDR" is inference from `lmp_subver=8821` (RTL8821C, a dual-mode part) plus the SCO layer, not a feature bitmap I read. It does not change the verdict: the blocker is entirely host-side software, and two of the missing pieces are Buildroot options.

## Approach

The interesting choice was what to do with the scan results. Listing nearby devices with no action on them looks lazy; adding a Connect button would have been this project's characteristic failure — an inherited assumption reported as success — compiled into the UI. The resolution is that each nearby row reads the advertisement's own Flags byte, bit 2, `BR/EDR Not Supported`. Clear means the device also speaks classic, which is what headphones look like from an LE scan, and the row prints `needs BR/EDR` exactly where the button would have gone. It is a measurement off the wire, not a guess from the device name, and it puts the reason at the point of the disappointment.

The other non-obvious call: the bond file was never fsynced. `File.write/2` plus an atomic rename reads as durable and is not, on a device with no `sync` binary that is switched off by pulling power — the same gap that ate a set of ROMs on this board. Since the task requires pairing keys to survive a power cut, that is fixed here rather than filed.

Adding audio later is a profile module under `Bluetooth` and a row action in `Scene.Pairing`; the flag plumbing and the app shell do not move.

## Follow-ups for reviewer

- **Nothing here has touched the radio.** The scan path is tested against the shared fake controller, which answers every command with success. `Scanner.status/0` reports a count of advertising events that decoded to nothing, so a disagreement with the real RTL8821CS shows on the panel rather than as an empty list — but the first run on hardware is the real test. Worth doing before this is trusted?
- **A twice to forget a bond**, rather than a chord. `Y` stays unbound and no new chord was invented. Is a two-press confirm the right weight for something that costs one re-pairing, or should it just do it on the first press?
- **`nerves_defconfig` is checksum-tracked**, so I deliberately changed nothing in the system repo — not even a comment — to avoid invalidating the published artifact. If the BlueZ/PipeWire question is ever taken up, that is where the 2-3 hour rebuild starts.
- The menu entry is called **"Bluetooth devices"**, not "Bluetooth pairing", so the name does not promise the thing it cannot do. Happy to rename.
