### PR TITLE
Put a file manager in the menu, with no new buttons and no silent deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,57 @@ Unmount before pulling the card out —
 — because exFAT has no journal and this device is switched off by pulling
 power.
 
+## Moving files around on the device
+
+Pick **Files** in the launcher. It opens on a short list of the places worth
+looking at — the ROM roots from `:rom_roots`, the installed bundles, the
+installed cores, and `/root` — and browsing starts inside one of them. It is an
+app rather than a program: a module in this firmware, no external process, no
+screen handed over.
+
+    D-pad up/down     move
+    D-pad left/right  a screen at a time
+    A                 open a directory, or the actions for a file
+    B                 back
+    Y                 the second verb; the bottom line says what it is
+    Menu              leave
+
+Copy, move, rename and delete. Copy and move are a clipboard, because there is
+nothing to type a destination with: pick the file, walk to where it should go,
+press Y and paste it. Renaming is a character picker for the same reason —
+slow, and reachable from the device, which a text field would not have been.
+
+Nothing overwrites. A destination that already exists is refused rather than
+replaced, because on this device the file being replaced is somebody's save.
+
+**Deleting asks, and the answer is not the button that asked.** A opens the
+confirmation and **Y** carries it out; A cancels, as does B and as does any
+direction. There is no undo and no trash on a handheld that is switched off by
+pulling its power, so a second press of the same button would not be a
+confirmation. A directory with anything in it is refused outright.
+
+Free space is shown for the filesystem the current directory is on, not for the
+device: the roots span the writable partition and, with a card in, the games
+card, and one number would be wrong for whichever it was not measuring. `/` is
+a full read-only squashfs and is not reachable from the app at all.
+
+Every copy is fsynced before it counts as done — there is no `sync` on this
+device, and an unsynced write survives exactly as long as the page cache. Bytes
+go to a `.part` file beside the destination, get fsynced, and are then renamed
+into place, so an interrupted copy leaves a `.part` rather than a ROM that
+looks complete and fails three hours into a game.
+
+Paths are built from a root key and checked names; nothing takes a path.
+`MayonnaiOS.Files` rejects a name rather than cleaning it, the same line
+`MayonnaiOS.Library` takes for uploads, and its moduledoc has the one honest
+caveat: symlinks already in the tree are followed for reading, because
+`bundles/retroarch/current` is one and the core directory is nothing but them.
+Deleting a link removes the link and never its target.
+
+None of this has been run on the handheld yet — it is 74 host tests and a
+target compile, and the panel layout in particular has been checked only as a
+graph, not with eyes on the glass.
+
 ## Emulator cores
 
 Cores are installed onto the device rather than built into the firmware, so

--- a/config/target.exs
+++ b/config/target.exs
@@ -226,7 +226,19 @@ config :mayonnaios, :programs, [
   # It takes hci0 for as long as it runs, so it cannot be up at the same time
   # as anything else that wants the Bluetooth controller. That is why it is
   # here as a menu entry and not in the boot supervision tree.
-  %{name: "Bluetooth controller", app: MayonnaiOS.Controller}
+  %{name: "Bluetooth controller", app: MayonnaiOS.Controller},
+  # Also an app, and for a much duller reason than Bluetooth: it needs the
+  # buttons and the panel and nothing else. Reading a directory is a syscall,
+  # not a device, so there is nothing here for it to take away from anything
+  # else -- which is why, unlike the controller, two of these running at once
+  # would be harmless rather than a bug. It is still one entry and one process.
+  #
+  # It reaches only the roots `MayonnaiOS.Files` derives from the configuration
+  # below -- the ROM roots, the bundles, the cores, and /root -- and it builds
+  # every path from a root key plus checked names rather than from a string.
+  # See that module's moduledoc for what the boundary does and does not
+  # promise; the symlink caveat is the part worth reading.
+  %{name: "Files", app: MayonnaiOS.FileManager}
 ]
 
 # The name a host shows in its pairing list, and the icon it draws next to it

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -26,7 +26,7 @@ defmodule MayonnaiOS.Application do
         [{Scenic, [Application.get_env(:mayonnaios, :viewport)]}]
       else
         []
-      end ++ [controller_sessions()] ++ target_children()
+      end ++ [controller_sessions(), file_manager_sessions()] ++ target_children()
 
     # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
@@ -40,6 +40,11 @@ defmodule MayonnaiOS.Application do
   # laptop with the bind error rather than with "no such supervisor", which is
   # a much less interesting thing to be told.
   defp controller_sessions, do: MayonnaiOS.Controller.sessions()
+
+  # The same arrangement for the file manager, and for the same reason: the
+  # launcher starts it from the process that owns the gamepad, so it must not
+  # be linked to that process. Empty until someone opens it.
+  defp file_manager_sessions, do: MayonnaiOS.FileManager.sessions()
 
   # List all child processes to be supervised
   if Mix.target() == :host do

