### PR TITLE
Make the volume rocker move the mixer it has been muting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hardware:
 - 640×480 panel
 - Mali-G31 MC1 GPU, via Panfrost and Mesa
 - Gamepad, volume keys and headphone-jack detection, through evdev
-- Audio out, speaker and headphones
+- Audio out, speaker and headphones, with the volume rocker moving the mixer
 - Battery, charge and discharge
 - Four thermal zones
 - RTL8821CS WiFi and Bluetooth
@@ -332,6 +332,7 @@ the way any BEAM node is:
     iex> MayonnaiOS.Bundle.install(MayonnaiOS.Bundle.spec(:retroarch))
     iex> MayonnaiOS.Library.index()
     iex> MayonnaiOS.GamesCard.mounted?()
+    iex> MayonnaiOS.Volume.up()
     iex> MayonnaiOS.Audio.run()
 
 `Bundle.install/1` is how RetroArch itself gets onto the device, by the same

--- a/config/target.exs
+++ b/config/target.exs
@@ -429,7 +429,8 @@ config :mayonnaios, autostart_ui: true
 #
 # This flag only gates the tone. The mixer itself is taken to 0% and muted at
 # boot by `MayonnaiOS.Audio.Startup` either way -- volume is something the
-# player asks for, not something the device assumes.
+# player asks for, not something the device assumes, and the rocker on the top
+# edge is how they ask: `MayonnaiOS.Volume` walks the mixer up from silence.
 config :mayonnaios, audio_test: true
 
 # Import target specific config. This must remain at the bottom

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -80,8 +80,12 @@ defmodule MayonnaiOS.Application do
         # restore -- which is exactly why it is worth setting.
         MayonnaiOS.Audio.Startup,
 
+        # The volume rocker. After Audio.Startup, because it starts believing
+        # the mixer is silent and that is the process that makes it so.
+        MayonnaiOS.Volume,
+
         # Collects battery, thermal, RTC, Bluetooth and mixer readings, and
-        # owns the volume keys and the headphone-jack switch. Before the
+        # reads the volume keys and the headphone-jack switch. Before the
         # Launcher, so the readout has data the moment the scene is opened.
         MayonnaiOS.Diagnostics,
 

--- a/lib/mayonnaios/audio.ex
+++ b/lib/mayonnaios/audio.ex
@@ -1,6 +1,7 @@
 defmodule MayonnaiOS.Audio do
   @moduledoc """
-  The mixer, and the test tone that settled whether audio works at all.
+  The mixer: the levels the volume rocker moves, and the test tone that
+  settled whether audio works at all.
 
   **Audio works.** Confirmed on hardware: unmute the mixer, play 440 Hz, and
   the speaker produces it. So the codec routing inherited from
@@ -31,7 +32,62 @@ defmodule MayonnaiOS.Audio do
   about twice, and a handheld that makes a noise nobody asked for, in a
   pocket, is a worse failure than one that starts quiet.
 
-  Raising the volume is `unmute/0`, and it is a deliberate act.
+  Raising the volume is a deliberate act. `MayonnaiOS.Volume` makes the
+  rocker on the shell that act; `unmute/0` is the same thing from IEx.
+
+  ## Which control is the volume, and which are routing
+
+  Five simple controls exist on this card. Read off the device with `amixer
+  scontents`, not guessed:
+
+      Speaker           pswitch only, mono          -- the amplifier
+      Line Out          0-31, pswitch, -inf..0 dB   -- the analog output
+      Line Out Source   enum: Stereo / Mono Diff.
+      DAC               0-63, pswitch, -73.08..0 dB -- the digital gain
+      DAC Reversed      pswitch
+
+  `DAC` carries the volume and the other two are held at the setting that is
+  already known to work. Three reasons, and they are all about not inventing
+  an operating point nobody has heard:
+
+    * `Line Out`'s bottom step reads `-99999.99dB`, which is a mute marker
+      rather than an attenuation. A control whose first step is silence is a
+      switch with extra numbers, not a volume ramp.
+    * `DAC` has 63 steps and reads `-73.08dB` at the bottom of them, so it is
+      the finer of the two and the one with a usable floor.
+    * With `DAC` at full and `Line Out` at full, this is exactly the state the
+      test tone was heard in. So the loudest setting here is the *verified*
+      setting, and every other level is that state attenuated digitally.
+
+  What is not established is the shape of the `DAC` scale between its ends.
+  Two dB readings came off the hardware -- `-73.08` at raw 0, and 0 dB
+  implied at the top -- and a linear scale between them would make 1.16 dB a
+  step. That is the ordinary shape for this kind of control and it is what the
+  even ladder below assumes, but nobody has read a midpoint: the device stopped
+  answering filesystem calls before it could be asked. If the middle of the
+  rocker's travel turns out to be bunched at one end, this is the assumption
+  that was wrong.
+
+  Matching on the name matters and is not decoration: this project has
+  already been bitten by `regulator.3` and `regulator.4` swapping identity
+  between two drivers of the same PMIC. `amixer sset DAC` names the control;
+  nothing here indexes into a list.
+
+  ## The levels
+
+  `steps/0` levels plus silence, and level 0 is `mute/0` -- the boot state.
+  Levels are mapped onto the control's percentage range starting at
+  `quietest/0` rather than at 0%, because the bottom of a 73 dB range is not
+  a quiet setting, it is an inaudible one. Ten presses that do nothing you
+  can hear is indistinguishable from a rocker that is not wired up, which is
+  the failure this exists to fix.
+
+  Both numbers are single constants and both are judgement, not measurement:
+  nobody has yet listened to level 1. If the quietest step is too loud, or
+  the ladder too coarse, `@steps` and `@quietest` are the two things to move.
+  The one thing that *is* checked is that no two levels round onto the same
+  raw value of a 0-63 control, because a press that changes nothing is the
+  failure this is here to fix; see `MayonnaiOS.VolumeTest`.
 
   ## The test tone
 
@@ -45,21 +101,49 @@ defmodule MayonnaiOS.Audio do
 
   require Logger
 
-  # Read off the device: 'Speaker' is a switch, 'Line Out' has volume 0-31,
-  # 'DAC' has volume 0-63. Names come from amixer scontrols, not guessed.
-  @unmute [
-    {"Speaker", ["unmute"]},
-    {"DAC", ["100%", "unmute"]},
-    {"Line Out", ["100%", "unmute"]}
-  ]
+  alias MayonnaiOS.Audio.Amixer
 
-  # The mirror image, and the boot state. `Speaker` takes no percentage --
-  # it is a switch and amixer errors on `0%` for it -- so it only gets muted.
-  @mute [
-    {"Speaker", ["mute"]},
-    {"DAC", ["0%", "mute"]},
-    {"Line Out", ["0%", "mute"]}
-  ]
+  # How many audible levels the rocker walks through, above silence.
+  @steps 10
+
+  # Level 1, as a percentage of the DAC control's range. 50% of 0-63 is raw
+  # 32, which on a scale of -73.08 dB to 0 dB in 1.16 dB steps is about
+  # -36 dB below the level the test tone was heard at. Quiet, and not silent.
+  @quietest 50
+
+  @doc """
+  The number of audible levels. Level 0 is silence, so the range is `0..steps`.
+  """
+  def steps, do: @steps
+
+  @doc """
+  Level 1 as a percentage of the volume control's range.
+  """
+  def quietest, do: @quietest
+
+  @doc """
+  Hold a level inside `0..steps/0`.
+
+  The rocker at either end of its travel is not an error, it is a rocker at
+  the end of its travel, so this saturates rather than wrapping. Wrapping
+  would put a device at full volume one press past silence.
+  """
+  @spec clamp(integer()) :: non_neg_integer()
+  def clamp(level) when is_integer(level), do: level |> max(0) |> min(@steps)
+
+  @doc """
+  The percentage the volume control is set to for `level`.
+
+  0 for silence; `quietest/0` for level 1, rising to 100 at `steps/0`. The
+  spacing is even in percent, which on this control is even in dB.
+  """
+  @spec percent(integer()) :: non_neg_integer()
+  def percent(level) when is_integer(level) do
+    case clamp(level) do
+      0 -> 0
+      n -> @quietest + round((100 - @quietest) * (n - 1) / (@steps - 1))
+    end
+  end
 
   @doc """
   Whether the audio test has been switched on. False unless configured.