--- a/lib/mayonnaios/file_manager.ex
+++ b/lib/mayonnaios/file_manager.ex
@@ -1,0 +1,717 @@
+defmodule MayonnaiOS.FileManager do
+  @moduledoc """
+  The file manager app: what is on the writable card, and what can be done to
+  it, with a D-pad and four buttons.
+
+  An app rather than a program -- a module in this firmware, started in this
+  VM, with no external process and no screen handed over. See
+  `MayonnaiOS.Programs` for what that distinction costs and buys, and
+  `MayonnaiOS.Controller` for the other one.
+
+      iex> MayonnaiOS.FileManager.start()
+      iex> MayonnaiOS.FileManager.snapshot().view
+      :places
+      iex> MayonnaiOS.FileManager.stop()
+
+  This process holds the cursor and the pending operation.
+  `MayonnaiOS.Files` holds the boundary -- every path this app touches is
+  built there from a root key and a list of checked names, and nothing here
+  ever assembles one. `MayonnaiOS.Scene.FileManager` draws what
+  `snapshot/0` returns.
+
+  ## The buttons are the ones that already exist
+
+      D-pad up/down   move the cursor
+      D-pad left/right one screen at a time
+      A               open -- a directory, or the actions for a file
+      B               back -- up a directory, or out of a sheet
+      Y               the second verb, and the screen says what it is
+      Menu            leave, handled by the Launcher
+
+  No chords. Nothing on X, which is the diagnostics key everywhere else, and
+  nothing on Select, which is the power-off modifier. Y was unbound and is now
+  the second verb: actions while browsing, "delete this" on the confirmation,
+  "remove this character" in the rename editor. What it means is written on the
+  panel in every view, because a button whose meaning changes and is not
+  labelled is a button nobody presses twice.
+
+  Autorepeat (evdev value 2) moves the cursor and is ignored for the action
+  buttons, so holding a direction scrolls and holding A does not fire twice.
+  Whether this board's gpio-keys emits autorepeat at all has not been checked,
+  which is why left and right page by a screen: paging works whether or not
+  the kernel repeats, and a directory with two hundred ROMs in it needs one of
+  the two.
+
+  ## Deleting takes two presses, on two different buttons
+
+  Choosing Delete opens a confirmation naming the full path, and the
+  confirmation is not answered by the button that opened it. A ran the action;
+  **Y** does the delete, and A -- like B, like any direction -- cancels it.
+
+  That is the whole reason the confirmation exists. A device that is switched
+  off by pulling its power has no undo, no trash and no journal to replay, so
+  a second press of the same button is not a confirmation, it is a
+  double-press waiting to happen.
+
+  `MayonnaiOS.Files.delete/1` will not remove a directory that has anything in
+  it, so nothing here can lose more than the one name on the screen.
+
+  ## Copy and move are a clipboard, because there is no keyboard
+
+  Choosing Copy or Move remembers the entry. Walk to another directory, press
+  Y, and the first action on the sheet is to paste it there. Nothing
+  overwrites: an existing destination is refused rather than replaced. A move
+  clears the clipboard because the source is gone; a copy keeps it, so the
+  same ROM can be put on both cards, and "Forget" clears it.
+
+  Renaming needs text, and this handheld has no text input, so the rename
+  editor is a character picker: left and right move the caret, up and down
+  change the character under it, Y removes it. It is slow and it is real -- the
+  alternative was a rename verb that could not be reached from the device.
+  """
+
+  use GenServer
+
+  alias MayonnaiOS.Files
+
+  # The buttons as InputEvent names them, which is not what the shell prints.
+  # `MayonnaiOS.Launcher` has the full account: the device tree lies about A/B
+  # and about X/Y, and this board's shell A is BTN_EAST (:btn_b) while shell Y
+  # is 307 (:btn_x). Getting these wrong is not a crash, it is a device where
+  # the wrong button deletes something, so they are named once and only here.
+  @a_button :btn_b
+  @b_button :btn_a
+  @y_button :btn_x
+
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @left :btn_dpad_left
+  @right :btn_dpad_right
+
+  @dpad [@up, @down, @left, @right]
+
+  # Menu belongs to the Launcher: it is the way out of any app, and this one
+  # drops it on the floor exactly as MayonnaiOS.Controller.Report does.
+  @menu :btn_mode
+
+  # One screen. The scene shows twelve rows; ten keeps two rows of context
+  # across a page, which is the difference between paging and teleporting.
+  @page 10
+
+  # What the rename editor can type. Not every character a filesystem accepts
+  # -- a picker with a thousand entries is not a picker -- but every character
+  # a ROM, a save or a directory on this device actually uses.
+  @alphabet String.graphemes(
+              "abcdefghijklmnopqrstuvwxyz" <>
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ" <>
+                "0123456789" <> ".-_ ()[]&'!+,"
+            )
+
+  # -- the app protocol the Launcher uses -------------------------------------
+
+  @sessions MayonnaiOS.FileManager.Sessions
+
+  @doc """
+  Start the app.
+
+  Under a DynamicSupervisor rather than linked to the caller, which is how
+  `MayonnaiOS.Controller` starts too. `MayonnaiOS.Launcher` calls this from
+  inside the process that owns `event0`, so a link would mean that a bug in
+  here -- a directory that turns into something odd halfway through a listing,
+  say -- takes the launcher down with it, and the device then stops answering
+  its buttons at all.
+
+  Named, so `stop/0` and `input/1` need no pid.
+  """
+  @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(opts \\ []) do
+    case DynamicSupervisor.start_child(@sessions, {__MODULE__, opts}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:error, {:already_started, pid}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Stop the app."
+  @spec stop() :: :ok
+  def stop do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(@sessions, pid)
+    end
+  end
+
+  @doc "The DynamicSupervisor the app runs under, for the application tree."
+  @spec sessions() :: Supervisor.child_spec()
+  def sessions do
+    %{
+      id: @sessions,
+      start: {DynamicSupervisor, :start_link, [[name: @sessions, strategy: :one_for_one]]},
+      type: :supervisor
+    }
+  end
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      # Temporary for the same reason the controller session is: whatever went
+      # wrong is in the log and on the panel, and a file manager that restarts
+      # itself back onto the screen someone just left is not help.
+      restart: :temporary
+    }
+  end
+
+  @doc false
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc "Whether the app is running."
+  @spec active?() :: boolean()
+  def active?, do: Process.whereis(__MODULE__) != nil
+
+  @doc """
+  Forward an evdev report from the Launcher.
+
+  A cast: this is called from the process holding `event0`, and a directory
+  listing must never be able to make the buttons late. Safe when the app is
+  not running, because the launcher's view of that and the actual state can
+  differ for as long as it takes to stop.
+  """
+  @spec input([tuple()]) :: :ok
+  def input(events) do
+    if Process.whereis(__MODULE__), do: GenServer.cast(__MODULE__, {:input, events}), else: :ok
+  end
+
+  @doc "The scene the launcher shows while this app has the buttons."
+  @spec scene() :: module()
+  def scene, do: MayonnaiOS.Scene.FileManager
+
+  @doc """
+  Everything the panel needs, as one map.
+
+  A call, so a test that has just cast a synthetic button press is ordered
+  behind it and does not have to sleep.
+  """
+  @spec snapshot() :: map() | :stopped
+  def snapshot do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, :snapshot), else: :stopped
+  end
+
+  @doc """
+  Be told when the snapshot changes, as `{:file_manager, snapshot}`.
+
+  The scene does this instead of polling. A poll fast enough to feel like a
+  button press is a `GenServer.call` every few frames forever; a push happens
+  when something happened, which for a menu is only when a button is pressed.
+  The watcher is monitored, so a scene torn down by `set_root/3` -- which
+  happens on every repaint the launcher does -- drops itself.
+  """
+  @spec watch(pid()) :: map() | :stopped
+  def watch(pid) do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, {:watch, pid}), else: :stopped
+  end
+
+  # -- state ------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    state = %{
+      view: :places,
+      places: Files.places(),
+      place_cursor: 0,
+      location: nil,
+      dir: nil,
+      entries: [],
+      cursor: 0,
+      space: nil,
+      readable?: true,
+      clipboard: nil,
+      actions: [],
+      action_cursor: 0,
+      pending: nil,
+      rename: nil,
+      message: nil,
+      watchers: []
+    }
+
+    state =
+      case Keyword.get(opts, :open) do
+        nil -> state
+        key -> enter_place(state, key)
+      end
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:snapshot, _from, state), do: {:reply, snapshot_of(state), state}
+
+  def handle_call({:watch, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, snapshot_of(state), %{state | watchers: [pid | state.watchers]}}
+  end
+
+  @impl GenServer
+  def handle_cast({:input, events}, state) do
+    {:noreply, state |> apply_events(events) |> notify(state)}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | watchers: List.delete(state.watchers, pid)}}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  defp snapshot_of(state), do: Map.delete(state, :watchers)
+
+  defp notify(state, previous) do
+    if state == previous do
+      state
+    else
+      snapshot = snapshot_of(state)
+      Enum.each(state.watchers, &send(&1, {:file_manager, snapshot}))
+      state
+    end
+  end
+
+  # -- input ------------------------------------------------------------------
+
+  defp apply_events(state, events) do
+    Enum.reduce(events, state, fn
+      # A press, always.
+      {:ev_key, key, 1}, acc -> press(acc, key)
+      # Autorepeat, for the D-pad only: a held direction scrolls, a held A
+      # does not launch an action over and over.
+      {:ev_key, key, 2}, acc when key in @dpad -> press(acc, key)
+      _event, acc -> acc
+    end)
+  end
+
+  # Menu is the Launcher's, in every view. It must not be able to cancel a
+  # confirmation or a rename either, because the launcher is going to act on
+  # it regardless and two things happening on one press is one too many.
+  defp press(state, @menu), do: state
+
+  defp press(%{view: :places} = state, key) do
+    count = length(state.places)
+
+    case key do
+      @up -> %{state | place_cursor: wrap(state.place_cursor - 1, count)}
+      @down -> %{state | place_cursor: wrap(state.place_cursor + 1, count)}
+      @left -> %{state | place_cursor: clamp(state.place_cursor - @page, count)}
+      @right -> %{state | place_cursor: clamp(state.place_cursor + @page, count)}
+      @a_button -> open_place(state)
+      _other -> state
+    end
+  end
+
+  defp press(%{view: :browse} = state, key) do
+    count = length(state.entries)
+
+    case key do
+      @up -> %{state | cursor: wrap(state.cursor - 1, count)}
+      @down -> %{state | cursor: wrap(state.cursor + 1, count)}
+      @left -> %{state | cursor: clamp(state.cursor - @page, count)}
+      @right -> %{state | cursor: clamp(state.cursor + @page, count)}
+      @a_button -> open(state)
+      @b_button -> back(state)
+      @y_button -> open_actions(state)
+      _other -> state
+    end
+  end
+
+  defp press(%{view: :actions} = state, key) do
+    count = length(state.actions)
+
+    case key do
+      @up -> %{state | action_cursor: wrap(state.action_cursor - 1, count)}
+      @down -> %{state | action_cursor: wrap(state.action_cursor + 1, count)}
+      @a_button -> run_action(state)
+      @b_button -> %{state | view: :browse, actions: [], action_cursor: 0}
+      _other -> state
+    end
+  end
+
+  # The confirmation. Y deletes; everything else -- A included, deliberately
+  # -- backs out. See the moduledoc.
+  defp press(%{view: :confirm} = state, @y_button), do: confirm_delete(state)
+
+  defp press(%{view: :confirm} = state, _key) do
+    %{state | view: :browse, pending: nil, message: {:ok, "Nothing was deleted."}}
+  end
+
+  defp press(%{view: :rename} = state, key) do
+    case key do
+      @left -> %{state | rename: move_caret(state.rename, -1)}
+      @right -> %{state | rename: move_caret(state.rename, +1)}
+      @up -> %{state | rename: step_char(state.rename, -1)}
+      @down -> %{state | rename: step_char(state.rename, +1)}
+      @y_button -> %{state | rename: drop_char(state.rename)}
+      @a_button -> confirm_rename(state)
+      @b_button -> %{state | view: :browse, rename: nil, message: {:ok, "Rename cancelled."}}
+      _other -> state
+    end
+  end
+
+  defp press(state, _key), do: state
+
+  # Wrapping for a single step, the way the launcher menu wraps: with the
+  # cursor at the bottom of a listing, the top is one press away.
+  defp wrap(_index, 0), do: 0
+  defp wrap(index, count), do: Integer.mod(index, count)
+
+  # Clamping for a page jump. A page that wrapped would mean pressing right
+  # near the end of a long directory and landing back at the top, which reads
+  # as the app having lost its place.
+  defp clamp(_index, 0), do: 0
+  defp clamp(index, count), do: index |> max(0) |> min(count - 1)
+
+  # -- navigation -------------------------------------------------------------
+
+  defp open_place(state) do
+    case Enum.at(state.places, state.place_cursor) do
+      nil -> state
+      place -> enter_place(state, place.key)
+    end
+  end
+
+  defp enter_place(state, key) do
+    case Files.at(key) do
+      {:ok, location} -> load(%{state | view: :browse}, location)
+      {:error, reason} -> %{state | message: {:error, "#{key}: #{why(reason)}"}}
+    end
+  end
+
+  defp open(state) do
+    case selected(state) do
+      nil -> state
+      %{type: :directory} = entry -> descend(state, entry)
+      _entry -> open_actions(state)
+    end
+  end
+
+  defp descend(state, entry) do
+    case Files.descend(state.location, entry.name) do
+      {:ok, location} -> load(state, location)
+      {:error, reason} -> %{state | message: {:error, "#{entry.name}: #{why(reason)}"}}
+    end
+  end
+
+  defp back(%{location: %{path: []}} = state) do
+    %{state | view: :places, location: nil, entries: [], cursor: 0, message: nil}
+  end
+
+  # Not at the top of a root, so `ascend/1` has a parent to give: the clause
+  # above is the one that answers for the empty path.
+  defp back(state) do
+    load(state, Files.ascend(state.location), Path.basename(state.dir || ""))
+  end
+
+  # Read a directory and put the cursor somewhere sensible.
+  #
+  # `landing` is the name to select on arrival, which is how coming back up
+  # puts the cursor on the directory just left rather than at the top -- the
+  # difference between walking a tree and being teleported to the start of it
+  # every time.
+  #
+  # A directory that cannot be read is a state to render, not an error to
+  # raise: `/root/cores` does not exist until a core is installed, and the
+  # games card's root does not exist with the card out. Both are things the
+  # panel should say plainly.
+  defp load(state, location, landing \\ nil) do
+    {entries, readable?, message} =
+      case Files.list(location) do
+        {:ok, entries} -> {entries, true, nil}
+        {:error, reason} -> {[], false, {:error, why(reason)}}
+      end
+
+    dir =
+      case Files.resolve(location) do
+        {:ok, dir} -> dir
+        {:error, _reason} -> nil
+      end
+
+    cursor =
+      case landing && Enum.find_index(entries, &(&1.name == landing)) do
+        nil -> 0
+        index -> index
+      end
+
+    %{
+      state
+      | view: :browse,
+        location: location,
+        dir: dir,
+        entries: entries,
+        cursor: cursor,
+        readable?: readable?,
+        space: Files.space(location),
+        actions: [],
+        action_cursor: 0,
+        pending: nil,
+        rename: nil,
+        message: message
+    }
+  end
+
+  # Re-read the current directory after an operation, keeping the cursor where
+  # it was rather than where the name was: the name may be the one that just
+  # went away.
+  defp reload(state, message) do
+    reloaded = load(state, state.location)
+    count = length(reloaded.entries)
+
+    %{reloaded | cursor: clamp(min(state.cursor, count - 1), count), message: message}
+  end
+
+  defp selected(%{entries: entries, cursor: cursor}), do: Enum.at(entries, cursor)
+
+  # -- actions ----------------------------------------------------------------
+
+  defp open_actions(%{view: :places} = state), do: state
+
+  defp open_actions(state) do
+    case actions_for(state) do
+      [] -> %{state | message: {:ok, "Nothing to do here."}}
+      actions -> %{state | view: :actions, actions: actions, action_cursor: 0, message: nil}
+    end
+  end
+
+  @doc """
+  The actions offered for the current selection and clipboard.
+
+  Public because it is the part worth testing without a panel: which verbs are
+  on offer is the whole safety story of the sheet -- a directory must not be
+  offered a copy it cannot do, and paste must appear only when something is
+  held.
+  """
+  @spec actions_for(map()) :: [map()]
+  def actions_for(state) do
+    paste_actions(state) ++ selection_actions(selected(state))
+  end
+
+  defp paste_actions(%{clipboard: nil}), do: []
+
+  defp paste_actions(%{clipboard: %{mode: mode, name: name}, readable?: true}) do
+    [
+      %{id: :paste, label: "#{verb(mode)} #{name} here"},
+      %{id: :forget, label: "Forget #{name}"}
+    ]
+  end
+
+  defp paste_actions(%{clipboard: %{name: name}}) do
+    [%{id: :forget, label: "Forget #{name}"}]
+  end
+
+  defp verb(:copy), do: "Paste a copy of"
+  defp verb(:move), do: "Move"
+
+  defp selection_actions(nil), do: []
+
+  defp selection_actions(%{name: name} = entry) do
+    copy =
+      if entry.type == :regular and entry.link == nil do
+        [%{id: :copy, label: "Copy #{name}"}]
+      else
+        []
+      end
+
+    copy ++
+      [
+        %{id: :move, label: "Move #{name}"},
+        %{id: :rename, label: "Rename #{name}"},
+        %{id: :delete, label: "Delete #{name}"}
+      ]
+  end
+
+  defp run_action(state) do
+    case Enum.at(state.actions, state.action_cursor) do
+      nil -> %{state | view: :browse}
+      action -> act(state, action.id)
+    end
+  end
+
+  defp act(state, :copy), do: pick_up(state, :copy)
+  defp act(state, :move), do: pick_up(state, :move)
+
+  defp act(state, :forget) do
+    %{state | view: :browse, clipboard: nil, actions: [], message: {:ok, "Clipboard cleared."}}
+  end
+
+  defp act(state, :delete) do
+    case selected(state) do
+      nil ->
+        %{state | view: :browse}
+
+      entry ->
+        case Files.descend(state.location, entry.name) do
+          {:ok, location} ->
+            %{state | view: :confirm, pending: %{location: location, entry: entry}}
+
+          {:error, reason} ->
+            %{state | view: :browse, message: {:error, "#{entry.name}: #{why(reason)}"}}
+        end
+    end
+  end
+
+  defp act(state, :rename) do
+    case selected(state) do
+      nil ->
+        %{state | view: :browse}
+
+      entry ->
+        %{
+          state
+          | view: :rename,
+            rename: %{name: entry.name, chars: String.graphemes(entry.name), caret: 0},
+            message: nil
+        }
+    end
+  end
+
+  defp act(%{clipboard: nil} = state, :paste), do: %{state | view: :browse}
+
+  defp act(%{clipboard: %{mode: mode, location: source, name: name}} = state, :paste) do
+    result =
+      case mode do
+        :copy -> Files.copy(source, state.location)
+        :move -> Files.move(source, state.location)
+      end
+
+    case result do
+      :ok ->
+        # A move consumes the clipboard: the source is not there any more, so
+        # a second paste could only fail. A copy keeps it, which is how the
+        # same ROM gets onto both cards.
+        clipboard = if mode == :move, do: nil, else: state.clipboard
+
+        %{reload(state, {:ok, "#{name} #{done(mode)}."}) | clipboard: clipboard}
+
+      {:error, reason} ->
+        %{state | view: :browse, message: {:error, "#{name}: #{why(reason)}"}}
+    end
+  end
+
+  defp act(state, _unknown), do: %{state | view: :browse}
+
+  defp done(:copy), do: "copied here"
+  defp done(:move), do: "moved here"
+
+  defp pick_up(state, mode) do
+    case selected(state) do
+      nil ->
+        %{state | view: :browse}
+
+      entry ->
+        case Files.descend(state.location, entry.name) do
+          {:ok, location} ->
+            %{
+              state
+              | view: :browse,
+                actions: [],
+                clipboard: %{mode: mode, location: location, name: entry.name},
+                message: {:ok, "#{entry.name} held. Open a folder and press Y to put it there."}
+            }
+
+          {:error, reason} ->
+            %{state | view: :browse, message: {:error, "#{entry.name}: #{why(reason)}"}}
+        end
+    end
+  end
+
+  # -- deleting ---------------------------------------------------------------
+
+  defp confirm_delete(%{pending: nil} = state), do: %{state | view: :browse}
+
+  defp confirm_delete(%{pending: %{location: location, entry: entry}} = state) do
+    message =
+      case Files.delete(location) do
+        :ok -> {:ok, "#{entry.name} deleted."}
+        {:error, reason} -> {:error, "#{entry.name}: #{why(reason)}"}
+      end
+
+    %{reload(state, message) | pending: nil}
+  end
+
+  # -- renaming ---------------------------------------------------------------
+
+  defp move_caret(%{chars: chars, caret: caret} = rename, delta) do
+    %{rename | caret: caret |> Kernel.+(delta) |> max(0) |> min(length(chars))}
+  end
+
+  # At the append position there is no character to change, so up or down puts
+  # one there and leaves the caret on it -- pressing up again then steps that
+  # character rather than adding a second one.
+  defp step_char(%{chars: chars, caret: caret} = rename, delta) do
+    if caret >= length(chars) do
+      %{rename | chars: chars ++ [first_char(delta)]}
+    else
+      current = Enum.at(chars, caret)
+      %{rename | chars: List.replace_at(chars, caret, next_char(current, delta))}
+    end
+  end
+
+  defp first_char(delta), do: next_char(nil, delta)
+
+  # A character the picker does not know about -- a ROM named in Japanese, say
+  # -- has no position to step from, so the first press replaces it with the
+  # start of the alphabet rather than doing nothing at all.
+  defp next_char(current, delta) do
+    case Enum.find_index(@alphabet, &(&1 == current)) do
+      nil -> hd(@alphabet)
+      index -> Enum.at(@alphabet, Integer.mod(index + delta, length(@alphabet)))
+    end
+  end
+
+  defp drop_char(%{chars: []} = rename), do: rename
+
+  defp drop_char(%{chars: chars, caret: caret} = rename) do
+    at = min(caret, length(chars) - 1)
+    chars = List.delete_at(chars, at)
+    %{rename | chars: chars, caret: min(at, length(chars))}
+  end
+
+  # The name the editor was opened on, not whatever the cursor is on now. The
+  # D-pad belongs to the editor while it is open so the two cannot currently
+  # differ -- but "cannot currently" is not a thing to rename a file on.
+  defp confirm_rename(%{rename: %{chars: chars, name: old}} = state) do
+    new_name = Enum.join(chars)
+
+    with {:ok, location} <- Files.descend(state.location, old),
+         :ok <- Files.rename(location, new_name) do
+      %{reload(state, {:ok, "#{old} is now #{new_name}."}) | rename: nil}
+    else
+      {:error, reason} -> %{state | message: {:error, "#{new_name}: #{why(reason)}"}}
+    end
+  end
+
+  # -- words for the panel ----------------------------------------------------
+
+  @doc """
+  A reason in words, for the panel.
+
+  Here rather than in the scene because these are the words that go in the
+  ring log as well, and a device whose only forensics is `RingLogger.next`
+  should not have two vocabularies for the same failure.
+  """
+  @spec why(term()) :: String.t()
+  def why(:unknown_root), do: "not one of the places this app can open"
+  def why(:bad_name), do: "that name is not allowed"
+  def why(:is_root), do: "that is a whole root, not a file"
+  def why(:eexist), do: "something with that name is already there"
+  def why(:eisdir), do: "that is a directory; only files can be copied"
+  def why(:enotdir), do: "that is not a directory"
+  def why(:enoent), do: "it is not there"
+  def why(:eacces), do: "no permission"
+  def why(:erofs), do: "that filesystem is read-only"
+  def why(:exdev), do: "a directory cannot be moved to another filesystem"
+  def why(:enospc), do: "not enough free space"
+  def why(:not_empty), do: "the directory is not empty"
+  def why(:is_symlink), do: "that is a link; copy what it points at instead"
+  def why(:same_path), do: "it is already there"
+  def why({:unsupported, type}), do: "cannot handle a #{type}"
+  def why({stage, reason}) when is_atom(stage), do: "#{stage} failed: #{why(reason)}"
+  def why(other), do: inspect(other)
+end