@@ -84,30 +168,80 @@ defmodule MayonnaiOS.Audio do
   end
 
   @doc """
-  Raise and unswitch the playback controls.
+  Put the mixer at `level`, between 0 and `steps/0`.
 
-  A deliberate act, not a boot step. Makes no sound by itself.
+  Level 0 is the boot state: every playback control at 0% and switched off.
+  Anything above it switches the same three controls on -- volume up from
+  silence unmutes, because a rocker that raises a number behind a closed
+  switch is the "plausible-looking but dead" failure written all over this
+  board's history.
+
+  The whole ladder is written on every call rather than only the control that
+  moved. It costs two more `amixer` runs per press and it means one press
+  restores a mixer that something else has changed underneath -- `unmute/0`
+  from IEx, say -- instead of leaving the two disagreeing until a reboot.
+
+  `mixer` is the seam the tests use; see `MayonnaiOS.Audio.Mixer`.
   """
-  def unmute, do: apply_controls(@unmute)
+  @spec set_level(integer(), module()) :: :ok | {:error, term()}
+  def set_level(level, mixer \\ Amixer) when is_integer(level) do
+    level |> clamp() |> controls_for() |> apply_controls(mixer)
+  end
+
+  @doc """
+  Raise and unswitch the playback controls, all the way up.
+
+  A deliberate act, not a boot step. Makes no sound by itself. This is the
+  state the test tone was heard in, and it is the top of the volume ladder --
+  the same thing said two ways, deliberately.
+
+  Note that `MayonnaiOS.Volume` does not learn about this: it holds the level
+  it last set, so the next press moves from there rather than from full. One
+  press puts the two back in agreement.
+  """
+  def unmute(mixer \\ Amixer), do: set_level(@steps, mixer)
 
   @doc """
   Take every playback control to 0% and switch it off.
 
-  This is what `Startup` does at boot. It is also what the hardware does on
-  its own -- `DAC` and `Line Out` come up switched off with Line Out at 0%,
-  there is no `/var/lib/alsa/asound.state` and nothing runs `alsactl restore`
-  -- and doing it anyway is the point. An inherited default that happens to
-  be right is indistinguishable from one that is about to stop being right,
-  and this board has already been wrong twice about things read rather than
-  set.
+  This is what `Startup` does at boot, and what level 0 means. It is also
+  what the hardware does on its own -- `DAC` and `Line Out` come up switched
+  off with Line Out at 0%, there is no `/var/lib/alsa/asound.state` and
+  nothing runs `alsactl restore` -- and doing it anyway is the point. An
+  inherited default that happens to be right is indistinguishable from one
+  that is about to stop being right, and this board has already been wrong
+  twice about things read rather than set.
   """