--- a/lib/mayonnaios/files.ex
+++ b/lib/mayonnaios/files.ex
@@ -1,0 +1,694 @@
+defmodule MayonnaiOS.Files do
+  @moduledoc """
+  The filesystem as the file manager is allowed to see it: a fixed set of
+  roots, names that are checked rather than cleaned, and writes that are
+  fsynced before they count as done.
+
+  This module is the whole boundary. `MayonnaiOS.FileManager` holds a cursor
+  and `MayonnaiOS.Scene.FileManager` draws it; neither of them ever builds a
+  path.
+
+  ## What is reachable, and why nothing else is
+
+  A location is a **root key and a list of names** -- never a string:
+
+      {:ok, here} = MayonnaiOS.Files.at("roms-1", ["snes"])
+      {:ok, "/root/ROMS/snes"} = MayonnaiOS.Files.resolve(here)
+
+  Every operation in this module takes locations. None of them takes a path,
+  so there is no argument anywhere that a traversal could arrive in. The path
+  is built here, by joining checked names onto a root that came from config.
+
+  The roots come from the configuration this application already has --
+  `:rom_roots`, `:bundle_root`, `:core_root` -- plus `/root` itself, because
+  the writable partition is the thing a file manager on this device is for.
+  Nothing names `/`: that is a 69 MB read-only squashfs and there is nothing
+  a file manager could do to it. `:file_roots` overrides the list, which is
+  how the tests point it at a temporary directory.
+
+  ## Names are rejected, not repaired
+
+  `safe_name/1` refuses:
+
+    * `""`, `"."` and `".."` exactly
+    * anything containing `/`, `\\` or a null byte
+    * anything longer than 200 bytes, or not valid UTF-8
+
+  `Path.basename/1` would turn `"../../bundles"` into `"bundles"`, which is
+  safe and dishonest: it accepts a request that was trying to leave and leaves
+  nothing in the log saying so. `MayonnaiOS.Library` takes the same line for
+  the same reason, and this module deliberately reads the same way.
+
+  One rule of Library's is **not** copied: a leading dot is allowed here.
+  Library rejects dotfiles because an upload must not be able to land as one;
+  here `/root/.config/retroarch` is one of the directories most worth looking
+  at, and a file manager that cannot see the dotfiles on the disk is lying
+  about what is on the disk.
+
+  ## Symlinks are the honest caveat
+
+  A checked name cannot leave a root. A symlink can, and following symlinks is
+  not optional on this device: `bundles/retroarch/current` is one, and
+  everything in RetroArch's core directory is one. So:
+
+    * navigation and listing **follow** links, and say so -- an entry carries
+      its target, and a link whose target is gone is marked broken. That is
+      worth having rather than hiding: a dangling `.so` in the core directory
+      looks like an installed core to anything that only lists names.
+    * `delete/1` removes the **link**, never what it points at.
+    * `copy/3` refuses a symlink source outright. Copying *through* a link is
+      the one way a read could leave the roots, and the file it points at can
+      be copied from where it actually lives.
+
+  So the guarantee is: no name can leave a root, and no destructive operation
+  acts on anything but the entry named. It is not "nothing outside /root can
+  be read", because a symlink already in the tree can be followed, and saying
+  otherwise would be a claim this code does not enforce.
+
+  ## Every write is fsynced
+
+  There is no `sync` on this device -- not the binary, not a busybox applet.
+  A file written and not fsynced survives exactly as long as the page cache,
+  and this handheld is switched off by pulling its power. That has already
+  cost a set of ROMs once.
+
+  So `copy/3` streams into a `.part` file beside the destination, calls
+  `:file.sync/1` on the handle **while it is still open**, and only then
+  renames it into place. Same directory, so the rename is atomic: an
+  interrupted copy leaves a `.part`, never a half-written ROM that looks
+  complete and fails three hours into a game. This is the shape
+  `MayonnaiOS.Library.receive_upload/4` already uses for uploads.
+
+  What cannot be done from here, stated rather than glossed: the *directory
+  entry* is not fsynced, because OTP cannot open a directory to sync it. A
+  rename or a delete is therefore durable only once the filesystem gets round
+  to it. `move/3` within one filesystem is a rename and so has nothing to
+  sync; across filesystems it copies -- and that copy is fsynced -- and then
+  removes the source.
+
+  ## What is deliberately not implemented
+
+  `copy/3` takes a regular file and no directories, and `move/3` will move a
+  directory only when the destination is on the same filesystem and the kernel
+  can do it as a rename. A recursive copy of a directory on a 13 GB card is a
+  long-running job that needs progress, cancellation and a free-space check
+  per file; refusing it with `:eisdir` and `:exdev` is honest, whereas
+  starting one inside the process that also reads the D-pad would freeze the
+  UI for minutes.
+
+  Nothing here overwrites. A destination that exists is `{:error, :eexist}`,
+  because the only interesting file on this device is a save or a ROM and a
+  file manager that silently replaces one is a file manager that eats them.
+  """
+
+  require Logger
+
+  alias MayonnaiOS.{Bundle, Cores, Library}
+
+  @typedoc "A root key plus the checked names below it. The only way to name a file."
+  @type location :: %{root: String.t(), path: [String.t()]}
+
+  @typedoc "A configured root: where browsing can start."
+  @type place :: %{key: String.t(), path: String.t(), note: String.t()}
+
+  @type entry :: %{
+          name: String.t(),
+          type: :directory | :regular | :missing | atom(),
+          size: non_neg_integer() | nil,
+          link: String.t() | nil,
+          broken?: boolean()
+        }
+
+  @type reason ::
+          :unknown_root
+          | :bad_name
+          | :is_root
+          | :eexist
+          | :eisdir
+          | :enotdir
+          | :enoent
+          | :exdev
+          | :enospc
+          | :not_empty
+          | :is_symlink
+          | :same_path
+          | atom()
+
+  # 64 KB per read. Big enough that a 200 MB ROM is not four thousand
+  # syscalls, small enough that eight of them in flight is nothing on a board
+  # with 1 GB of RAM.
+  @chunk 65_536
+
+  @max_name 200
+
+  # -- roots ------------------------------------------------------------------
+
+  @doc """
+  The roots browsing can start from, in the order they are offered.
+
+  Derived from the configuration that already exists rather than written out
+  again here: the ROM roots are `MayonnaiOS.Library.roots/0`, so the file
+  manager and the library can never disagree about where games live, and a
+  second card added to `:rom_roots` appears here with no code change.
+  """
+  @spec places() :: [place()]
+  def places do
+    case Application.get_env(:mayonnaios, :file_roots) do
+      [_ | _] = configured -> Enum.map(configured, &normalize_place/1)
+      _ -> default_places()
+    end
+  end
+
+  defp default_places do
+    roms =
+      Library.roots()
+      |> Enum.with_index(1)
+      |> Enum.map(fn {path, index} ->
+        %{key: "roms-#{index}", path: path, note: rom_note(index)}
+      end)
+
+    roms ++
+      [
+        %{key: "bundles", path: Bundle.root(), note: "installed bundles"},
+        %{key: "cores", path: Cores.root(), note: "installed cores"},
+        %{key: "root", path: "/root", note: "the writable partition"}
+      ]
+  end
+
+  # The first ROM root is the one uploads are written to; see Library.root/0.
+  # Saying which is which matters here, because this is the screen where
+  # someone decides where to put a file.
+  defp rom_note(1), do: "games, and where uploads land"
+  defp rom_note(_), do: "games on another card, read as one library"
+
+  defp normalize_place(place) when is_list(place), do: place |> Map.new() |> normalize_place()
+
+  defp normalize_place(%{key: key, path: path} = place) do
+    %{key: to_string(key), path: path, note: Map.get(place, :note, "")}
+  end
+
+  @doc "The configured root with this key, or `nil`."
+  @spec place(String.t()) :: place() | nil
+  def place(key), do: Enum.find(places(), &(&1.key == key))
+
+  # -- locations --------------------------------------------------------------
+
+  @doc """
+  A location inside a root, with every name checked.
+
+  The only constructor. An unknown root is an error rather than a path, and so
+  is a name that could mean anything but itself.
+  """
+  @spec at(String.t(), [String.t()]) :: {:ok, location()} | {:error, reason()}
+  def at(root_key, names \\ []) do
+    with {:ok, _place} <- fetch_place(root_key),
+         {:ok, names} <- safe_names(names) do
+      {:ok, %{root: root_key, path: names}}
+    end
+  end
+
+  @doc """
+  One level down, by name.
+  """
+  @spec descend(location(), String.t()) :: {:ok, location()} | {:error, reason()}
+  def descend(%{root: root, path: names}, name) do
+    with {:ok, name} <- safe_name(name), do: at(root, names ++ [name])
+  end
+
+  @doc """
+  One level up. At the top of a root, `nil` -- which is the list of roots.
+  """
+  @spec ascend(location()) :: location() | nil
+  def ascend(%{path: []}), do: nil
+  def ascend(%{path: names} = location), do: %{location | path: Enum.drop(names, -1)}
+
+  @doc """
+  The absolute path of a location.
+
+  Re-checks every name rather than trusting the struct it was handed. Cheap,
+  and it means a location assembled by hand somewhere else cannot become a
+  path here.
+  """
+  @spec resolve(location()) :: {:ok, String.t()} | {:error, reason()}
+  def resolve(%{root: root, path: names}) do
+    with {:ok, place} <- fetch_place(root),
+         {:ok, names} <- safe_names(names) do
+      {:ok, Path.join([place.path | names])}
+    end
+  end
+
+  def resolve(_other), do: {:error, :bad_name}
+
+  @doc """
+  The name of the thing a location points at, or `:is_root` for a root.
+
+  An operation on a root is refused here rather than deeper down: `delete/1`
+  on `%{root: "root", path: []}` would be `rm -rf /root`.
+  """
+  @spec basename(location()) :: {:ok, String.t()} | {:error, :is_root}
+  def basename(%{path: []}), do: {:error, :is_root}
+  def basename(%{path: names}), do: {:ok, List.last(names)}
+
+  @doc """
+  Whether a name may be used at all. Rejects; does not repair.
+  """
+  @spec safe_name(term()) :: {:ok, String.t()} | {:error, :bad_name}
+  def safe_name(name) when is_binary(name) do
+    cond do
+      name in ["", ".", ".."] -> {:error, :bad_name}
+      String.contains?(name, ["/", "\\", <<0>>]) -> {:error, :bad_name}
+      byte_size(name) > @max_name -> {:error, :bad_name}
+      not String.valid?(name) -> {:error, :bad_name}
+      true -> {:ok, name}
+    end
+  end
+
+  def safe_name(_name), do: {:error, :bad_name}
+
+  defp safe_names(names) when is_list(names) do
+    Enum.reduce_while(names, {:ok, []}, fn name, {:ok, acc} ->
+      case safe_name(name) do
+        {:ok, name} -> {:cont, {:ok, acc ++ [name]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp safe_names(_names), do: {:error, :bad_name}
+
+  defp fetch_place(key) do
+    case place(key) do
+      nil -> {:error, :unknown_root}
+      place -> {:ok, place}
+    end
+  end
+
+  # -- reading ----------------------------------------------------------------
+
+  @doc """
+  What is in a directory: directories first, then names, case-insensitively.
+
+  Directories first because they are the thing being navigated and the panel
+  shows twelve rows at a time. Dotfiles are included -- see the moduledoc.
+  """
+  @spec list(location()) :: {:ok, [entry()]} | {:error, reason()}
+  def list(location) do
+    with {:ok, dir} <- resolve(location),
+         {:ok, names} <- File.ls(dir) do
+      entries =
+        names
+        |> Enum.map(&describe(dir, &1))
+        |> Enum.sort_by(&{&1.type != :directory, String.downcase(&1.name)})
+
+      {:ok, entries}
+    end
+  end
+
+  @doc """
+  One entry, without listing its parent.
+  """
+  @spec stat(location()) :: {:ok, entry()} | {:error, reason()}
+  def stat(location) do
+    with {:ok, path} <- resolve(location),
+         {:ok, name} <- basename(location) do
+      case File.lstat(path) do
+        {:ok, _info} -> {:ok, describe(Path.dirname(path), name)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  # lstat for what the entry *is*, stat for what it leads to. Both, because on
+  # this device the difference is the whole story in two directories: the core
+  # directory is nothing but symlinks, and `bundles/retroarch/current` is one.
+  defp describe(dir, name) do
+    path = Path.join(dir, name)
+
+    link =
+      case :file.read_link(path) do
+        {:ok, target} -> List.to_string(target)
+        _error -> nil
+      end
+
+    {type, size} =
+      case File.stat(path) do
+        {:ok, %File.Stat{type: :regular, size: size}} -> {:regular, size}
+        {:ok, %File.Stat{type: type}} -> {type, nil}
+        {:error, _reason} -> {:missing, nil}
+      end
+
+    %{name: name, type: type, size: size, link: link, broken?: type == :missing}
+  end
+
+  @doc """
+  Free space on the filesystem holding a location, or `nil`.
+
+  Per location, not per device, and that is the point. The roots span more
+  than one filesystem -- the writable f2fs partition and, when the card is in,
+  the exFAT games card -- so one global number would be wrong for whichever
+  one it was not measuring. `/` is a read-only squashfs at 100% full and is
+  not reachable from here at all, which is the number it would be most
+  misleading to show.
+
+  Read from `df`, because OTP has no statvfs and busybox's `df` is in the
+  image. `nil` rather than a guess when the output does not parse.
+  """
+  @spec space(location() | String.t()) ::
+          %{device: String.t(), total: non_neg_integer(), free: non_neg_integer()} | nil
+  def space(%{} = location) do
+    case resolve(location) do
+      {:ok, path} -> space(path)
+      {:error, _reason} -> nil
+    end
+  end
+
+  def space(path) when is_binary(path) do
+    {out, 0} = System.cmd("df", ["-k", path], stderr_to_stdout: true)
+
+    # Positional from the front, matching the parse that is already proven
+    # against this image's busybox df. Anything unexpected falls into the
+    # rescue below and becomes nil.
+    [device, total, used, free | _rest] =
+      out
+      |> String.split("\n", trim: true)
+      |> List.last()
+      |> String.split()
+
+    %{
+      device: device,
+      total: kb(total),
+      used: kb(used),
+      free: kb(free)
+    }
+  rescue
+    _error -> nil
+  end
+
+  defp kb(blocks), do: String.to_integer(blocks) * 1024
+
+  # -- writing ----------------------------------------------------------------
+
+  @doc """
+  Copy a regular file into a directory, keeping its name.
+
+  Fsynced before the rename; see the moduledoc. Refuses a symlink source, a
+  directory, an existing destination, and a destination filesystem with less
+  free space than the file needs.
+
+  `:sync` is the one seam this module has for the tests. Durability cannot be
+  asserted by looking at a file afterwards -- an unsynced file is there too,
+  right up until the power goes -- so the test passes a function that records
+  that the sync happened, and that it happened on a handle that was still
+  open.
+  """
+  @spec copy(location(), location(), keyword()) :: :ok | {:error, reason()}
+  def copy(source, dest_dir, opts \\ []) do
+    with {:ok, from} <- resolve(source),
+         {:ok, name} <- basename(source),
+         {:ok, dir} <- resolve(dest_dir),
+         :ok <- require_no_link(from),
+         {:ok, size} <- require_regular(from),
+         :ok <- require_directory(dir),
+         to = Path.join(dir, name),
+         :ok <- require_different(from, to),
+         :ok <- require_absent(to),
+         :ok <- require_room(dir, size) do
+      case stream_copy(from, to, opts) do
+        :ok ->
+          Logger.info("[files] copied #{from} -> #{to} (#{size} bytes)")
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("[files] copy #{from} -> #{to} failed: #{inspect(reason)}")
+          {:error, reason}
+      end
+    end
+  end
+
+  @doc """
+  Move an entry into a directory, keeping its name.
+
+  A rename when the destination is on the same filesystem, which is the usual
+  case and is atomic and instant whatever the file's size. Across filesystems
+  the kernel answers `:exdev` and this falls back to a copy -- fsynced -- and
+  then removes the source, which is the only way a ROM gets from the internal
+  card onto the games card.
+
+  A directory can be moved only by rename. Across filesystems it is refused,
+  because that is a recursive copy; see the moduledoc.
+
+  `:rename` is a test seam, and it exists for one reason: a test cannot mount
+  a second filesystem, so there is no other way to reach the `:exdev` path --
+  the path that has to fsync -- from the host.
+  """
+  @spec move(location(), location(), keyword()) :: :ok | {:error, reason()}
+  def move(source, dest_dir, opts \\ []) do
+    with {:ok, from} <- resolve(source),
+         {:ok, name} <- basename(source),
+         {:ok, dir} <- resolve(dest_dir),
+         :ok <- require_exists(from),
+         :ok <- require_directory(dir),
+         to = Path.join(dir, name),
+         :ok <- require_different(from, to),
+         :ok <- require_absent(to) do
+      rename = Keyword.get(opts, :rename, &File.rename/2)
+
+      case rename.(from, to) do
+        :ok ->
+          Logger.info("[files] moved #{from} -> #{to}")
+          :ok
+
+        {:error, :exdev} ->
+          across(source, from, to, opts)
+
+        {:error, reason} ->
+          Logger.warning("[files] move #{from} -> #{to} failed: #{inspect(reason)}")
+          {:error, reason}
+      end
+    end
+  end
+
+  # Same filesystem was not on offer, so this is a copy and a delete. The copy
+  # is the fsynced one; the source is removed only after the destination is
+  # renamed into place, so an interruption leaves two files rather than none.
+  defp across(source, from, to, opts) do
+    with :ok <- require_no_link(from),
+         {:ok, size} <- require_regular(from),
+         :ok <- require_room(Path.dirname(to), size),
+         :ok <- stream_copy(from, to, opts),
+         :ok <- delete(source) do
+      Logger.info("[files] moved #{from} -> #{to} across filesystems (#{size} bytes)")
+      :ok
+    else
+      {:error, :eisdir} ->
+        {:error, :exdev}
+
+      {:error, reason} ->
+        Logger.warning("[files] move #{from} -> #{to} failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Rename an entry in place.
+
+  The new name goes through `safe_name/1` like every other name, so a rename
+  cannot be a move and cannot be a traversal: it stays in the directory it was
+  already in.
+  """
+  @spec rename(location(), String.t(), keyword()) :: :ok | {:error, reason()}
+  def rename(source, new_name, opts \\ []) do
+    with {:ok, _old} <- basename(source),
+         {:ok, new_name} <- safe_name(new_name),
+         {:ok, from} <- resolve(source),
+         parent = ascend(source),
+         {:ok, dir} <- resolve(parent),
+         to = Path.join(dir, new_name),
+         :ok <- require_exists(from),
+         :ok <- require_different(from, to),
+         :ok <- require_absent(to) do
+      rename = Keyword.get(opts, :rename, &File.rename/2)
+
+      case rename.(from, to) do
+        :ok ->
+          Logger.info("[files] renamed #{from} -> #{new_name}")
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("[files] rename #{from} failed: #{inspect(reason)}")
+          {:error, reason}
+      end
+    end
+  end
+
+  @doc """
+  Delete one entry.
+
+  A regular file, a symlink -- the link itself, never its target -- or an
+  empty directory. A directory with anything in it is `{:error, :not_empty}`:
+  a recursive delete driven by a D-pad, on the partition that holds the
+  bundles and the saves, is not a thing this device needs.
+
+  There is no confirmation here on purpose. The confirmation belongs to the
+  screen that has the name on it; a module that asked twice would be asking
+  the caller, which is not who is about to lose a file.
+  """
+  @spec delete(location()) :: :ok | {:error, reason()}
+  def delete(location) do
+    with {:ok, path} <- resolve(location),
+         {:ok, _name} <- basename(location) do
+      case File.lstat(path) do
+        {:ok, %File.Stat{type: :symlink}} -> remove(path, &File.rm/1, "link")
+        {:ok, %File.Stat{type: :regular}} -> remove(path, &File.rm/1, "file")
+        {:ok, %File.Stat{type: :directory}} -> remove(path, &rmdir/1, "directory")
+        {:ok, %File.Stat{type: type}} -> {:error, {:unsupported, type}}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp remove(path, remover, what) do
+    case remover.(path) do
+      :ok ->
+        Logger.info("[files] deleted #{what} #{path}")
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("[files] delete #{path} failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  # Linux says :enotempty and some systems say :eexist. One name for it, so
+  # the panel can say "not empty" without knowing which kernel it is on.
+  defp rmdir(path) do
+    case File.rmdir(path) do
+      {:error, reason} when reason in [:eexist, :enotempty] -> {:error, :not_empty}
+      other -> other
+    end
+  end
+
+  # -- the copy itself --------------------------------------------------------
+
+  defp stream_copy(from, to, opts) do
+    sync = Keyword.get(opts, :sync, &:file.sync/1)
+    part = to <> ".part"
+    File.rm(part)
+
+    case File.open(from, [:read, :binary, :raw]) do
+      {:ok, src} ->
+        result = write_part(src, part, sync)
+        File.close(src)
+        finish(result, part, to)
+
+      {:error, reason} ->
+        {:error, {:open, reason}}
+    end
+  end
+
+  defp write_part(src, part, sync) do
+    case File.open(part, [:write, :binary, :raw]) do
+      {:ok, dst} ->
+        result = pump(src, dst)
+
+        # The sync goes here, before the close and only on a complete copy:
+        # syncing a handle that has already been closed is not a sync, and
+        # syncing a truncated file makes the truncation durable.
+        result = if result == :ok, do: sync.(dst), else: result
+
+        File.close(dst)
+        result
+
+      {:error, reason} ->
+        {:error, {:open, reason}}
+    end
+  end
+
+  defp pump(src, dst) do
+    case :file.read(src, @chunk) do
+      {:ok, data} ->
+        # :file.write, not IO.binwrite: the handle is :raw, so there is no IO
+        # server behind it for the IO functions to talk to.
+        case :file.write(dst, data) do
+          :ok -> pump(src, dst)
+          {:error, reason} -> {:error, {:write, reason}}
+        end
+
+      :eof ->
+        :ok
+
+      {:error, reason} ->
+        {:error, {:read, reason}}
+    end
+  end
+
+  defp finish(:ok, part, to) do
+    case File.rename(part, to) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        File.rm(part)
+        {:error, {:rename, reason}}
+    end
+  end
+
+  defp finish({:error, reason}, part, _to) do
+    File.rm(part)
+    {:error, reason}
+  end
+
+  # -- checks -----------------------------------------------------------------
+
+  defp require_regular(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :regular, size: size}} -> {:ok, size}
+      {:ok, %File.Stat{type: :directory}} -> {:error, :eisdir}
+      {:ok, %File.Stat{type: :symlink}} -> {:error, :is_symlink}
+      {:ok, %File.Stat{}} -> {:error, :enotsup}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp require_no_link(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :symlink}} -> {:error, :is_symlink}
+      {:ok, %File.Stat{}} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp require_exists(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{}} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp require_directory(path) do
+    if File.dir?(path), do: :ok, else: {:error, :enotdir}
+  end
+
+  defp require_absent(path) do
+    # lstat, so a broken symlink counts as present: renaming onto one would
+    # remove it, and that is a delete nobody asked for.
+    case File.lstat(path) do
+      {:ok, %File.Stat{}} -> {:error, :eexist}
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp require_different(from, to) do
+    if from == to, do: {:error, :same_path}, else: :ok
+  end
+
+  # Checked before the first byte, not discovered after 4 GB. Skipped when df
+  # says nothing useful, because refusing every copy on a board where df
+  # surprised us would be worse than the risk of running out.
+  defp require_room(dir, size) do
+    case space(dir) do
+      %{free: free} when free < size -> {:error, :enospc}
+      _other -> :ok
+    end
+  end
+end

--- a/lib/mayonnaios/library.ex
+++ b/lib/mayonnaios/library.ex
@@ -340,19 +340,17 @@ defmodule MayonnaiOS.Library do
 
   Read from `df`, because there is no statvfs in OTP and busybox's df is in
   the image. Returns `nil` rather than guessing if the output does not parse.
+
+  The `df` call itself is `MayonnaiOS.Files.space/1`, which the file manager
+  needs per-location -- the roots span more than one filesystem. Two parses of
+  the same command's output would be one parse too many, and this is the older
+  of the two callers rather than the more general one.
   """
   def free_bytes do
-    {out, 0} = System.cmd("df", ["-k", root()], stderr_to_stdout: true)
-
-    out
-    |> String.split("\n", trim: true)
-    |> List.last()
-    |> String.split()
-    |> Enum.at(3)
-    |> String.to_integer()
-    |> Kernel.*(1024)
-  rescue
-    _ -> nil
+    case MayonnaiOS.Files.space(root()) do
+      %{free: free} -> free
+      _other -> nil
+    end
   end
 
   defp fetch_system(key) do

--- a/lib/mayonnaios/scene/file_manager.ex
+++ b/lib/mayonnaios/scene/file_manager.ex
@@ -1,0 +1,564 @@
+defmodule MayonnaiOS.Scene.FileManager do
+  @moduledoc """
+  What the panel shows while the file manager has the buttons.
+
+  It draws `MayonnaiOS.FileManager.snapshot/0` and nothing else: no cursor of
+  its own, no listing of its own, no path of its own. `set_root/3` terminates
+  a scene and starts a new one on every repaint the launcher does, so anything
+  remembered here would be lost at the first opportunity -- the same reason
+  `MayonnaiOS.Scene.Home` takes its cursor as a start argument.
+
+  It is told when to redraw rather than polling for it. `FileManager.watch/1`
+  registers this process, and a snapshot arrives as `{:file_manager, snapshot}`
+  when a button has changed something. A poll fast enough to feel like a button
+  press would be a `GenServer.call` every few frames for the whole time the app
+  is open, for a screen that changes only when someone presses something.
+
+  ## The top strip is left alone
+
+  Every app is going to get a shared top bar -- battery, WiFi, clock, at the
+  top right. It is not built here and it is not faked here; what this scene
+  does is not paint above `@status_bar`, so that when the bar arrives this
+  screen does not have to be re-laid-out around it.
+
+  ## Why the footer says what the buttons do, on every screen
+
+  Y means a different thing in each view -- the actions sheet while browsing,
+  the delete on a confirmation, remove-a-character in the rename editor -- and
+  a handheld has no tooltips and no manual. So the bottom line of every view
+  spells out A, B and Y for that view. It is the cheapest form of the thing
+  this whole project keeps relearning: a control nobody can discover is a
+  control nobody has.
+  """
+
+  use Scenic.Scene
+
+  alias MayonnaiOS.FileManager
+  alias Scenic.Graph
+
+  import Scenic.Primitives
+
+  @width 640
+  @height 480
+
+  # Same palette as Scene.Home and Scene.Diagnostics, so the screens read as
+  # one device rather than three programs sharing a panel.
+  @bg {12, 14, 22}
+  @title {235, 238, 245}
+  @head {90, 170, 255}
+  @label {150, 165, 195}
+  @pass {120, 220, 150}
+  @fail {245, 110, 120}
+  @wait {235, 190, 90}
+  @dim {110, 125, 155}
+  @row_bg {26, 34, 52}
+
+  # Reserved for the shared top bar that every app will get: battery, WiFi,
+  # clock. Nothing is drawn above this line, which is why this screen starts
+  # its own title lower than `Scene.Home` does. Text is positioned by its
+  # baseline, so the first baseline is far enough below the line that the
+  # ascenders clear it too.
+  @status_bar 30
+
+  @title_y 50
+  @path_y 74
+  @space_y 90
+  @rule_y 98
+
+  @top 104
+  @pitch 26
+  @visible 11
+
+  # Two lines per row in the list of places -- the path and what it is for --
+  # so the row that says where uploads land says it rather than implying it.
+  @place_pitch 44
+  @places_visible 6
+
+  @message_y 412
+  @footer_rule 430
+  @footer_y 452
+
+  # A name longer than this is cut, with the tail kept: ROM filenames differ
+  # at the end far more often than at the start.
+  @name_chars 46
+
+  # The rename editor draws one character per cell so the caret can sit under
+  # exactly one of them. A proportional font gives no way to place a caret
+  # honestly; a grid does.
+  @cell 15
+  @cells 36
+
+  @impl Scenic.Scene
+  def init(scene, param, _opts) do
+    error = if is_map(param), do: Map.get(param, :error), else: nil
+
+    {:ok, scene |> assign(error: error) |> show(watch())}
+  end
+
+  @impl GenServer
+  def handle_info({:file_manager, snapshot}, scene), do: {:noreply, show(scene, snapshot)}
+  def handle_info(_message, scene), do: {:noreply, scene}
+
+  # The app not running is a state to render rather than crash on: it is what
+  # the launcher shows when starting failed, and the reason is then the only
+  # useful thing on the panel.
+  defp watch do
+    FileManager.watch(self())
+  rescue
+    _error -> :stopped
+  catch
+    :exit, _reason -> :stopped
+  end
+
+  defp show(scene, snapshot), do: push_graph(scene, graph(snapshot, scene.assigns[:error]))
+
+  @doc """
+  The height of the strip this scene leaves for the shared top bar.
+
+  Public so a test can assert that nothing is drawn above it -- which is the
+  only way to keep that true through later edits -- and so the status bar,
+  when someone builds it, has a number to fit into rather than a screenshot to
+  measure.
+  """
+  @spec status_bar() :: pos_integer()
+  def status_bar, do: @status_bar
+
+  @doc """
+  Build the graph for a snapshot.
+
+  Public because it is the tested surface: no viewport, no driver and no
+  framebuffer, so a host test can assert what the panel says for an empty
+  directory, a windowed listing, a confirmation and a rename -- the states
+  that would otherwise only be checked by looking at the device.
+  """
+  @spec graph(map() | :stopped, term()) :: Scenic.Graph.t()
+  def graph(snapshot, error \\ nil)
+
+  def graph(:stopped, error) do
+    base("Files")
+    |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, 120})
+    |> text(reason(error), font_size: 16, fill: {:color, @label}, translate: {20, 150})
+    |> footer("Menu goes back.")
+  end
+
+  def graph(%{view: :places} = snapshot, _error) do
+    base("Files")
+    |> text("Where to look", font_size: 18, fill: {:color, @title}, translate: {20, @path_y})
+    |> text("the roots this app can open; nothing else is reachable",
+      font_size: 12,
+      fill: {:color, @dim},
+      translate: {20, @space_y}
+    )
+    |> rule()
+    |> places(snapshot)
+    |> message(snapshot)
+    |> footer("A opens. Menu leaves.")
+  end
+
+  def graph(%{view: :browse} = snapshot, _error) do
+    base("Files")
+    |> header(snapshot)
+    |> listing(snapshot)
+    |> message(snapshot)
+    |> footer(browse_hint(snapshot))
+  end
+
+  def graph(%{view: :actions} = snapshot, _error) do
+    base("Files")
+    |> text(selected_name(snapshot),
+      font_size: 18,
+      fill: {:color, @title},
+      translate: {20, @path_y}
+    )
+    |> text(detail(snapshot), font_size: 12, fill: {:color, @dim}, translate: {20, @space_y})
+    |> rule()
+    |> rows(snapshot.actions, snapshot.action_cursor, fn graph, action, y, _selected? ->
+      text(graph, action.label, fill: {:color, @title}, translate: {36, y + 16}, font_size: 16)
+    end)
+    |> footer("A does it. B goes back.")
+  end
+
+  def graph(%{view: :confirm, pending: %{entry: entry}} = snapshot, _error) do
+    base("Delete")
+    |> text("Delete this?", font_size: 26, fill: {:color, @fail}, translate: {20, 70})
+    # The tail of the path, not the head: which directory and which file is
+    # about to go is the part being confirmed, and "/root/mnt/games/ROMS/…"
+    # would be the half that is the same for everything.
+    |> text(truncate_left(path_of(snapshot, entry.name), 60),
+      font_size: 16,
+      fill: {:color, @title},
+      translate: {20, 106}
+    )
+    |> text(what(entry), font_size: 14, fill: {:color, @label}, translate: {20, 130})
+    |> text("There is no undo, and no trash to fish it out of.",
+      font_size: 14,
+      fill: {:color, @wait},
+      translate: {20, 176}
+    )
+    |> text("This device is switched off by pulling its power.",
+      font_size: 14,
+      fill: {:color, @dim},
+      translate: {20, 198}
+    )
+    |> text("Y deletes it.", font_size: 20, fill: {:color, @fail}, translate: {20, 250})
+    |> text("A, B or any direction cancels -- on purpose: the button that",
+      font_size: 14,
+      fill: {:color, @label},
+      translate: {20, 280}
+    )
+    |> text("got you here is not the button that does it.",
+      font_size: 14,
+      fill: {:color, @label},
+      translate: {20, 300}
+    )
+    |> footer("Y deletes. Anything else cancels.")
+  end
+
+  # A confirmation with nothing pending cannot happen from the app, but the
+  # scene is a separate process reading a snapshot and must not crash on one.
+  def graph(%{view: :confirm} = snapshot, error), do: graph(%{snapshot | view: :browse}, error)
+
+  def graph(%{view: :rename, rename: %{chars: chars, caret: caret}} = snapshot, _error) do
+    base("Rename")
+    |> text(truncate(snapshot.rename.name, 60),
+      font_size: 14,
+      fill: {:color, @dim},
+      translate: {20, @path_y}
+    )
+    |> rule()
+    |> cells(chars, caret)
+    |> text("Left and right move. Up and down change the character.",
+      font_size: 14,
+      fill: {:color, @label},
+      translate: {20, 220}
+    )
+    |> text("Y removes it. A saves the name. B cancels.",
+      font_size: 14,
+      fill: {:color, @label},
+      translate: {20, 242}
+    )
+    |> message(snapshot)
+    |> footer("A saves. B cancels. Y removes a character.")
+  end
+
+  # A view this scene has no clause for. The app has five and none of them get
+  # here, but the scene is a separate process rendering a snapshot it did not
+  # produce, and saying so on the panel beats either crashing or drawing the
+  # wrong screen convincingly.
+  def graph(%{view: view}, _error) do
+    base("Files")
+    |> text("Nothing to draw for #{inspect(view)}.",
+      font_size: 18,
+      fill: {:color, @wait},
+      translate: {20, 120}
+    )
+    |> footer("Menu goes back.")
+  end
+
+  # -- pieces -----------------------------------------------------------------
+
+  defp base(title) do
+    Graph.build(font: :roboto, font_size: 16)
+    |> rect({@width, @height}, fill: {:color, @bg})
+    # The title sits below the reserved strip, not in it.
+    |> text(title, font_size: 20, fill: {:color, @title}, translate: {20, @title_y})
+  end
+
+  defp rule(graph),
+    do: rect(graph, {@width - 40, 2}, fill: {:color, @head}, translate: {20, @rule_y})
+
+  defp footer(graph, hint) do
+    graph
+    |> rect({@width - 40, 1}, fill: {:color, @dim}, translate: {20, @footer_rule})
+    |> text(hint, font_size: 14, fill: {:color, @dim}, translate: {20, @footer_y})
+  end
+
+  defp header(graph, snapshot) do
+    graph
+    |> text(truncate_left(snapshot.dir || "", 58),
+      font_size: 18,
+      fill: {:color, @title},
+      translate: {20, @path_y}
+    )
+    |> text(space_line(snapshot), font_size: 12, fill: {:color, @dim}, translate: {20, @space_y})
+    |> rule()
+    |> held(snapshot)
+  end
+
+  # Free space for the filesystem this directory is on, not for the device.
+  # The roots span more than one -- the writable partition and, with the card
+  # in, the games card -- and `/` is a full read-only squashfs that is not
+  # reachable from here at all.
+  defp space_line(%{space: %{device: device, free: free, total: total}}) do
+    "#{device} -- #{size(free)} free of #{size(total)}"
+  end
+
+  defp space_line(_snapshot), do: "free space unknown: df said nothing this could parse"
+
+  # What is on the clipboard, top right, because a held file that is not shown
+  # is a file someone pastes into the wrong place a minute later.
+  defp held(graph, %{clipboard: nil}), do: graph
+
+  defp held(graph, %{clipboard: %{mode: mode, name: name}}) do
+    text(graph, "holding: #{truncate(name, 24)} (#{mode})",
+      font_size: 12,
+      fill: {:color, @wait},
+      translate: {330, @space_y}
+    )
+  end
+
+  defp places(graph, %{places: places, place_cursor: cursor}) do
+    window = window(places, cursor, @places_visible)
+
+    {graph, _y} =
+      Enum.reduce(window.rows, {graph, @top}, fn {place, index}, {acc, y} ->
+        selected? = index == window.cursor
+
+        acc =
+          acc
+          |> highlight(y, selected?, @place_pitch)
+          |> text(place.path,
+            font_size: 18,
+            fill: {:color, if(selected?, do: @title, else: @label)},
+            translate: {36, y + 18}
+          )
+          |> text(place.note, font_size: 12, fill: {:color, @dim}, translate: {36, y + 34})
+
+        {acc, y + @place_pitch}
+      end)
+
+    graph
+  end
+
+  defp listing(graph, %{entries: [], readable?: false} = snapshot) do
+    text(graph, "This directory cannot be read: #{reason_text(snapshot)}",
+      font_size: 16,
+      fill: {:color, @wait},
+      translate: {20, @top + 20}
+    )
+  end
+
+  defp listing(graph, %{entries: []}) do
+    text(graph, "Empty.", font_size: 16, fill: {:color, @dim}, translate: {20, @top + 20})
+  end
+
+  defp listing(graph, %{entries: entries, cursor: cursor}) do
+    graph
+    |> rows(entries, cursor, &entry_row/4)
+    |> position(entries, cursor)
+  end
+
+  defp entry_row(graph, entry, y, selected?) do
+    graph
+    |> text(name_of(entry),
+      font_size: 16,
+      fill: {:color, name_colour(entry, selected?)},
+      translate: {36, y + 17}
+    )
+    |> text(right_of(entry),
+      font_size: 13,
+      fill: {:color, right_colour(entry)},
+      translate: {466, y + 17}
+    )
+  end
+
+  defp name_of(%{type: :directory, name: name}), do: truncate(name, @name_chars) <> "/"
+  defp name_of(%{name: name}), do: truncate(name, @name_chars)
+
+  defp name_colour(%{broken?: true}, _selected?), do: @fail
+  defp name_colour(_entry, true), do: @title
+  defp name_colour(%{type: :directory}, false), do: @head
+  defp name_colour(_entry, false), do: @label
+
+  # A symlink says so, because in two directories on this device -- the core
+  # directory and `bundles/retroarch/current` -- everything is one, and a
+  # listing that hides that makes a dangling core look like an installed one.
+  defp right_of(%{broken?: true}), do: "broken link"
+  defp right_of(%{link: link}) when is_binary(link), do: "link"
+  defp right_of(%{type: :directory}), do: "folder"
+  defp right_of(%{type: :regular, size: size}), do: size(size)
+  defp right_of(%{type: type}), do: to_string(type)
+
+  defp right_colour(%{broken?: true}), do: @fail
+  defp right_colour(%{link: link}) when is_binary(link), do: @wait
+  defp right_colour(_entry), do: @dim
+
+  # A shared row renderer: one filled rect plus a 4 px accent bar for the
+  # selection, which is what stays visible on this panel in daylight.
+  defp rows(graph, items, cursor, render) do
+    window = window(items, cursor, @visible)
+
+    {graph, _y} =
+      Enum.reduce(window.rows, {graph, @top}, fn {item, index}, {acc, y} ->
+        selected? = index == window.cursor
+        {render.(highlight(acc, y, selected?, @pitch), item, y, selected?), y + @pitch}
+      end)
+
+    graph
+  end
+
+  defp highlight(graph, _y, false, _pitch), do: graph
+
+  defp highlight(graph, y, true, pitch) do
+    graph
+    |> rect({@width - 40, pitch - 4}, fill: {:color, @row_bg}, translate: {20, y})
+    |> rect({4, pitch - 4}, fill: {:color, @head}, translate: {20, y})
+  end
+
+  # Window the list when it outgrows the panel, keeping the cursor on screen.
+  # Without this the hundredth ROM in a directory would be selected somewhere
+  # nobody can see, and nothing would look wrong.
+  defp window(items, cursor, visible) do
+    count = length(items)
+    cursor = if count == 0, do: 0, else: min(max(cursor, 0), count - 1)
+    start = min(max(0, cursor - visible + 1), max(0, count - visible))
+
+    %{rows: items |> Enum.slice(start, visible) |> Enum.with_index(start), cursor: cursor}
+  end
+
+  defp position(graph, entries, cursor) do
+    count = length(entries)
+
+    if count <= @visible do
+      graph
+    else
+      text(graph, "#{min(cursor + 1, count)} of #{count}",
+        font_size: 12,
+        fill: {:color, @dim},
+        translate: {540, @space_y}
+      )
+    end
+  end
+
+  defp message(graph, %{message: nil}), do: graph
+
+  defp message(graph, %{message: {level, text}}) do
+    colour = if level == :error, do: @fail, else: @pass
+
+    text(graph, truncate(text, 70),
+      font_size: 14,
+      fill: {:color, colour},
+      translate: {20, @message_y}
+    )
+  end
+
+  defp message(graph, _snapshot), do: graph
+
+  defp reason_text(%{message: {_level, text}}), do: text
+  defp reason_text(_snapshot), do: "no reason given"
+
+  defp browse_hint(snapshot) do
+    case selected_entry(snapshot) do
+      %{type: :directory} -> "A opens. B goes up. Y for what can be done here."
+      nil -> "B goes up. Y for what can be done here."
+      _entry -> "A and Y both show what can be done with this file. B goes up."
+    end
+  end
+
+  defp selected_entry(%{entries: entries, cursor: cursor}), do: Enum.at(entries, cursor)
+  defp selected_entry(_snapshot), do: nil
+
+  defp selected_name(snapshot) do
+    case selected_entry(snapshot) do
+      nil -> "Actions"
+      entry -> truncate(entry.name, 52)
+    end
+  end
+
+  defp detail(snapshot) do
+    case selected_entry(snapshot) do
+      nil -> ""
+      %{link: link} when is_binary(link) -> "link to #{truncate_left(link, 60)}"
+      %{type: :regular, size: size} -> "#{size(size)} in #{truncate_left(snapshot.dir || "", 46)}"
+      %{type: type} -> "#{type} in #{truncate_left(snapshot.dir || "", 50)}"
+    end
+  end
+
+  defp what(%{type: :directory}), do: "A directory. Only an empty one can go."
+
+  defp what(%{link: link}) when is_binary(link),
+    do: "A link. Deleting it leaves #{truncate_left(link, 40)} alone."
+
+  defp what(%{type: :regular, size: size}), do: "A file of #{size(size)}."
+  defp what(%{type: type}), do: "A #{type}."
+
+  defp path_of(%{dir: dir}, name) when is_binary(dir), do: Path.join(dir, name)
+  defp path_of(_snapshot, name), do: name
+
+  # -- the rename grid --------------------------------------------------------
+
+  # One character per cell, and the caret is a box under a cell rather than a
+  # bar between two: with a proportional font there is no honest way to draw a
+  # bar in the right place, and a caret in the wrong place is worse than none.
+  defp cells(graph, chars, caret) do
+    count = length(chars)
+    # The append slot is a cell too, so a name can be grown at the end.
+    start = min(max(0, caret - @cells + 1), max(0, count + 1 - @cells))
+    y = 130
+
+    Enum.reduce(0..(@cells - 1), graph, fn column, acc ->
+      index = start + column
+      x = 24 + column * @cell
+
+      cond do
+        index > count ->
+          acc
+
+        index == count ->
+          acc
+          |> caret_box(x, y, index == caret)
+          |> text("+", font_size: 18, fill: {:color, @dim}, translate: {x + 3, y + 20})
+
+        true ->
+          acc
+          |> caret_box(x, y, index == caret)
+          |> text(Enum.at(chars, index),
+            font_size: 18,
+            fill: {:color, @title},
+            translate: {x + 3, y + 20}
+          )
+      end
+    end)
+  end
+
+  defp caret_box(graph, _x, _y, false), do: graph
+
+  defp caret_box(graph, x, y, true) do
+    rect(graph, {@cell, 28}, fill: {:color, @row_bg}, stroke: {1, @head}, translate: {x, y})
+  end
+
+  # -- words ------------------------------------------------------------------
+
+  # Powers of 1024 with df's one-letter units, because that is what the rest
+  # of this project's numbers are quoted in.
+  defp size(nil), do: ""
+  defp size(bytes) when bytes < 1024, do: "#{bytes} B"
+
+  defp size(bytes) do
+    {value, unit} =
+      cond do
+        bytes >= 1024 * 1024 * 1024 -> {bytes / (1024 * 1024 * 1024), "G"}
+        bytes >= 1024 * 1024 -> {bytes / (1024 * 1024), "M"}
+        true -> {bytes / 1024, "K"}
+      end
+
+    "#{:erlang.float_to_binary(value, decimals: 1)}#{unit}"
+  end
+
+  defp truncate(text, limit) do
+    if String.length(text) > limit, do: String.slice(text, 0, limit - 1) <> "…", else: text
+  end
+
+  # For paths, keep the end: which directory this is matters more than which
+  # of the two cards it is on, and the card is on the row above anyway.
+  defp truncate_left(text, limit) do
+    if String.length(text) > limit do
+      "…" <> String.slice(text, String.length(text) - limit + 1, limit)
+    else
+      text
+    end
+  end
+
+  defp reason(nil), do: "Start it from the menu."
+  defp reason(reason), do: FileManager.why(reason)
+end

--- a/test/file_manager_test.exs
+++ b/test/file_manager_test.exs
@@ -1,0 +1,641 @@
+defmodule MayonnaiOS.FileManagerTest do
+  # Not async: the app is a named process and the roots are application
+  # environment, both of which are one global.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.FileManager
+  alias MayonnaiOS.Scene.FileManager, as: Scene
+
+  # The buttons as InputEvent names them, not as the shell prints them. Spelled
+  # out here rather than reused from the module under test: if these ever
+  # disagree, the test is the thing that should notice, and a test that imports
+  # its expectations from the code cannot.
+  #
+  #   shell A = 305 BTN_EAST  -> :btn_b
+  #   shell B = 304 BTN_SOUTH -> :btn_a
+  #   shell Y = 307           -> :btn_x
+  @a :btn_b
+  @b :btn_a
+  @y :btn_x
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @left :btn_dpad_left
+  @right :btn_dpad_right
+  @menu :btn_mode
+
+  setup do
+    id = System.unique_integer([:positive])
+    root = Path.join(System.tmp_dir!(), "fm-#{id}")
+    card = Path.join(System.tmp_dir!(), "fm-card-#{id}")
+
+    File.mkdir_p!(Path.join(root, "snes"))
+    File.mkdir_p!(Path.join(root, "backup"))
+    File.mkdir_p!(card)
+    File.write!(Path.join([root, "snes", "chrono.sfc"]), "rom bytes")
+    File.write!(Path.join([root, "snes", "zelda.sfc"]), "zelda")
+    File.write!(Path.join(root, "readme.txt"), "hello")
+
+    Application.put_env(:mayonnaios, :file_roots, [
+      %{key: "internal", path: root, note: "games, and where uploads land"},
+      %{key: "card", path: card, note: "the other card"}
+    ])
+
+    {:ok, _pid} = FileManager.start()
+
+    on_exit(fn ->
+      FileManager.stop()
+      Application.delete_env(:mayonnaios, :file_roots)
+      File.rm_rf(root)
+      File.rm_rf(card)
+    end)
+
+    %{root: root, card: card}
+  end
+
+  # input/1 is a cast and snapshot/0 is a call, so the call is ordered behind
+  # the press and no test has to sleep.
+  defp press(key, value \\ 1) do
+    FileManager.input([{:ev_key, key, value}])
+    FileManager.snapshot()
+  end
+
+  defp names(%{entries: entries}), do: Enum.map(entries, & &1.name)
+  defp labels(%{actions: actions}), do: Enum.map(actions, & &1.label)
+
+  defp selected(%{entries: entries, cursor: cursor}) do
+    case Enum.at(entries, cursor) do
+      nil -> nil
+      entry -> entry.name
+    end
+  end
+
+  # B is the way back out of anything, so it is also the way back to a known
+  # place before the next step of a test.
+  defp home do
+    Enum.reduce_while(1..8, FileManager.snapshot(), fn _step, snapshot ->
+      if snapshot.view == :places, do: {:halt, snapshot}, else: {:cont, press(@b)}
+    end)
+  end
+
+  # Open a directory by name from the first root.
+  defp open(name) do
+    home()
+    press(@a)
+    to(name)
+    press(@a)
+  end
+
+  defp to(name) do
+    snapshot =
+      Enum.reduce_while(1..60, FileManager.snapshot(), fn _step, snapshot ->
+        if selected(snapshot) == name, do: {:halt, snapshot}, else: {:cont, press(@down)}
+      end)
+
+    assert selected(snapshot) == name, "never found #{name} in #{inspect(names(snapshot))}"
+    snapshot
+  end
+
+  describe "opening" do
+    test "starts on the list of places, which is the only entry point" do
+      snapshot = FileManager.snapshot()
+      assert snapshot.view == :places
+      assert Enum.map(snapshot.places, & &1.key) == ["internal", "card"]
+    end
+
+    test "A opens a place and lists it, directories first", %{root: root} do
+      snapshot = press(@a)
+
+      assert snapshot.view == :browse
+      assert snapshot.dir == root
+      assert names(snapshot) == ["backup", "snes", "readme.txt"]
+    end
+
+    test "the free space shown is for the filesystem the directory is on" do
+      snapshot = press(@a)
+      assert %{free: free, device: device} = snapshot.space
+      assert free > 0
+      assert is_binary(device)
+    end
+  end
+
+  describe "the D-pad" do
+    test "down moves and up wraps round the ends" do
+      press(@a)
+      assert selected(press(@down)) == "snes"
+      assert selected(press(@down)) == "readme.txt"
+      assert selected(press(@down)) == "backup"
+      assert selected(press(@up)) == "readme.txt"
+    end
+
+    test "autorepeat moves the cursor, unlike the launcher menu" do
+      # The launcher drops autorepeat because each move re-roots the viewport.
+      # Here a move is a graph push, so holding a direction may scroll -- may,
+      # because whether this board's gpio-keys emits autorepeat at all has not
+      # been checked on the device.
+      press(@a)
+      assert press(@down, 2).cursor == 1
+    end
+
+    test "autorepeat on a face button does nothing, so a held A cannot repeat" do
+      snapshot = press(@a, 2)
+      assert snapshot.view == :places
+    end
+
+    test "left and right page, and clamp rather than wrap", %{root: root} do
+      for index <- 1..30, do: File.write!(Path.join(root, "rom-#{index}.sfc"), "x")
+
+      snapshot = press(@a)
+      # Two directories, thirty ROMs and the readme.
+      assert length(snapshot.entries) == 33
+
+      assert press(@right).cursor == 10
+      assert press(@right).cursor == 20
+      assert press(@right).cursor == 30
+
+      # Clamped at the end rather than wrapped: a page that wrapped would read
+      # as the app having lost its place in a long directory.
+      assert press(@right).cursor == 32
+      assert press(@right).cursor == 32
+
+      assert press(@left).cursor == 22
+      assert press(@left).cursor == 12
+      assert press(@left).cursor == 2
+      assert press(@left).cursor == 0
+    end
+  end
+
+  describe "walking the tree" do
+    test "A descends into a directory and B comes back to it" do
+      open("snes")
+      snapshot = FileManager.snapshot()
+      assert names(snapshot) == ["chrono.sfc", "zelda.sfc"]
+
+      # Back up, and the cursor is on the directory just left rather than at
+      # the top of the parent.
+      snapshot = press(@b)
+      assert snapshot.view == :browse
+      assert selected(snapshot) == "snes"
+    end
+
+    test "B at the top of a root goes back to the places, not out of it" do
+      press(@a)
+      snapshot = press(@b)
+      assert snapshot.view == :places
+      # And again does nothing: there is nowhere above the roots.
+      assert press(@b).view == :places
+    end
+
+    test "Menu is the launcher's and changes nothing here" do
+      before = press(@a)
+      assert press(@menu) == before
+    end
+
+    test "a directory that is not there is reported rather than raising", %{root: root} do
+      press(@a)
+      to("snes")
+
+      # Removed behind the app's back, which is the case that must not crash:
+      # the listing on screen is a moment old, and the web upload page and a
+      # shell over SSH can both change the disk under it.
+      File.rm_rf!(Path.join(root, "snes"))
+      snapshot = press(@a)
+
+      refute snapshot.readable?
+      assert {:error, _text} = snapshot.message
+      assert snapshot.entries == []
+    end
+  end
+
+  describe "the actions sheet" do
+    test "Y offers the verbs for a file" do
+      open("snes")
+      snapshot = press(@y)
+
+      assert snapshot.view == :actions
+
+      assert labels(snapshot) == [
+               "Copy chrono.sfc",
+               "Move chrono.sfc",
+               "Rename chrono.sfc",
+               "Delete chrono.sfc"
+             ]
+    end
+
+    test "a directory is not offered a copy it cannot do" do
+      press(@a)
+      snapshot = press(@y)
+
+      assert labels(snapshot) == ["Move backup", "Rename backup", "Delete backup"]
+    end
+
+    test "A on a file opens the same sheet, because there is nothing to open" do
+      open("snes")
+      assert press(@a).view == :actions
+    end
+
+    test "B leaves the sheet without doing anything" do
+      open("snes")
+      press(@y)
+      snapshot = press(@b)
+
+      assert snapshot.view == :browse
+      assert snapshot.actions == []
+    end
+  end
+
+  describe "deleting" do
+    test "choosing Delete deletes nothing; it asks", %{root: root} do
+      open("snes")
+      press(@y)
+      # Copy, Move, Rename, Delete
+      press(@down)
+      press(@down)
+      press(@down)
+      snapshot = press(@a)
+
+      assert snapshot.view == :confirm
+      assert snapshot.pending.entry.name == "chrono.sfc"
+      assert File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+    end
+
+    test "A on the confirmation cancels, because A is the button that got here", ctx do
+      %{root: root} = ctx
+      confirm_delete_of("chrono.sfc")
+
+      snapshot = press(@a)
+
+      assert snapshot.view == :browse
+      assert snapshot.message == {:ok, "Nothing was deleted."}
+      assert File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+    end
+
+    test "B cancels too, and so does a direction", %{root: root} do
+      confirm_delete_of("chrono.sfc")
+      assert press(@b).view == :browse
+      assert File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+
+      confirm_delete_of("chrono.sfc")
+      assert press(@down).view == :browse
+      assert File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+    end
+
+    test "Y deletes it, and the listing is re-read", %{root: root} do
+      confirm_delete_of("chrono.sfc")
+
+      snapshot = press(@y)
+
+      assert snapshot.view == :browse
+      assert snapshot.message == {:ok, "chrono.sfc deleted."}
+      refute File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+      assert names(snapshot) == ["zelda.sfc"]
+    end
+
+    test "a directory with something in it is refused, with the reason", ctx do
+      %{root: root} = ctx
+      press(@a)
+      to("snes")
+      press(@y)
+      press(@down)
+      press(@down)
+      snapshot = press(@a)
+      assert snapshot.view == :confirm
+
+      snapshot = press(@y)
+
+      assert {:error, message} = snapshot.message
+      assert message =~ "not empty"
+      assert File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+    end
+
+    defp confirm_delete_of(name) do
+      open("snes")
+      to(name)
+      press(@y)
+      snapshot = FileManager.snapshot()
+      index = Enum.find_index(snapshot.actions, &(&1.id == :delete))
+      for _step <- 1..index, do: press(@down)
+      snapshot = press(@a)
+      assert snapshot.view == :confirm
+      snapshot
+    end
+  end
+
+  describe "copying and moving" do
+    test "copy holds the file, and pasting puts it somewhere else", ctx do
+      %{root: root} = ctx
+      open("snes")
+      choose(:copy)
+
+      snapshot = FileManager.snapshot()
+      assert snapshot.clipboard.name == "chrono.sfc"
+      assert snapshot.view == :browse
+
+      press(@b)
+      to("backup")
+      press(@a)
+      snapshot = paste()
+
+      assert snapshot.message == {:ok, "chrono.sfc copied here."}
+      assert File.read!(Path.join([root, "backup", "chrono.sfc"])) == "rom bytes"
+      # Still there, so this really was a copy.
+      assert File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+      # And still held, so the same ROM can go on both cards.
+      assert FileManager.snapshot().clipboard != nil
+    end
+
+    test "move takes it, and clears the clipboard", %{root: root} do
+      open("snes")
+      choose(:move)
+
+      press(@b)
+      to("backup")
+      press(@a)
+      snapshot = paste()
+
+      assert snapshot.message == {:ok, "chrono.sfc moved here."}
+      assert File.exists?(Path.join([root, "backup", "chrono.sfc"]))
+      refute File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+      assert snapshot.clipboard == nil
+    end
+
+    test "pasting onto a name that is taken is refused, not an overwrite", ctx do
+      %{root: root} = ctx
+      File.write!(Path.join([root, "backup", "chrono.sfc"]), "someone's save")
+
+      open("snes")
+      choose(:copy)
+      press(@b)
+      to("backup")
+      press(@a)
+      snapshot = paste()
+
+      assert {:error, message} = snapshot.message
+      assert message =~ "already there"
+      assert File.read!(Path.join([root, "backup", "chrono.sfc"])) == "someone's save"
+    end
+
+    test "the clipboard can be forgotten" do
+      open("snes")
+      choose(:copy)
+      press(@y)
+      snapshot = FileManager.snapshot()
+      index = Enum.find_index(snapshot.actions, &(&1.id == :forget))
+      for _step <- 1..index, do: press(@down)
+      snapshot = press(@a)
+
+      assert snapshot.clipboard == nil
+    end
+
+    defp choose(id) do
+      press(@y)
+      snapshot = FileManager.snapshot()
+      index = Enum.find_index(snapshot.actions, &(&1.id == id))
+      for _step <- 1..index//1, do: press(@down)
+      press(@a)
+    end
+
+    defp paste do
+      press(@y)
+      snapshot = FileManager.snapshot()
+      assert hd(snapshot.actions).id == :paste
+      press(@a)
+    end
+  end
+
+  describe "renaming" do
+    test "the editor starts on the current name" do
+      open("snes")
+      choose(:rename)
+      snapshot = FileManager.snapshot()
+
+      assert snapshot.view == :rename
+      assert Enum.join(snapshot.rename.chars) == "chrono.sfc"
+      assert snapshot.rename.caret == 0
+    end
+
+    test "up changes the character under the caret, and A saves it", %{root: root} do
+      open("snes")
+      choose(:rename)
+
+      # 'c' -> 'd', then save.
+      snapshot = press(@down)
+      assert Enum.join(snapshot.rename.chars) == "dhrono.sfc"
+
+      snapshot = press(@a)
+      assert snapshot.view == :browse
+      assert snapshot.message == {:ok, "chrono.sfc is now dhrono.sfc."}
+      assert File.exists?(Path.join([root, "snes", "dhrono.sfc"]))
+    end
+
+    test "the caret moves and stops at both ends" do
+      open("snes")
+      choose(:rename)
+
+      assert press(@left).rename.caret == 0
+      assert press(@right).rename.caret == 1
+
+      # Ten characters, so caret 10 is the append slot and there is nothing
+      # past it.
+      snapshot = Enum.reduce(1..20, nil, fn _step, _acc -> press(@right) end)
+      assert snapshot.rename.caret == 10
+    end
+
+    test "up on the append slot adds a character and stays on it" do
+      open("snes")
+      choose(:rename)
+      for _step <- 1..10, do: press(@right)
+
+      snapshot = press(@up)
+      assert Enum.join(snapshot.rename.chars) == "chrono.sfca"
+      assert snapshot.rename.caret == 10
+
+      # And stepping again changes that character rather than adding another.
+      snapshot = press(@up)
+      assert String.length(Enum.join(snapshot.rename.chars)) == 11
+    end
+
+    test "Y removes the character under the caret" do
+      open("snes")
+      choose(:rename)
+      snapshot = press(@y)
+
+      assert Enum.join(snapshot.rename.chars) == "hrono.sfc"
+    end
+
+    test "an empty name is refused and the editor stays open" do
+      open("snes")
+      choose(:rename)
+      for _step <- 1..12, do: press(@y)
+
+      snapshot = press(@a)
+
+      assert snapshot.view == :rename
+      assert {:error, message} = snapshot.message
+      assert message =~ "not allowed"
+    end
+
+    test "B cancels and the file keeps its name", %{root: root} do
+      open("snes")
+      choose(:rename)
+      press(@down)
+      snapshot = press(@b)
+
+      assert snapshot.view == :browse
+      assert File.exists?(Path.join([root, "snes", "chrono.sfc"]))
+    end
+
+    test "the picker cannot type a separator, so a rename cannot become a move" do
+      # The boundary in MayonnaiOS.Files rejects it anyway -- that is tested
+      # there -- and the editor cannot even produce it. Both, because the
+      # second is a UI decision that could be changed by someone who had not
+      # read the first.
+      open("snes")
+      choose(:rename)
+      snapshot = FileManager.snapshot()
+
+      typed =
+        Enum.reduce(1..80, snapshot, fn _step, _acc -> press(@up) end)
+        |> Map.fetch!(:rename)
+        |> Map.fetch!(:chars)
+        |> Enum.join()
+
+      refute String.contains?(typed, "/")
+      refute String.contains?(typed, "\\")
+    end
+  end
+
+  describe "symlinks" do
+    test "are shown as links, and deleting one leaves the target", %{root: root} do
+      target = Path.join(root, "readme.txt")
+      File.ln_s!(target, Path.join(root, "link.txt"))
+
+      press(@a)
+      snapshot = to("link.txt")
+      entry = Enum.at(snapshot.entries, snapshot.cursor)
+      assert entry.link == target
+
+      press(@y)
+      snapshot = FileManager.snapshot()
+      # No copy for a link: copying through one is the one way a read could
+      # leave the roots.
+      refute Enum.any?(snapshot.actions, &(&1.id == :copy))
+
+      index = Enum.find_index(snapshot.actions, &(&1.id == :delete))
+      for _step <- 1..index, do: press(@down)
+      press(@a)
+      press(@y)
+
+      refute File.exists?(Path.join(root, "link.txt"))
+      assert File.read!(target) == "hello"
+    end
+  end
+
+  describe "the panel" do
+    test "nothing is drawn in the strip reserved for the shared top bar" do
+      # The status bar is another agent's job. This asserts only that this
+      # screen leaves room for it, in every view, so that arriving later is a
+      # matter of drawing rather than of re-laying-out this one.
+      for snapshot <- every_view() do
+        graph = Scene.graph(snapshot)
+
+        for {y, primitive} <- placements(graph) do
+          assert y >= Scene.status_bar(),
+                 "#{inspect(primitive)} is at y=#{y}, inside the top #{Scene.status_bar()} px"
+        end
+      end
+    end
+
+    test "the confirmation says the whole path and which button does it" do
+      confirm_delete_of("chrono.sfc")
+      words = texts(Scene.graph(FileManager.snapshot()))
+
+      assert Enum.any?(words, &String.ends_with?(&1, "snes/chrono.sfc"))
+      assert "Y deletes it." in words
+      assert Enum.any?(words, &String.contains?(&1, "no undo"))
+    end
+
+    test "an empty directory says so rather than looking broken", %{root: root} do
+      press(@a)
+      to("backup")
+      press(@a)
+
+      assert "Empty." in texts(Scene.graph(FileManager.snapshot()))
+      assert File.dir?(Path.join(root, "backup"))
+    end
+
+    test "a long listing is windowed and says where in it you are", %{root: root} do
+      for index <- 1..40, do: File.write!(Path.join(root, "rom-#{index}.sfc"), "x")
+
+      press(@a)
+      for _step <- 1..30, do: press(@down)
+
+      words = texts(Scene.graph(FileManager.snapshot()))
+      assert Enum.any?(words, &String.match?(&1, ~r/^\d+ of 43$/))
+    end
+
+    test "the places screen names each root and what it is for" do
+      words = texts(Scene.graph(FileManager.snapshot()))
+      assert "games, and where uploads land" in words
+    end
+
+    test "every view builds a graph, including the app not running" do
+      assert %Scenic.Graph{} = Scene.graph(:stopped)
+      assert %Scenic.Graph{} = Scene.graph(:stopped, :enoent)
+
+      for snapshot <- every_view() do
+        assert %Scenic.Graph{} = Scene.graph(snapshot), "#{snapshot.view} did not build"
+      end
+    end
+
+    test "a snapshot from a state the app cannot reach still builds" do
+      # The scene is its own process reading a snapshot, so it must not crash
+      # on one that does not make sense to it.
+      assert %Scenic.Graph{} = Scene.graph(%{FileManager.snapshot() | view: :confirm})
+      assert %Scenic.Graph{} = Scene.graph(%{FileManager.snapshot() | view: :nonsense})
+    end
+
+    # One snapshot per view, taken from the app rather than written out here,
+    # so a view that changes shape cannot leave the rendering test passing
+    # against a shape nothing produces.
+    defp every_view do
+      places = FileManager.snapshot()
+      browse = press(@a)
+
+      press(@y)
+      actions = FileManager.snapshot()
+      press(@b)
+
+      confirm = confirm_delete_of("chrono.sfc")
+      press(@b)
+
+      open("snes")
+      choose(:rename)
+      rename = FileManager.snapshot()
+      press(@b)
+
+      [places, browse, actions, confirm, rename]
+    end
+
+    defp texts(graph) do
+      Scenic.Graph.reduce(graph, [], fn
+        %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+        _primitive, acc -> acc
+      end)
+    end
+
+    # Every primitive's y, except the full-screen background: the status bar
+    # will paint over that, and a screen with no background is not a screen.
+    defp placements(graph) do
+      Scenic.Graph.reduce(graph, [], fn
+        %Scenic.Primitive{data: {640, 480}}, acc ->
+          acc
+
+        %Scenic.Primitive{} = primitive, acc ->
+          case get_in(primitive.transforms, [:translate]) do
+            {_x, y} -> [{y, primitive.module} | acc]
+            _none -> acc
+          end
+      end)
+    end
+  end
+end

--- a/test/files_test.exs
+++ b/test/files_test.exs
@@ -1,0 +1,420 @@
+defmodule MayonnaiOS.FilesTest do
+  # Not async: two tests here set :rom_roots to check that the roots come from
+  # the library's, and `MayonnaiOS.LibraryRootsTest` sets the same key. The
+  # application environment is one global, so a shared key is a shared
+  # resource; a suite that passes except when it does not is worse than a
+  # slower one.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Files
+
+  # Two roots, standing in for the internal card and the games card. Everything
+  # here runs on the host: the boundary is arithmetic on names, and the writes
+  # are the part that has already cost this project a set of ROMs, so both are
+  # worth checking somewhere that does not need the device plugged in.
+
+  setup do
+    id = System.unique_integer([:positive])
+    internal = Path.join(System.tmp_dir!(), "files-internal-#{id}")
+    card = Path.join(System.tmp_dir!(), "files-card-#{id}")
+    File.mkdir_p!(internal)
+    File.mkdir_p!(card)
+
+    Application.put_env(:mayonnaios, :file_roots, [
+      %{key: "internal", path: internal, note: "games, and where uploads land"},
+      %{key: "card", path: card, note: "games on another card"}
+    ])
+
+    on_exit(fn ->
+      Application.delete_env(:mayonnaios, :file_roots)
+      File.rm_rf(internal)
+      File.rm_rf(card)
+    end)
+
+    %{internal: internal, card: card}
+  end
+
+  # Everything a request-shaped name could try. Each of these must be an
+  # error, not a repair: `Path.basename/1` would turn most of them into
+  # something harmless and leave nothing saying an escape was attempted.
+  @rejected [
+    "..",
+    ".",
+    "",
+    "../bundles",
+    "a/b",
+    "/etc/shadow",
+    "..\\bundles",
+    <<"rom", 0, "boot">>,
+    <<0xFF, 0xFE>>
+  ]
+
+  describe "the boundary" do
+    test "a location is a root key and names, and resolves under that root", %{internal: internal} do
+      assert {:ok, location} = Files.at("internal", ["snes", "game.sfc"])
+      assert Files.resolve(location) == {:ok, Path.join([internal, "snes", "game.sfc"])}
+    end
+
+    test "an unknown root is an error, not a path" do
+      assert Files.at("etc") == {:error, :unknown_root}
+      assert Files.resolve(%{root: "etc", path: []}) == {:error, :unknown_root}
+    end
+
+    test "every name that could mean something other than itself is rejected" do
+      for name <- @rejected do
+        assert Files.at("internal", [name]) == {:error, :bad_name},
+               "at/2 accepted #{inspect(name)}"
+
+        {:ok, root} = Files.at("internal")
+
+        assert Files.descend(root, name) == {:error, :bad_name},
+               "descend/2 accepted #{inspect(name)}"
+      end
+    end
+
+    test "a name longer than 200 bytes is rejected" do
+      assert Files.at("internal", [String.duplicate("a", 201)]) == {:error, :bad_name}
+      assert {:ok, _} = Files.at("internal", [String.duplicate("a", 200)])
+    end
+
+    test "a location assembled by hand is re-checked when it is resolved" do
+      # The struct is a plain map, so nothing stops another module building
+      # one. resolve/1 is where that stops mattering.
+      assert Files.resolve(%{root: "internal", path: [".."]}) == {:error, :bad_name}
+      assert Files.resolve(%{root: "internal", path: ["ok", "../.."]}) == {:error, :bad_name}
+    end
+
+    test "dotfiles are reachable, deliberately unlike the upload boundary" do
+      # Library rejects a leading dot so an upload cannot land as a dotfile.
+      # Here /root/.config/retroarch is one of the directories most worth
+      # looking at, and hiding it would be a lie about what is on the disk.
+      assert {:ok, location} = Files.at("internal", [".config", "retroarch"])
+      assert {:ok, path} = Files.resolve(location)
+      assert String.ends_with?(path, "/.config/retroarch")
+    end
+
+    test "ascend stops at the root rather than climbing out of it" do
+      {:ok, deep} = Files.at("internal", ["a", "b"])
+      assert %{path: ["a"]} = Files.ascend(deep)
+      assert %{path: []} = deep |> Files.ascend() |> Files.ascend()
+      assert Files.ascend(%{root: "internal", path: []}) == nil
+    end
+
+    test "a root itself is not an entry, so nothing can operate on one", %{internal: internal} do
+      root = %{root: "internal", path: []}
+      assert Files.basename(root) == {:error, :is_root}
+      assert Files.delete(root) == {:error, :is_root}
+      assert File.dir?(internal)
+    end
+  end
+
+  describe "listing" do
+    test "directories first, then names case-insensitively", %{internal: internal} do
+      File.mkdir_p!(Path.join(internal, "snes"))
+      File.mkdir_p!(Path.join(internal, "Arcade"))
+      File.write!(Path.join(internal, "zelda.sfc"), "z")
+      File.write!(Path.join(internal, "Chrono.sfc"), "c")
+
+      {:ok, location} = Files.at("internal")
+      assert {:ok, entries} = Files.list(location)
+
+      assert Enum.map(entries, & &1.name) == ["Arcade", "snes", "Chrono.sfc", "zelda.sfc"]
+    end
+
+    test "sizes come from the file, and dotfiles are listed", %{internal: internal} do
+      File.write!(Path.join(internal, "game.sfc"), String.duplicate("x", 42))
+      File.mkdir_p!(Path.join(internal, ".config"))
+
+      {:ok, location} = Files.at("internal")
+      {:ok, entries} = Files.list(location)
+      by_name = Map.new(entries, &{&1.name, &1})
+
+      assert by_name["game.sfc"].size == 42
+      assert by_name["game.sfc"].type == :regular
+      assert by_name[".config"].type == :directory
+    end
+
+    test "a symlink says so, and a broken one says that", %{internal: internal} do
+      File.write!(Path.join(internal, "real.so"), "elf")
+      File.ln_s!(Path.join(internal, "real.so"), Path.join(internal, "good.so"))
+      File.ln_s!(Path.join(internal, "gone.so"), Path.join(internal, "bad.so"))
+
+      {:ok, location} = Files.at("internal")
+      {:ok, entries} = Files.list(location)
+      by_name = Map.new(entries, &{&1.name, &1})
+
+      assert by_name["good.so"].link == Path.join(internal, "real.so")
+      refute by_name["good.so"].broken?
+
+      # This is the case that matters on the device: the core directory is
+      # nothing but symlinks, and a dangling one looks like an installed core
+      # to anything that only lists names.
+      assert by_name["bad.so"].broken?
+      assert by_name["bad.so"].type == :missing
+    end
+
+    test "a directory that is not there is an error to render, not a raise" do
+      {:ok, location} = Files.at("internal", ["not-here"])
+      assert Files.list(location) == {:error, :enoent}
+    end
+  end
+
+  describe "copy" do
+    setup %{internal: internal} do
+      File.mkdir_p!(Path.join(internal, "snes"))
+      File.mkdir_p!(Path.join(internal, "backup"))
+      File.write!(Path.join([internal, "snes", "game.sfc"]), "rom bytes")
+
+      {:ok, source} = Files.at("internal", ["snes", "game.sfc"])
+      {:ok, dest} = Files.at("internal", ["backup"])
+      %{source: source, dest: dest}
+    end
+
+    test "copies the bytes", %{source: source, dest: dest, internal: internal} do
+      assert Files.copy(source, dest) == :ok
+      assert File.read!(Path.join([internal, "backup", "game.sfc"])) == "rom bytes"
+    end
+
+    test "fsyncs the whole file, on an open handle, before the rename", ctx do
+      %{source: source, dest: dest, internal: internal} = ctx
+      final = Path.join([internal, "backup", "game.sfc"])
+      test = self()
+
+      sync = fn fd ->
+        # Three things are asserted by taking them here rather than
+        # afterwards. That the handle is still open -- :file.position answers
+        # on an open fd and raises or errors on a closed one. That everything
+        # was written first, because the position is the byte count. And that
+        # the destination does not exist yet, so the sync happened while the
+        # data was still in the .part file and before it was renamed into
+        # place. A test that only looked at the file afterwards could not tell
+        # a synced copy from an unsynced one: both are there until the power
+        # goes, which is the failure this guards against.
+        send(test, {:synced, :file.position(fd, :cur), File.exists?(final)})
+        :file.sync(fd)
+      end
+
+      assert Files.copy(source, dest, sync: sync) == :ok
+
+      assert_received {:synced, {:ok, 9}, false}
+      assert File.read!(final) == "rom bytes"
+      # And the .part file is gone, so the rename happened rather than a copy.
+      refute File.exists?(final <> ".part")
+    end
+
+    test "refuses to overwrite", %{source: source, dest: dest, internal: internal} do
+      File.write!(Path.join([internal, "backup", "game.sfc"]), "someone's save")
+
+      assert Files.copy(source, dest) == {:error, :eexist}
+      assert File.read!(Path.join([internal, "backup", "game.sfc"])) == "someone's save"
+    end
+
+    test "refuses a directory", %{dest: dest} do
+      {:ok, source} = Files.at("internal", ["snes"])
+      assert Files.copy(source, dest) == {:error, :eisdir}
+    end
+
+    test "refuses a symlink source, so a copy cannot read through one", ctx do
+      %{internal: internal, dest: dest} = ctx
+      File.ln_s!("/etc/hosts", Path.join([internal, "snes", "outside"]))
+
+      {:ok, source} = Files.at("internal", ["snes", "outside"])
+      assert Files.copy(source, dest) == {:error, :is_symlink}
+    end
+
+    test "copies across roots, which is what two cards are for", ctx do
+      %{source: source, card: card} = ctx
+      {:ok, dest} = Files.at("card")
+
+      assert Files.copy(source, dest) == :ok
+      assert File.read!(Path.join(card, "game.sfc")) == "rom bytes"
+    end
+  end
+
+  describe "move" do
+    setup %{internal: internal} do
+      File.mkdir_p!(Path.join(internal, "snes"))
+      File.mkdir_p!(Path.join(internal, "megadrive"))
+      File.write!(Path.join([internal, "snes", "game.sfc"]), "rom bytes")
+
+      {:ok, source} = Files.at("internal", ["snes", "game.sfc"])
+      {:ok, dest} = Files.at("internal", ["megadrive"])
+      %{source: source, dest: dest}
+    end
+
+    test "is a rename when it can be", %{source: source, dest: dest, internal: internal} do
+      assert Files.move(source, dest) == :ok
+      refute File.exists?(Path.join([internal, "snes", "game.sfc"]))
+      assert File.read!(Path.join([internal, "megadrive", "game.sfc"])) == "rom bytes"
+    end
+
+    test "refuses to overwrite", %{source: source, dest: dest, internal: internal} do
+      File.write!(Path.join([internal, "megadrive", "game.sfc"]), "not this one")
+
+      assert Files.move(source, dest) == {:error, :eexist}
+      assert File.exists?(Path.join([internal, "snes", "game.sfc"]))
+    end
+
+    test "across filesystems it copies, fsyncs and then removes the source", ctx do
+      %{source: source, dest: dest, internal: internal} = ctx
+      test = self()
+
+      # A test cannot mount a second filesystem, so :exdev is injected. That
+      # is the whole reason the seam exists: the cross-device path is the one
+      # that writes bytes, and therefore the one that has to fsync them.
+      assert Files.move(source, dest,
+               rename: fn _from, _to -> {:error, :exdev} end,
+               sync: fn fd ->
+                 send(test, {:synced, :file.position(fd, :cur)})
+                 :file.sync(fd)
+               end
+             ) == :ok
+
+      assert_received {:synced, {:ok, 9}}
+      refute File.exists?(Path.join([internal, "snes", "game.sfc"]))
+      assert File.read!(Path.join([internal, "megadrive", "game.sfc"])) == "rom bytes"
+    end
+
+    test "a directory across filesystems is refused rather than copied", ctx do
+      %{dest: dest, internal: internal} = ctx
+      {:ok, source} = Files.at("internal", ["snes"])
+
+      assert Files.move(source, dest, rename: fn _f, _t -> {:error, :exdev} end) ==
+               {:error, :exdev}
+
+      assert File.dir?(Path.join(internal, "snes"))
+    end
+  end
+
+  describe "rename" do
+    setup %{internal: internal} do
+      File.write!(Path.join(internal, "game.sfc"), "rom")
+      {:ok, source} = Files.at("internal", ["game.sfc"])
+      %{source: source}
+    end
+
+    test "renames in place", %{source: source, internal: internal} do
+      assert Files.rename(source, "zelda.sfc") == :ok
+      assert File.read!(Path.join(internal, "zelda.sfc")) == "rom"
+      refute File.exists?(Path.join(internal, "game.sfc"))
+    end
+
+    test "cannot become a move, because the new name goes through the boundary", ctx do
+      %{source: source} = ctx
+
+      for name <- @rejected do
+        assert Files.rename(source, name) == {:error, :bad_name},
+               "rename accepted #{inspect(name)}"
+      end
+    end
+
+    test "refuses a name that is already taken", %{source: source, internal: internal} do
+      File.write!(Path.join(internal, "taken.sfc"), "someone else")
+
+      assert Files.rename(source, "taken.sfc") == {:error, :eexist}
+      assert File.read!(Path.join(internal, "taken.sfc")) == "someone else"
+    end
+  end
+
+  describe "delete" do
+    test "removes a file", %{internal: internal} do
+      File.write!(Path.join(internal, "game.sfc"), "rom")
+      {:ok, location} = Files.at("internal", ["game.sfc"])
+
+      assert Files.delete(location) == :ok
+      refute File.exists?(Path.join(internal, "game.sfc"))
+    end
+
+    test "removes the link and not what it points at", %{internal: internal} do
+      real = Path.join(internal, "real.so")
+      File.write!(real, "elf")
+      File.ln_s!(real, Path.join(internal, "core.so"))
+
+      {:ok, location} = Files.at("internal", ["core.so"])
+      assert Files.delete(location) == :ok
+
+      refute File.exists?(Path.join(internal, "core.so"))
+      assert File.read!(real) == "elf"
+    end
+
+    test "removes an empty directory", %{internal: internal} do
+      File.mkdir_p!(Path.join(internal, "empty"))
+      {:ok, location} = Files.at("internal", ["empty"])
+
+      assert Files.delete(location) == :ok
+      refute File.exists?(Path.join(internal, "empty"))
+    end
+
+    test "will not remove a directory with anything in it", %{internal: internal} do
+      File.mkdir_p!(Path.join(internal, "snes"))
+      File.write!(Path.join([internal, "snes", "game.sfc"]), "rom")
+
+      {:ok, location} = Files.at("internal", ["snes"])
+      assert Files.delete(location) == {:error, :not_empty}
+      assert File.exists?(Path.join([internal, "snes", "game.sfc"]))
+    end
+
+    test "a name that could mean something else deletes nothing" do
+      for name <- @rejected do
+        {:ok, root} = Files.at("internal")
+        assert Files.descend(root, name) == {:error, :bad_name}
+      end
+    end
+  end
+
+  describe "space" do
+    test "reports the filesystem holding a location", %{internal: internal} do
+      {:ok, location} = Files.at("internal")
+
+      assert %{device: device, free: free, total: total} = Files.space(location)
+      assert is_binary(device)
+      assert free > 0
+      assert total >= free
+      # The same numbers as the path, because the location is the path.
+      assert Files.space(internal).total == total
+    end
+
+    test "is nil rather than a guess when there is nothing to measure" do
+      assert Files.space(%{root: "etc", path: []}) == nil
+      assert Files.space("/definitely/not/here") == nil
+    end
+
+    test "the library's free space is now the same measurement" do
+      # One df parse in this application, not two. Library.free_bytes/0 is the
+      # older caller and the web page reads it.
+      on_exit(fn -> Application.delete_env(:mayonnaios, :rom_roots) end)
+      Application.put_env(:mayonnaios, :rom_roots, [System.tmp_dir!()])
+
+      # A delta, not equality: these are two calls to df a millisecond apart,
+      # and the rest of this suite is writing temporary files to the same
+      # filesystem. Asserting the two numbers were identical made this test
+      # fail on the difference between two moments rather than on the thing
+      # it is about.
+      assert_in_delta MayonnaiOS.Library.free_bytes(),
+                      Files.space(System.tmp_dir!()).free,
+                      64 * 1024 * 1024
+
+      # And the same nil from the same parse when there is nothing to measure.
+      Application.put_env(:mayonnaios, :rom_roots, ["/definitely/not/here"])
+      assert MayonnaiOS.Library.free_bytes() == nil
+    end
+  end
+
+  describe "the configured roots" do
+    test "come from the library's roots, so the two cannot disagree" do
+      Application.delete_env(:mayonnaios, :file_roots)
+
+      Application.put_env(:mayonnaios, :rom_roots, ["/root/ROMS", "/root/mnt/games/ROMS"])
+      on_exit(fn -> Application.delete_env(:mayonnaios, :rom_roots) end)
+
+      paths = Enum.map(Files.places(), & &1.path)
+
+      assert "/root/ROMS" in paths
+      assert "/root/mnt/games/ROMS" in paths
+      assert "/root" in paths
+      # Nothing outside /root is offered, and there is no key that reaches
+      # the read-only squashfs.
+      assert Enum.all?(paths, &String.starts_with?(&1, "/root"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A **Files** entry in the launcher: browse the ROM roots, the bundles, the cores
and `/root`, with copy, move, rename and delete. Until now anything about the
filesystem needed SSH, on a device whose whole point is that it does not.

An app rather than a program, on the `%{name:, app:}` seam the controller
already uses. Nothing new on the buttons: D-pad moves, A opens, B goes back,
Menu leaves, and **Y** — deliberately unbound until now — is the second verb.

## Approach

**The boundary rejects paths by not accepting them.** `MayonnaiOS.Files` takes
a root key and a list of names, never a path, so there is no argument for a
traversal to arrive in; names are refused rather than cleaned, on the grounds
`Library.safe_name/1` already gives. The alternative — sanitising, or accepting
a path and checking it is under a root with a prefix test — is the shape that
invites "was the cleaning complete?", and this is the one filesystem on the
device that holds the bundles, the saves and the ROMs. One of Library's rules
is deliberately *not* copied: a leading dot is allowed, because
`/root/.config/retroarch` is one of the directories most worth looking at.

**The symlink caveat is written down instead of claimed away.** Following links
is not optional here (`bundles/retroarch/current` is one; the core directory is
nothing but them), so listing follows and reports them, delete removes the link
and never the target, and copy refuses a symlink source outright — that being
the only way a read could leave the roots. The guarantee is "no name can leave
a root", not "nothing outside /root can be read", because only the first is
enforced.

**Deleting is confirmed on a different button.** A opens the confirmation, Y
carries it out, A cancels. Same-button confirmation is a double-press waiting
to happen on a handheld that is switched off by pulling its power, where there
is no undo and no trash. A non-empty directory is refused outright rather than
recursed, which also keeps a minutes-long job out of the process that reads the
D-pad.

**Copy and move are a clipboard, and rename is a character picker,** because
there is no text input on this device. The picker is slow; the alternative was
a rename verb unreachable from the handheld, or a fake keyboard. It also cannot
type a separator, so the boundary is enforced twice.

**Free space is per location, not per device.** The roots span the writable
f2fs partition and, with the card in, the exFAT games card, so one number would
be wrong for whichever it was not measuring. `/` is a full read-only squashfs
and no root names it. `Library.free_bytes/0` now goes through the same `df`
parse rather than a second one.

**Every copy fsyncs the open handle before the rename**, `receive_upload/4`'s
shape, since there is no `sync` on this device. The test asserts the sync
happened on a still-open handle carrying every byte, before the destination
existed — an unsynced file is present too, right up until the power goes, so
asserting the file exists would assert nothing. What OTP cannot do is named in
the moduledoc rather than implied: the directory entry is not fsynced, because
there is no way to open a directory to sync it.

## What is and is not verified

Verified on the host: 385 tests (74 new), `mix format` clean, and the target
compiles. The input tests drive the real GenServer with the synthetic evdev
reports the launcher forwards, so the button atoms — which this board's device
tree lies about twice over — are exercised rather than reasoned about.

**Not verified: any of it on the handheld.** Nobody has seen the panel, so the
layout is checked as a graph and not with eyes on the glass; no real ROM has
moved between the two cards, so the cross-filesystem path is reached only
through an injected `:exdev`; and whether holding a direction scrolls depends
on autorepeat this board has not been asked about. The scene leaves the top
30 px empty for the shared status bar, which is somebody else's branch.

## Follow-ups for reviewer

- Y now means three different things depending on the view, with the footer
  saying which. Is that better than spending A on it, or should the sheet have
  had its own row in the listing instead?
- `Files.copy/3` and `move/3` take `:sync` and `:rename` as test seams. The
  fsync ordering and the cross-device path cannot be reached from a host any
  other way — is a seam in the module the right price for asserting them?
- Recursive copy and recursive delete are refused rather than implemented. Is
  refusing the right long-term answer, or does this want a progress screen and
  a cancel later?