-  def mute, do: apply_controls(@mute)
+  def mute(mixer \\ Amixer), do: set_level(0, mixer)
 
-  defp apply_controls(controls) do
+  # Silence. `Speaker` takes no percentage -- it is a switch and amixer errors
+  # on `0%` for it -- so it only gets muted.
+  #
+  # The amplifier goes off first and comes on last, in the clause below. On a
+  # rising level the gains are already lower than where they are going, so
+  # ordering the writes this way means there is no moment where a switched-on
+  # output carries a level nobody asked for.
+  defp controls_for(0) do
+    [
+      {"Speaker", ["mute"]},
+      {"DAC", ["0%", "mute"]},
+      {"Line Out", ["0%", "mute"]}
+    ]
+  end
+
+  defp controls_for(level) do
+    [
+      {"DAC", ["#{percent(level)}%", "unmute"]},
+      {"Line Out", ["100%", "unmute"]},
+      {"Speaker", ["unmute"]}
+    ]
+  end
+
+  defp apply_controls(controls, mixer) do
     Enum.reduce_while(controls, :ok, fn {control, args}, _acc ->
-      case cmd("amixer", ["sset", control | args]) do
-        {:ok, _} -> {:cont, :ok}
-        :error -> {:halt, {:error, {:no_tool, "amixer"}}}
+      case mixer.set(control, args) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
   end
@@ -119,17 +253,67 @@ defmodule MayonnaiOS.Audio do
     # exit 1, nothing played -- because the minimum is 2. It was in the first
     # version of this function, so the test would have failed silently-ish on
     # the first press and looked like a hardware problem.
-    case cmd("speaker-test", ["-c", "2", "-t", "sine", "-f", "440", "-l", "1"]) do
+    case Amixer.run("speaker-test", ["-c", "2", "-t", "sine", "-f", "440", "-l", "1"]) do
       {:ok, _} -> :ok
-      :error -> {:error, {:no_tool, "speaker-test"}}
+      {:error, _} -> {:error, {:no_tool, "speaker-test"}}
     end
   end
 
-  defp cmd(exe, args) do
-    {out, _status} = System.cmd(exe, args, stderr_to_stdout: true)
-    {:ok, out}
-  rescue
-    _ -> :error
+  defmodule Mixer do
+    @moduledoc """
+    The one thing the level arithmetic needs from the outside world.
+
+    `set(control, args)` runs one `amixer sset`. That is the whole interface,
+    and it is this small on purpose: the parts of volume that can be wrong
+    without hardware saying so -- clamping, the level ladder, whether raising
+    from silence also unswitches, which control is named -- are then testable
+    on a laptop with a mixer that records what it was asked to do.
+
+    There is deliberately no `get`. Reading the mixer back to decide the next
+    level would make the level depend on a parse of `amixer sget` output, and
+    `MayonnaiOS.Volume` already holds it. Writing the full ladder every time
+    (see `MayonnaiOS.Audio.set_level/2`) is the cheaper answer to the same
+    drift problem.
+    """
+
+    @callback set(control :: String.t(), args :: [String.t()]) :: :ok | {:error, term()}
+  end
+
+  defmodule Amixer do
+    @moduledoc """
+    The real mixer: `amixer sset <control> <args...>`.
+
+    Percentages rather than raw values, because `amixer` maps a percentage
+    linearly onto the control's raw range and this card's `DAC` scale is
+    linear in dB -- so an even ladder in percent is an even ladder in
+    loudness, and nothing here has to know that the range is 0-63.
+    """
+
+    @behaviour MayonnaiOS.Audio.Mixer
+
+    @impl MayonnaiOS.Audio.Mixer
+    def set(control, args) do
+      case run("amixer", ["sset", control | args]) do
+        {:ok, _out} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+
+    @doc """
+    Run a tool, and report a missing one as an error rather than raising.
+
+    `System.cmd/3` raises `ErlangError` when the executable is not on the
+    path, which on a laptop is every one of these. A mixer call that takes
+    down its caller because the host has no ALSA is not a useful failure.
+    """
+    def run(exe, args) do
+      case System.cmd(exe, args, stderr_to_stdout: true) do
+        {out, 0} -> {:ok, out}
+        {out, status} -> {:error, {:exit, status, String.trim(out)}}
+      end
+    rescue
+      _ -> {:error, {:no_tool, exe}}
+    end
   end
 
   defmodule Startup do

--- a/lib/mayonnaios/diagnostics.ex
+++ b/lib/mayonnaios/diagnostics.ex
@@ -13,11 +13,11 @@ defmodule MayonnaiOS.Diagnostics do
   check becomes "press the button and watch the number change" rather than a
   session over the network.
 
-  ## Why it owns two input devices
+  ## Why it opens two input devices
 
   The gamepad is `event0` and `MayonnaiOS.Launcher` has it. `InputEvent`
-  delivers to whichever process opened the device, so the two devices nobody
-  else uses are opened here:
+  delivers to whichever process opened the device, so the two devices the
+  Launcher does not read are opened here:
 
       event1  gpio-keys-volume            KEY_VOLUMEDOWN 114, KEY_VOLUMEUP 115
       event2  H616 Audio Codec Headphone  SW_HEADPHONE_INSERT
@@ -25,6 +25,12 @@ defmodule MayonnaiOS.Diagnostics do
   Both codes were read from `/sys/firmware/devicetree/base/gpio-keys-volume/`
   on the device rather than assumed. They happen to be the obvious ones this
   time; the gamepad's were not, which is the reason for looking.
+
+  `MayonnaiOS.Volume` opens the rocker as well, and acts on it. Both readers
+  get every event -- evdev is only exclusive to a reader that asks for
+  `EVIOCGRAB`, and `InputEvent` does not unless told to -- so the press counts
+  here stay a plain observation of the hardware while the mixer is somebody
+  else's job. That split is deliberate; this process reports, it does not act.
 
   ## Switch state at startup
 

--- a/lib/mayonnaios/volume.ex
+++ b/lib/mayonnaios/volume.ex
@@ -1,0 +1,207 @@
+defmodule MayonnaiOS.Volume do
+  @moduledoc """
+  The volume rocker, and the level it moves.
+
+  The two keys on the top edge have been seen arriving as input events since
+  the diagnostics screen started counting them -- `KEY_VOLUMEUP` and
+  `KEY_VOLUMEDOWN` on `gpio-keys-volume`, incrementing a counter on the panel
+  when pressed. Nothing acted on them. This process is the thing that acts:
+  each press moves a level, and each level is written to the mixer by
+  `MayonnaiOS.Audio.set_level/2`.
+
+  ## Where volume lives, and why it is the ALSA control
+
+  Two candidates, and only one of them is reachable from here.
+
+  RetroArch has its own volume -- `audio_volume`, applied as
+  `DB_TO_GAIN(audio_volume)` in `audio_driver_flush`. It is **in dB**, and the
+  `0.000000` in the installed config is `0 dB`, which is unity gain and the
+  shipped default. It is not a muted player, and it is not why the buttons did
+  nothing; reading that zero as silence is the same mistake as reading a
+  config file as the program. It is also only reachable through RetroArch's
+  own menu and hotkeys, and it does nothing for the launcher.
+
+  The ALSA control is the other one, and it is the whole device: the codec's
+  gain, applied to whatever is playing, whoever is playing it. ALSA's control
+  interface is not the PCM -- `/dev/snd/controlC0` is opened separately from
+  `/dev/snd/pcmC0D0p`, and a program holding a playback stream is not holding
+  the mixer.
+
+  So the rocker moves the ALSA control. One volume, in the launcher and in a
+  game, and no per-program settings to keep in step.
+
+  Be clear about which half of that is established. The RetroArch reading is
+  from its source -- `DB_TO_GAIN(audio_volume)` in `audio_driver_flush`, and
+  `DEFAULT_AUDIO_VOLUME 0.0f` commented "0.0 dB == unity gain" in
+  `config.def.h`. The separation of the control interface from the PCM is
+  ALSA's design and not something anyone has demonstrated on *this* board:
+  nobody has yet moved the mixer while RetroArch had a game running and
+  listened to the result. That is the check to make, and it is a check with
+  ears rather than one this code can make for itself.
+
+  ## Why this process, and not the Diagnostics one
+
+  `gpio-keys-volume` is opened here *as well as* in `MayonnaiOS.Diagnostics`,
+  which counts presses for the panel. That is not a mistake and not a race:
+  evdev is not exclusive unless a reader asks for `EVIOCGRAB`, and
+  `InputEvent` only asks when told to (`grab: false` is its default, checked
+  in its port source). Both readers get every event.
+
+  The same fact answers the more interesting question, which is whether the
+  rocker keeps working while RetroArch has the screen. RetroArch reads the
+  gamepad through udev, so it opens this device too -- and `EVIOCGRAB` does
+  not appear anywhere in RetroArch 1.22.2, the version installed here. Its
+  `grab_mouse` is a pointer grab under X11 and Wayland, not an evdev one. So
+  it never takes a device away from this process.
+
+  Two openers rather than one owner because the alternative is worse in the
+  way that matters. Diagnostics is a read-only observer of hardware -- that is
+  its entire job -- and having it drive the mixer would put a control path
+  inside the process whose failure mode is meant to be "the readout is stale".
+  And moving the device out of Diagnostics would mean the volume counters on
+  the panel, which are how the rocker was verified in the first place, stop
+  working whenever this process is not running.
+
+  ## What a press does
+
+  One press, one level. Autorepeat (`value` 2) is ignored, the same as in
+  `MayonnaiOS.Launcher`: holding the rocker does not ramp. That is a decision
+  rather than an omission -- `gpio-keys` only emits repeats when its device
+  tree node says `autorepeat`, this one has not been observed emitting any,
+  and code for an event nobody has seen is the kind of plausible-looking thing
+  this board keeps punishing. `InputEvent` can turn repeats on itself
+  (`repeat_delay`/`repeat_period`, an `EVIOCSREP` on the shared fd) if it
+  turns out to be wanted, and that would change what Diagnostics sees too.
+
+  Level 0 is silence *and* muted, which is the state `MayonnaiOS.Audio.Startup`
+  leaves at boot -- so this process starts believing the mixer, rather than
+  asserting anything over it. Volume up from there unswitches the outputs on
+  the way to level 1; volume down to 0 switches them off again. A rocker whose
+  first press raises a number behind a closed switch would look exactly like
+  one that is not wired up.
+
+  ## No on-screen indicator, yet
+
+  Deliberately none. The level is visible on the diagnostics screen already --
+  the `DAC` row is the control this moves, shown as a percentage and an
+  on/off -- and a transient overlay belongs with the shared top bar rather
+  than being invented twice.
+  """
+
+  use GenServer
+  require Logger
+
+  alias MayonnaiOS.Audio
+
+  # The name the driver gives the rocker, and the path it has had. Looked up
+  # by name because /dev/input numbering is probe order; see `MayonnaiOS.Input`.
+  @device_name "gpio-keys-volume"
+  @device "/dev/input/event1"
+
+  # Read off the hardware, not the device tree: these are the atoms
+  # `InputEvent` decodes KEY_VOLUMEUP (115) and KEY_VOLUMEDOWN (114) to, and
+  # they are the atoms the diagnostics counters have been incrementing on real
+  # presses. The gamepad's codes needed pressing to establish; these did not
+  # turn out to lie, but they were checked the same way.
+  @up :key_volumeup
+  @down :key_volumedown
+
+  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc """
+  The level the mixer was last put at, from 0 to `MayonnaiOS.Audio.steps/0`.
+  """
+  def level(server \\ __MODULE__), do: GenServer.call(server, :level)
+
+  @doc """
+  One step up, or down, without pressing anything. Returns the new level.
+  """
+  def up(server \\ __MODULE__), do: GenServer.call(server, {:step, +1})
+  def down(server \\ __MODULE__), do: GenServer.call(server, {:step, -1})
+
+  @doc """
+  Go straight to a level. Clamped, so `set(99)` is the top of the ladder.
+  """
+  def set(server \\ __MODULE__, level) when is_integer(level),
+    do: GenServer.call(server, {:set, level})
+
+  @impl GenServer
+  def init(opts) do
+    device = Keyword.get(opts, :device, MayonnaiOS.Input.find(@device_name, @device))
+
+    case open_device(device) do
+      {:ok, _pid} ->
+        Logger.info("[volume] watching #{device}: #{Audio.steps()} levels above silence")
+
+      {:error, reason} ->
+        # No rocker is not a reason to fail the boot. Everything else about
+        # the device still works, and `up/0` from IEx still works.
+        Logger.warning("[volume] #{device} unavailable: #{inspect(reason)}")
+    end
+
+    # Silence, because that is what `MayonnaiOS.Audio.Startup` has just set
+    # and what the hardware powers on as. Nothing is written here: the boot
+    # state is already correct, and re-asserting it would make this process
+    # the second thing that decides how loud a freshly booted device is.
+    {:ok, %{level: Keyword.get(opts, :level, 0), mixer: Keyword.get(opts, :mixer, Audio.Amixer)}}
+  end
+
+  # The same guard the Launcher uses, and for the same reason: InputEvent's
+  # port binary is only built on Linux, so `start_link/1` *raises* on a macOS
+  # host rather than returning an error, which inside a linked start would
+  # take this process down at boot instead of degrading to "no rocker".
+  defp open_device(device) do
+    if File.exists?(device), do: InputEvent.start_link(device), else: {:error, :enoent}
+  end
+
+  @impl GenServer
+  def handle_call(:level, _from, state), do: {:reply, state.level, state}
+
+  def handle_call({:step, delta}, _from, state) do
+    state = apply_level(state, state.level + delta)
+    {:reply, state.level, state}
+  end
+
+  def handle_call({:set, level}, _from, state) do
+    state = apply_level(state, level)
+    {:reply, state.level, state}
+  end
+
+  @impl GenServer
+  # One report, one move. The presses in a report are summed rather than
+  # applied one at a time so that a report carrying both keys -- which is what
+  # someone squeezing the rocker in the middle produces -- is a no-op instead
+  # of two writes that fight, and so that a press is one round of `amixer`
+  # rather than three.
+  def handle_info({:input_event, _device, events}, state) do
+    case Enum.reduce(events, 0, &delta/2) do
+      0 -> {:noreply, state}
+      delta -> {:noreply, apply_level(state, state.level + delta)}
+    end
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # Value 1 only. 0 is a release and 2 is autorepeat; see the moduledoc.
+  defp delta({:ev_key, @up, 1}, acc), do: acc + 1
+  defp delta({:ev_key, @down, 1}, acc), do: acc - 1
+  defp delta(_event, acc), do: acc
+
+  # The level is stored whatever the mixer says, so a card that has gone away
+  # does not leave the rocker stuck at the level it failed on -- and the log
+  # line is a warning, because a volume key that cannot reach the mixer is a
+  # real fault and not something to find out about by listening.
+  defp apply_level(state, level) do
+    level = Audio.clamp(level)
+
+    case Audio.set_level(level, state.mixer) do
+      :ok ->
+        Logger.info("[volume] level #{level}/#{Audio.steps()} (#{Audio.percent(level)}%)")
+
+      {:error, reason} ->
+        Logger.warning("[volume] level #{level} not set: #{inspect(reason)}")
+    end
+
+    %{state | level: level}
+  end
+end

--- a/test/volume_test.exs
+++ b/test/volume_test.exs
@@ -1,0 +1,355 @@
+defmodule MayonnaiOS.VolumeTest do
+  # Not async: the fake mixer reports through a registered name, so that the
+  # same recording works whether the call came from this process or from
+  # inside the Volume process.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.{Audio, Volume}
+
+  # There is no ALSA on the machine these tests run on, so the mixer is a
+  # module that records what it was asked to do. That is the whole seam:
+  # everything that can be wrong about volume without the hardware saying so
+  # -- the ladder, the clamping, whether raising from silence also unswitches
+  # the outputs, which control gets named -- is arithmetic and argument lists,
+  # and both are readable from here.
+  defmodule FakeMixer do
+    @behaviour MayonnaiOS.Audio.Mixer
+
+    @recorder MayonnaiOS.VolumeTest.Recorder
+
+    @impl MayonnaiOS.Audio.Mixer
+    def set(control, args) do
+      if pid = Process.whereis(@recorder), do: send(pid, {:mixer, control, args})
+      :ok
+    end
+  end
+
+  # A mixer with no `amixer` behind it, for the failure path.
+  defmodule BrokenMixer do
+    @behaviour MayonnaiOS.Audio.Mixer
+
+    @impl MayonnaiOS.Audio.Mixer
+    def set(_control, _args), do: {:error, {:no_tool, "amixer"}}
+  end
+
+  setup do
+    Process.register(self(), MayonnaiOS.VolumeTest.Recorder)
+    :ok
+  end
+
+  defp writes, do: Enum.reverse(drain([]))
+
+  defp drain(acc) do
+    receive do
+      {:mixer, control, args} -> drain([{control, args} | acc])
+    after
+      0 -> acc
+    end
+  end
+
+  describe "Audio.clamp/1" do
+    test "saturates rather than wrapping at either end" do
+      # Wrapping would put the device at full volume one press past silence,
+      # in a pocket, which is the one outcome worth designing against.
+      assert Audio.clamp(-1) == 0
+      assert Audio.clamp(-99) == 0
+      assert Audio.clamp(Audio.steps() + 1) == Audio.steps()
+      assert Audio.clamp(999) == Audio.steps()
+    end
+
+    test "leaves everything in range alone" do
+      for level <- 0..Audio.steps(), do: assert(Audio.clamp(level) == level)
+    end
+  end
+
+  describe "Audio.percent/1" do
+    test "level 0 is 0% and the top level is 100%" do
+      assert Audio.percent(0) == 0
+      assert Audio.percent(Audio.steps()) == 100
+    end
+
+    test "the first audible level is not near-silence" do
+      # The point of a floor: the control's range is 73 dB, so the bottom of
+      # it is inaudible rather than quiet. A rocker whose first presses do
+      # nothing you can hear is indistinguishable from one that is not wired
+      # up, which is the bug this module exists to fix.
+      assert Audio.percent(1) == Audio.quietest()
+      assert Audio.percent(1) >= 25
+    end
+
+    test "rises with every step, and never stalls" do
+      # A stalled step is a press that changes nothing. Rounding a ladder onto
+      # a percentage is exactly where that would come from.
+      percents = Enum.map(1..Audio.steps(), &Audio.percent/1)
+      assert percents == Enum.sort(percents)
+      assert length(Enum.uniq(percents)) == length(percents)
+    end
+
+    test "is clamped, so an out-of-range level is still a percentage" do
+      assert Audio.percent(-5) == 0
+      assert Audio.percent(Audio.steps() + 5) == 100
+    end
+
+    test "no two levels land on the same raw value of the DAC control" do
+      # The step that matters is the one the *hardware* takes, and a ladder in
+      # percent only survives contact with a 0-63 control if it does not round
+      # two levels onto the same number. That would be a press that changes
+      # nothing, which is the failure this whole module is about.
+      #
+      # The conversion is amixer's own, read out of alsa-utils 1.2.15.2 --
+      # the version Buildroot builds for this image -- rather than remembered:
+      #
+      #     static long convert_prange1(long perc, long min, long max)
+      #     {
+      #             tmp = rint((double)perc * (double)(max - min) * 0.01);
+      #             if (tmp == 0 && perc > 0) tmp++;
+      #             return tmp + min;
+      #     }
+      #
+      # It is linear in the *raw* value, and stays that way because nothing
+      # here passes `-M`, which is the only thing that would switch amixer to
+      # its mapped scale (`std_vol_type = VOL_RAW` otherwise). Whether an even
+      # ladder in raw is also an even ladder in loudness depends on the
+      # control's own dB scale, which is an assumption rather than a
+      # measurement; see the moduledoc. Distinct raw values are the part that
+      # can be asserted from here, and the part that matters most: two levels
+      # rounding onto one raw value is a press that does nothing.
+      dac_max = 63
+      raws = Enum.map(1..Audio.steps(), &amixer_raw(Audio.percent(&1), 0, dac_max))
+
+      assert length(Enum.uniq(raws)) == Audio.steps()
+      assert raws == Enum.sort(raws)
+      assert List.last(raws) == dac_max
+    end
+  end
+
+  describe "Audio.set_level/2" do
+    test "level 0 mutes every playback control and drops it to 0%" do
+      assert Audio.set_level(0, FakeMixer) == :ok
+
+      assert writes() == [
+               {"Speaker", ["mute"]},
+               {"DAC", ["0%", "mute"]},
+               {"Line Out", ["0%", "mute"]}
+             ]
+    end
+
+    test "an audible level unmutes as well as setting the gain" do
+      # The mute interaction is the failure mode being fixed: this device
+      # boots muted, so a volume-up that only moved a percentage would move a
+      # number behind a closed switch and make no sound at all.
+      assert Audio.set_level(1, FakeMixer) == :ok
+
+      writes = writes()
+      assert {"DAC", ["#{Audio.quietest()}%", "unmute"]} in writes
+      assert {"Line Out", ["100%", "unmute"]} in writes
+      assert {"Speaker", ["unmute"]} in writes
+    end
+
+    test "the amplifier is switched on last and off first" do
+      # Nothing here can hear the difference, but the ordering is why there is
+      # no moment where a switched-on output carries a level nobody asked for.
+      Audio.set_level(Audio.steps(), FakeMixer)
+      assert {"Speaker", ["unmute"]} = List.last(writes())
+
+      Audio.set_level(0, FakeMixer)
+      assert [{"Speaker", ["mute"]} | _] = writes()
+    end
+
+    test "volume lives on the DAC control, named and not indexed" do
+      # Regulator indices on this board's PMIC are enumeration order rather
+      # than identity, and the same reasoning applies to mixer controls: the
+      # only thing that identifies this one is the string.
+      Audio.set_level(5, FakeMixer)
+      assert Enum.any?(writes(), &match?({"DAC", [_, "unmute"]}, &1))
+    end
+
+    test "Line Out is held at the setting the test tone was heard at" do
+      for level <- 1..Audio.steps() do
+        Audio.set_level(level, FakeMixer)
+        assert {"Line Out", ["100%", "unmute"]} in writes()
+      end
+    end
+
+    test "the Speaker switch is never given a percentage" do
+      # amixer errors on `0%` for a control that is only a switch, and that
+      # error would abort the rest of the ladder.
+      for level <- 0..Audio.steps() do
+        Audio.set_level(level, FakeMixer)
+
+        for {control, args} <- writes(), control == "Speaker" do
+          refute Enum.any?(args, &String.ends_with?(&1, "%"))
+        end
+      end
+    end
+
+    test "out-of-range levels are clamped rather than refused" do
+      Audio.set_level(99, FakeMixer)
+      assert {"DAC", ["100%", "unmute"]} in writes()
+
+      Audio.set_level(-99, FakeMixer)
+      assert {"DAC", ["0%", "mute"]} in writes()
+    end
+
+    test "stops at the first control that will not set" do
+      assert Audio.set_level(3, BrokenMixer) == {:error, {:no_tool, "amixer"}}
+    end
+  end
+
+  describe "Audio.mute/1 and Audio.unmute/1" do
+    test "mute is level 0 and unmute is the top of the ladder" do
+      Audio.mute(FakeMixer)
+      muted = writes()
+      Audio.set_level(0, FakeMixer)
+      assert writes() == muted
+
+      Audio.unmute(FakeMixer)
+      loud = writes()
+      Audio.set_level(Audio.steps(), FakeMixer)
+      assert writes() == loud
+    end
+
+    test "unmute is the state the test tone was heard in" do
+      Audio.unmute(FakeMixer)
+      writes = writes()
+      assert {"DAC", ["100%", "unmute"]} in writes
+      assert {"Line Out", ["100%", "unmute"]} in writes
+      assert {"Speaker", ["unmute"]} in writes
+    end
+  end
+
+  describe "the rocker" do
+    setup do
+      # No device: there is no /dev/input here, so Volume degrades to "no
+      # rocker" and takes its events from send/2 instead. The shape is the one
+      # the InputEvent driver delivers, so what is exercised below is the code
+      # the device runs.
+      pid = start_supervised!({Volume, [device: "/dev/input/nothing", mixer: FakeMixer]})
+      %{volume: pid}
+    end
+
+    test "starts silent, because that is what boot leaves the mixer at", %{volume: pid} do
+      assert Volume.level(pid) == 0
+    end
+
+    test "writes nothing at startup", %{volume: pid} do
+      # The boot state is already silence. A process that re-asserted it would
+      # be a second thing deciding how loud a freshly booted device is.
+      assert Volume.level(pid) == 0
+      assert writes() == []
+    end
+
+    test "volume up from silence goes to level 1, unmuting on the way", %{volume: pid} do
+      press(pid, :key_volumeup)
+      assert Volume.level(pid) == 1
+      assert {"Speaker", ["unmute"]} in writes()
+    end
+
+    test "each press moves exactly one level", %{volume: pid} do
+      for expected <- 1..Audio.steps() do
+        press(pid, :key_volumeup)
+        assert Volume.level(pid) == expected
+      end
+    end
+
+    test "presses past the top stay at the top", %{volume: pid} do
+      for _ <- 1..(Audio.steps() + 5), do: press(pid, :key_volumeup)
+      assert Volume.level(pid) == Audio.steps()
+    end
+
+    test "presses past silence stay at silence", %{volume: pid} do
+      for _ <- 1..5, do: press(pid, :key_volumedown)
+      assert Volume.level(pid) == 0
+    end
+
+    test "down from level 1 is silence, and mutes", %{volume: pid} do
+      press(pid, :key_volumeup)
+      _ = writes()
+      press(pid, :key_volumedown)
+      assert Volume.level(pid) == 0
+      assert {"Speaker", ["mute"]} in writes()
+    end
+
+    test "a press at the end of the travel still re-asserts the mixer", %{volume: pid} do
+      # Deliberate: one press repairs a mixer that something else has moved --
+      # `Audio.unmute/0` from IEx, say -- rather than leaving the two
+      # disagreeing until a reboot.
+      _ = writes()
+      press(pid, :key_volumedown)
+      assert Volume.level(pid) == 0
+      refute writes() == []
+    end
+
+    test "releases do nothing", %{volume: pid} do
+      send(pid, {:input_event, "test", [{:ev_key, :key_volumeup, 0}]})
+      assert Volume.level(pid) == 0
+      assert writes() == []
+    end
+
+    test "autorepeat does nothing", %{volume: pid} do
+      # Deliberate: holding the rocker does not ramp. If this ever changes it
+      # should change because someone saw a repeat arrive from this device.
+      send(pid, {:input_event, "test", [{:ev_key, :key_volumeup, 2}]})
+      assert Volume.level(pid) == 0
+      assert writes() == []
+    end
+
+    test "a report with both keys is a no-op, not two fighting writes", %{volume: pid} do
+      press(pid, :key_volumeup)
+      _ = writes()
+
+      send(
+        pid,
+        {:input_event, "test", [{:ev_key, :key_volumeup, 1}, {:ev_key, :key_volumedown, 1}]}
+      )
+
+      assert Volume.level(pid) == 1
+      assert writes() == []
+    end
+
+    test "gamepad keys on the same device are ignored", %{volume: pid} do
+      send(pid, {:input_event, "test", [{:ev_key, :btn_b, 1}, {:ev_key, :btn_mode, 1}]})
+      assert Volume.level(pid) == 0
+      assert writes() == []
+    end
+
+    test "up/0 and down/0 move the same level the buttons do", %{volume: pid} do
+      assert Volume.up(pid) == 1
+      assert Volume.up(pid) == 2
+      assert Volume.down(pid) == 1
+    end
+
+    test "set/1 clamps", %{volume: pid} do
+      assert Volume.set(pid, 99) == Audio.steps()
+      assert Volume.set(pid, -99) == 0
+    end
+
+    test "a mixer that cannot be reached still moves the level" do
+      # So that a card which has gone away does not leave the rocker stuck on
+      # the level it failed at, with every later press retrying the same one.
+      stop_supervised!(Volume)
+      pid = start_supervised!({Volume, [device: "/dev/input/nothing", mixer: BrokenMixer]})
+      assert Volume.up(pid) == 1
+      assert Volume.up(pid) == 2
+    end
+  end
+
+  # amixer's percent-to-raw conversion, transcribed from `convert_prange1` in
+  # alsa-utils 1.2.15.2. `rint` rounds half to even and `round/1` rounds half
+  # away from zero; the only level that lands on an exact half here is 50% of
+  # 0-63, and both give 32.
+  defp amixer_raw(percent, min, max) do
+    case round(percent * (max - min) * 0.01) do
+      0 when percent > 0 -> 1 + min
+      raw -> raw + min
+    end
+  end
+
+  # The shape the InputEvent driver delivers, which is what the device sends.
+  # The call afterwards is the synchronisation: it returns only once the send
+  # above has been handled.
+  defp press(pid, key) do
+    send(pid, {:input_event, "test", [{:ev_key, key, 1}]})
+    Volume.level(pid)
+  end
+end


### PR DESCRIPTION
## Summary

The volume keys have been arriving as input events for a while — the diagnostics screen counts them — and nothing acted on them. The mixer boots at 0% and muted, so the rocker was a press counter. Now it moves an ALSA level.

## Approach

**Volume is the ALSA control, not RetroArch's.** The tempting other answer looks compelling and is wrong, so it is worth stating: the installed RetroArch config reads `audio_volume = "0.000000"`, which reads as a muted player. It is not. `audio_volume` is in dB — `DB_TO_GAIN(audio_volume)` in `audio_driver_flush`, and `DEFAULT_AUDIO_VOLUME 0.0f` in `config.def.h` carries the comment "0.0 dB == unity gain". That zero is the shipped default at full gain, and it is also unreachable from outside RetroArch and useless to the launcher.

**`DAC` carries the level; `Line Out` is pinned at 100%.** That pair is exactly the state the test tone was heard in, so the top of the ladder is the already-verified operating point and every lower level is that state attenuated digitally. `Line Out` was the alternative and its bottom step reads `-99999.99dB` — a mute marker, not an attenuation, so it is a switch with extra numbers.

**Level 1 is 50%, not 10%.** The control spans 73 dB, so the bottom of its range is inaudible rather than quiet. Four presses that change nothing audible is indistinguishable from a rocker that is not wired up, which is the bug. Level 0 is `Audio.mute/0` verbatim, so up-from-silence unswitches the outputs on the way and down-to-silence closes them again — the mute interaction is the failure mode here, not a detail.

**Both processes open `gpio-keys-volume`.** evdev is only exclusive to a reader that asks for `EVIOCGRAB`; `InputEvent` does not unless told to, and `EVIOCGRAB` appears nowhere in RetroArch 1.22.2. So the rocker and a running game both see every press, Diagnostics' counters keep working independently of this code, and Diagnostics stays the read-only observer it is meant to be.

## What is verified, and what is not

Verified without making a sound: the five simple controls, their ranges and their switch capabilities, read off the hardware with `amixer scontents`. The percent-to-raw conversion is `convert_prange1` from the alsa-utils 1.2.15.2 source Buildroot builds for this image, which is what the new test uses to assert that no two levels round onto the same raw value of a 0-63 control — a stalled step would be a press that does nothing.

Not verified, and only ears can settle it: that the `DAC` scale is linear between its two known dB endpoints, and that level 1 is audible while level 10 is not painful. Both are a single constant away from being right. Nothing here has run on the device — no firmware was built, no sound was played, and the device stopped answering filesystem calls partway through (a `:prim_file.read_file_nif/1` blocked in the kernel, unrelated to audio) so the last two mixer reads I wanted were never taken.

## Follow-ups for reviewer

- Is 10 levels with a floor at 50% the right feel, or should the quietest step be lower? `@steps` and `@quietest` in `MayonnaiOS.Audio` are the two knobs.
- No on-screen indicator, deliberately — the `DAC` row on the diagnostics screen already shows the level, and a transient overlay belongs with the shared top bar rather than being invented twice here. Should it?
- Holding the rocker does not ramp: autorepeat is ignored, matching the Launcher, because nobody has seen this device emit a repeat. `InputEvent` can turn repeats on itself if it turns out to be wanted, but that is an `EVIOCSREP` on the fd Diagnostics shares. Worth it?