### PR TITLE
Put the panel to sleep on Select+Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Software:
 - RetroArch, with cores installed and upgraded independently of the firmware
 - Checksum-verified bundle install, with versioned directories and rollback
 - A web UI for uploading games from a phone
+- Sleep on Select+Start: the backlight goes off and any button brings it back.
+  Not the power button, which Linux cannot see on this board, and not suspend —
+  no button on the front of the device is wakeup-capable, so a real suspend
+  would look like a brick
 
 ## Building and flashing
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ host-only path:
 | `c` | X — the diagnostics screen |
 | enter | Menu — back to the home screen |
 | backspace | Select |
+| `s` | Start — with backspace held, the sleep chord |
 | escape | Select+Menu, the power-off chord |
 
 `x` and `v` are sent too, as B and Y, and do nothing — the launcher binds

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -101,7 +101,8 @@ defmodule MayonnaiOS.Application do
         MayonnaiOS.Web,
 
         # A launches the selected program, Menu goes back to the home screen,
-        # X opens the diagnostics readout, Select+Menu powers off.
+        # X opens the diagnostics readout, Select+Start turns the backlight
+        # off until any button is pressed, and Select+Menu powers off.
         MayonnaiOS.Launcher
       ] ++ boot_diagnostics()
     end

--- a/lib/mayonnaios/keyboard.ex
+++ b/lib/mayonnaios/keyboard.ex
@@ -31,6 +31,7 @@ defmodule MayonnaiOS.Keyboard do
       c                   X -- the diagnostics screen
       enter               Menu -- back to the home screen
       backspace           Select
+      s                   Start -- with backspace held, the sleep chord
       escape              Select+Menu, the power-off chord
 
   Arrows and `jk` both move because the arrows are where a hand goes first and
@@ -85,7 +86,13 @@ defmodule MayonnaiOS.Keyboard do
     # X: diagnostics
     "c" => :btn_y,
     # Y, also unbound in the Launcher
-    "v" => :btn_x
+    "v" => :btn_x,
+    # Start, which the Launcher does not bind on its own either -- but held
+    # with backspace it is Select+Start, the sleep chord. A codepoint has no
+    # release, and this is the one key where that is worth saying: the chord
+    # works because *Select* is held through the :key path, and `s` only has
+    # to be the press that completes it.
+    "s" => :btn_start
   }
 
   # Escape is the chord rather than a single key, because Select+Menu is

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -33,6 +33,7 @@ defmodule MayonnaiOS.Launcher do
       A             launch the selected program
       Menu          go back to the home screen
       X             switch between the menu and diagnostics
+      Select+Start  sleep -- backlight off, and any press wakes it
       Select+Menu   power off
 
   These are the buttons as printed on the shell. Two of the atoms above name
@@ -47,6 +48,31 @@ defmodule MayonnaiOS.Launcher do
   Select+Menu still powers off, so the chord is checked before the plain
   press. Power off is a chord rather than a button because it is not undoable
   and this is a handheld that gets carried in a pocket.
+
+  ## Sleep, and the press that wakes it
+
+  Select+Start turns the backlight off; `MayonnaiOS.Sleep` owns both the
+  mechanism and the choice of keys, including why it is not the power button
+  (Linux cannot see the power button on this board) and why it is not suspend.
+
+  What belongs here is the other half: while the panel is dark, **the next
+  press is consumed**. Waking is not a binding of its own -- any button wakes,
+  which is the only thing someone holding a dark handheld can be expected to
+  discover -- and the press that wakes must not also do what it usually does.
+  The failure that rule prevents is small and infuriating: pressing A to see
+  the screen again and having the launcher start a game.
+
+  The held set is cleared at the same time, so a key that was down when the
+  device woke cannot become half of a chord it was never meant to complete.
+
+  Three limits, all deliberate. The volume rocker does not wake it, because
+  `MayonnaiOS.Diagnostics` owns that input device and the Launcher never sees
+  its events. An app that has the buttons keeps them, sleep chord included,
+  for the same reason it keeps Menu -- see below. And a running *program* has
+  its own file descriptor on the pad: it goes on running with the panel dark,
+  and the press that wakes the device reaches it too. Only the launcher's own
+  bindings can be swallowed, which is the half that would have launched
+  something.
 
   This process owns `event0`, so everything on the gamepad is bound here even
   when it belongs to something else. `MayonnaiOS.Diagnostics` owns the
@@ -76,7 +102,7 @@ defmodule MayonnaiOS.Launcher do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.Programs
+  alias MayonnaiOS.{Input, Programs, Sleep}
 
   # The name the driver gives the gamepad, and the path it has always had.
   # `MayonnaiOS.Input` prefers the name and falls back to the path, because
@@ -116,7 +142,7 @@ defmodule MayonnaiOS.Launcher do
   # them to these atoms (deps/input_event types table). Unlike the face
   # buttons there is no name collision to fall into here -- but the codes came
   # off this board's device tree, which has already lied once about X and Y,
-  # so the catch-all `press/2` logs unhandled keys at debug: if up and down
+  # so the catch-all `bound/2` logs unhandled keys at debug: if up and down
   # turn out to be swapped, `log_attach_all(:debug)` on the device says so
   # immediately instead of leaving a menu that scrolls the wrong way.
   @up_button :btn_dpad_up
@@ -156,20 +182,52 @@ defmodule MayonnaiOS.Launcher do
   """
   def selected, do: GenServer.call(__MODULE__, :selected)
 
+  @doc """
+  Sleep and wake without pressing anything, and ask which it is.
+
+  `sleep/0` returns what the backlight write returned, so a console gets the
+  reason rather than a cheerful `:ok` over a lit screen. `asleep?/0` answers
+  from this process's own state, which is the thing that decides whether the
+  next button press is swallowed; `MayonnaiOS.Sleep.asleep?/0` answers from
+  sysfs, and the two can legitimately differ -- see that module.
+  """
+  def sleep, do: GenServer.call(__MODULE__, :sleep)
+  def wake, do: GenServer.call(__MODULE__, :wake)
+  def asleep?, do: GenServer.call(__MODULE__, :asleep?)
+
   @impl GenServer
   def init(opts) do
-    device = Keyword.get(opts, :device, MayonnaiOS.Input.find(@device_name, @device))
+    Enum.each(devices(opts), &watch/1)
+    {:ok, new_state()}
+  end
 
+  # The gamepad, plus whatever device the sleep key is on.
+  #
+  # Today those are the same node and `uniq` collapses them to one open, which
+  # is why this is not speculation: it is the same single device it has always
+  # been. The day `CONFIG_INPUT_AXP20X_PEK` is enabled, `Sleep.device/0`
+  # resolves to the `axp20x-pek` node instead and the launcher opens both --
+  # evdev is not a broadcast, so the only way to see `KEY_POWER` is to have
+  # that node open, and both devices deliver into the same `handle_info`.
+  #
+  # An explicit `:device` overrides the lot, which is how the tests and
+  # `MayonnaiOS.Dev` drive this with synthetic events.
+  defp devices(opts) do
+    case Keyword.get(opts, :device) do
+      nil -> Enum.uniq([Input.find(@device_name, @device), Sleep.device()])
+      device -> [device]
+    end
+  end
+
+  defp watch(device) do
     case open_device(device) do
       {:ok, _pid} ->
-        Logger.info("[launcher] watching #{device}: D-pad moves, A launches, Start stops")
-        {:ok, new_state()}
+        Logger.info("[launcher] watching #{device}")
 
       {:error, reason} ->
         # No buttons is not a reason to fail the boot -- the UI is still
         # useful, and this is the only thing that would be lost.
         Logger.warning("[launcher] #{device} unavailable: #{inspect(reason)}")
-        {:ok, new_state()}
     end
   end
 
@@ -192,7 +250,13 @@ defmodule MayonnaiOS.Launcher do
       running: nil,
       held: MapSet.new(),
       scene: :home,
-      selected: 0
+      selected: 0,
+      # Whether the backlight was turned off by the chord. Kept here rather
+      # than read back from sysfs on every event, because it is this process
+      # that has to decide whether to swallow a press and because the panel
+      # can be dark for reasons this process did not cause -- and the reading
+      # that matters is "did we turn it off", not "is it off".
+      asleep: false
     }
 
   @impl GenServer
@@ -210,8 +274,46 @@ defmodule MayonnaiOS.Launcher do
   def handle_call(:launch, _from, state), do: {:reply, :ok, do_launch(state)}
   def handle_call(:stop, _from, state), do: {:reply, :ok, do_stop(state)}
   def handle_call(:selected, _from, state), do: {:reply, state.selected, state}
+  def handle_call(:asleep?, _from, state), do: {:reply, state.asleep, state}
+
+  def handle_call(:sleep, _from, state) do
+    {result, state} = enter_sleep(state)
+    {:reply, result, state}
+  end
+
+  def handle_call(:wake, _from, state) do
+    {result, state} = wake_up(state)
+    {:reply, result, state}
+  end
 
   @impl GenServer
+  # Asleep: the panel is dark, and the next press is spent on turning it back
+  # on. First clause, before the app one, because "any button wakes it" has to
+  # be true of every button in every state -- someone holding a dark handheld
+  # has no way to find out which button is the right one.
+  #
+  # The press is swallowed rather than dispatched. Pressing A to see the
+  # screen again must not launch a game, and pressing Menu to see it must not
+  # stop the one that is running.
+  #
+  # Releases are still tracked, and only a press wakes: the chord that put the
+  # device to sleep is still held at that moment, and its release arriving a
+  # moment later must not wake the device straight back up.
+  def handle_info({:input_event, _device, events}, %{asleep: true} = state) do
+    if Enum.any?(events, &match?({:ev_key, _key, 1}, &1)) do
+      {_result, state} = wake_up(state)
+      {:noreply, state}
+    else
+      state =
+        Enum.reduce(events, state, fn
+          {:ev_key, key, 0}, acc -> release(acc, key)
+          _, acc -> acc
+        end)
+
+      {:noreply, state}
+    end
+  end
+
   # An app has the buttons: the launcher's own bindings are off and every
   # event is forwarded, Menu included. The app is free to ignore what it does
   # not want -- `MayonnaiOS.Controller.Report` drops Menu on the floor -- and
@@ -327,17 +429,55 @@ defmodule MayonnaiOS.Launcher do
     %{state | app: nil, running: nil}
   end
 
-  defp press(state, @launch_button), do: do_launch(state)
-  defp press(state, @diagnostics_button), do: toggle_scene(state)
-  defp press(state, @up_button), do: move(state, -1)
-  defp press(state, @down_button), do: move(state, +1)
+  # The sleep chord is tested before any single-key binding, for the reason
+  # the power-off chord is tested before Menu: a modifier that only works when
+  # the other key happens to be unbound is not a modifier, and the next thing
+  # someone does with `MayonnaiOS.Sleep`'s one-line binding is move it onto a
+  # key that *is* bound (`KEY_POWER` is not, but Select+X would be). Asking
+  # `Sleep` first means that keeps working instead of silently doing nothing.
+  defp press(state, key) do
+    if Sleep.trigger?(state.held, key) do
+      {_result, state} = enter_sleep(state)
+      state
+    else
+      bound(state, key)
+    end
+  end
+
+  # Entering sleep only counts if the backlight write landed. A dark-panel
+  # flag over a lit screen would swallow the next press for nothing, which is
+  # the same failure as not sleeping at all plus a button that does not work.
+  # `Sleep` has already logged why.
+  defp enter_sleep(state) do
+    case Sleep.sleep() do
+      :ok -> {:ok, %{state | asleep: true}}
+      {:error, reason} -> {{:error, reason}, state}
+    end
+  end
+
+  # Waking clears the flag whether or not the write landed, deliberately. If
+  # the backlight cannot be turned back on, more presses will not do it, and a
+  # device that keeps eating them is worse off than one with a dark panel and
+  # working buttons -- a game can still be started, and Select+Menu still
+  # powers it off. `Sleep` logs the failure and the console call returns it.
+  #
+  # The held set goes too: the press that woke the device was consumed, so it
+  # must not also count as the modifier half of a chord.
+  defp wake_up(state) do
+    {Sleep.wake(), %{state | asleep: false, held: MapSet.new()}}
+  end
+
+  defp bound(state, @launch_button), do: do_launch(state)
+  defp bound(state, @diagnostics_button), do: toggle_scene(state)
+  defp bound(state, @up_button), do: move(state, -1)
+  defp bound(state, @down_button), do: move(state, +1)
 
   # Menu: back to the home screen, or -- with Select held -- power off.
   #
   # The chord is checked first, so the modifier is not decorative: a bare
   # Menu must never be able to shut the device down, because it is the key
   # someone reaches for to get out of a game.
-  defp press(state, @home_button) do
+  defp bound(state, @home_button) do
     if MapSet.member?(state.held, @poweroff_modifier) do
       poweroff()
       state
@@ -346,7 +486,7 @@ defmodule MayonnaiOS.Launcher do
     end
   end
 
-  defp press(state, key) do
+  defp bound(state, key) do
     # Debug, not info: this fires for every unbound button on the pad. It
     # exists because the D-pad codes are inherited from the device tree and
     # this board's device tree has been wrong before -- if up and down feel

--- a/lib/mayonnaios/sleep.ex
+++ b/lib/mayonnaios/sleep.ex
@@ -1,0 +1,220 @@
+defmodule MayonnaiOS.Sleep do
+  @moduledoc """
+  Turns the panel's backlight off and on again.
+
+  This is the whole of "sleep" on this device, and the name is deliberately
+  the user's word rather than the kernel's: nothing is suspended, no process
+  is stopped, and the CPUs keep running. What changes is the one thing that
+  costs anything -- the panel and its backlight are the budget, with the whole
+  board measured at about 1.83 W idle with the screen on.
+
+  ## Why it is not suspend
+
+  `/sys/power/mem_sleep` on this board offers only `[s2idle]`. There is no
+  `deep`, because ATF's `sun50i_h616` platform does not implement PSCI
+  SYSTEM_SUSPEND, and an s2idle attempt aborts anyway inside rtw88's SDIO
+  suspend handler with `-EINVAL` (there is no `keep-power-in-suspend` in any
+  device tree here). There is also no cpuidle driver, so the deepest state
+  these cores reach is a bare WFI whether "suspended" or not: a successful
+  s2idle would save almost nothing.
+
+  And it would be dangerous. **No button on the front of this device is
+  wakeup-capable** -- only `alarmtimer.0.auto`, `musb-hdrc.2.auto` and
+  `7000000.rtc` have a `power/wakeup` at all. A system suspend that worked
+  would look exactly like a brick in someone's hands.
+
+  ## Why the backlight, and why 0 and 1
+
+  `/sys/class/backlight/backlight/brightness` is mode 0644 and its
+  `max_brightness` is `1`: the panel's backlight is a GPIO (PD28, driven by
+  `gpio-backlight`) and not a PWM, because there is no mainline H616 PWM
+  driver and adding one was estimated at some 1900 lines of out-of-tree patch.
+  So this writes `0` or `1`, straight through to `gpiod_set_value_cansleep`.
+  A PWM backlight would need this module to read `max_brightness` and restore
+  a previous level; a binary one has nothing to remember.
+
+  Nothing else has to cooperate. Scenic renders through `cairo-fb` into
+  `/dev/fb0` on the CPU -- a plain mmap writer, not a DRM master -- so the app
+  keeps running with the panel dark, and turning the backlight back on shows
+  the current frame with no re-init and no scene restart.
+
+  ## What a successful write does and does not prove
+
+  It proves the GPIO was set. It does not prove the panel went dark, and this
+  module cannot find that out:
+
+    * `actual_brightness` is not a hardware readout. `gpio-backlight` has no
+      `get_brightness` op, so it echoes what was last set.
+
+    * `/sys/class/graphics/fb0/blank` is writable and lies. `fb_blank()`
+      records the requested value before calling the driver,
+      `drm_fb_helper_blank()` returns 0 unconditionally and
+      `drm_fb_helper_dpms()` is `void`, so a successful write there means only
+      that the write was accepted. There is live evidence of exactly that on
+      this device: `fb0/blank` reads `4` (POWERDOWN) while the backlight reads
+      `1` and DSI-1 dpms reads `On`. It is not used here for that reason.
+
+  So `asleep?/0` reports what was last written, and says so. Whether the panel
+  is dark is answerable by looking at the device and by nothing else.
+
+  A write that fails is returned and logged rather than swallowed, because a
+  sleep that silently does not sleep is this project's characteristic failure
+  -- an inherited assumption reported as success -- and the caller uses the
+  answer: `MayonnaiOS.Launcher` only starts swallowing button presses if the
+  panel really was told to go dark.
+
+  ## The binding, and the power button
+
+  Karl asked for the power button, and the power button does not exist as far
+  as Linux is concerned. There are exactly four input devices on this board --
+  `adc-joystick`, `gpio-keys-gamepad`, `gpio-keys-volume` and
+  `H616 Audio Codec Headphone Jack` -- and no power key among them. The button
+  is on the PMIC's PWRON pin; mainline has the driver
+  (`drivers/input/misc/axp20x-pek.c`, which would expose `KEY_POWER` on an
+  input device named `axp20x-pek`), but `CONFIG_INPUT_AXP20X_PEK` appears
+  nowhere in the system repo -- not in `linux/nerves.fragment`, not in
+  `linux/linux-6.18.defconfig`. Enabling it is a one-line kernel config change
+  and a 2-3 hour Buildroot rebuild, and no device-tree change at all, since it
+  is an MFD cell rather than a DT node.
+
+  Until that rebuild happens the trigger is a chord on the pad, and `@binding`
+  below is one line so that the day the key exists, moving sleep onto it is
+  one line:
+
+      @binding {"axp20x-pek", "/dev/input/event0", {nil, :key_power}}
+
+  `MayonnaiOS.Input.find/2` is what makes that safe in both directions: it
+  looks the device up by the name its driver gives it and falls back to a
+  path, so firmware without the option still finds the pad and the chord keeps
+  working.
+  """
+
+  require Logger
+
+  alias MayonnaiOS.Input
+
+  # The brightness file. Configurable rather than written out at each use, so
+  # a test can point it at a temp file and so a panel wired differently is a
+  # config line instead of a patch.
+  @default_path "/sys/class/backlight/backlight/brightness"
+
+  # max_brightness is 1; see the moduledoc.
+  @off "0"
+  @on "1"
+
+  # `{device name, path to fall back on, {modifier, key}}`.
+  #
+  # Select+Start. Select because it is already the modifier this launcher uses
+  # and a second modifier would be a second thing to remember; Start because
+  # the launcher binds it to nothing at all, so the chord cannot be half of an
+  # existing action the way Select+X would be, and because Select and Start
+  # are the two recessed buttons in the middle of the shell -- nobody's thumb
+  # is resting on them while playing, which is what "cannot be pressed by
+  # accident" has to mean on a handheld.
+  #
+  # Not Menu: Select+Menu powers off, and the reason that chord is guarded is
+  # that Menu is the key someone mashes to get out of a game. Not Y, which is
+  # deliberately unbound and stays that way.
+  #
+  # A `nil` modifier means the key alone is the trigger, which is what the
+  # real power button will want.
+  @binding {"gpio-keys-gamepad", "/dev/input/event0", {:btn_select, :btn_start}}
+
+  # Taken apart at compile time, so the one line above stays the only place
+  # any of it is written down.
+  @device_name elem(@binding, 0)
+  @device_fallback elem(@binding, 1)
+  @modifier @binding |> elem(2) |> elem(0)
+  @key @binding |> elem(2) |> elem(1)
+
+  @doc """
+  The sysfs file that turns the backlight off and on.
+
+  From `config :mayonnaios, :backlight_brightness`, defaulting to the panel's.
+  """
+  @spec path() :: String.t()
+  def path, do: Application.get_env(:mayonnaios, :backlight_brightness, @default_path)
+
+  @doc """
+  The input device the sleep key arrives on.
+
+  Looked up by driver name with a path fallback, because `/dev/input/eventN`
+  is probe order and not a promise. See `MayonnaiOS.Input`.
+  """
+  @spec device() :: String.t()
+  def device, do: Input.find(@device_name, @device_fallback)
+
+  @doc """
+  Whether this press is the sleep trigger, given what is currently held.
+
+  Takes the held set rather than reading it, so the launcher stays the only
+  thing that knows about button state and this stays a pure predicate.
+  """
+  @spec trigger?(MapSet.t(atom()), atom()) :: boolean()
+  def trigger?(held, key), do: triggered?(held, key)
+
+  # Which of the two shapes this is, is decided when the module is compiled:
+  # a nil modifier -- what the real power key will want -- makes the key alone
+  # the trigger, and then nothing looks at the held set at all.
+  if @modifier do
+    defp triggered?(held, key), do: key == @key and MapSet.member?(held, @modifier)
+  else
+    defp triggered?(_held, key), do: key == @key
+  end
+
+  @doc """
+  The chord, for a log line or a help screen that wants to name it.
+  """
+  @spec binding() :: {atom() | nil, atom()}
+  def binding, do: {@modifier, @key}
+
+  @doc """
+  Backlight off. `{:error, reason}` when the write does not land.
+  """
+  @spec sleep() :: :ok | {:error, File.posix()}
+  def sleep, do: write(@off, "off")
+
+  @doc """
+  Backlight on. `{:error, reason}` when the write does not land.
+  """
+  @spec wake() :: :ok | {:error, File.posix()}
+  def wake, do: write(@on, "on")
+
+  @doc """
+  Whether the backlight was last set to off.
+
+  This is what was written, not what the panel is doing; see the moduledoc.
+  An unreadable file is reported as awake, because "we cannot tell" must not
+  become "the screen is off" -- that reading is the one that would make a
+  caller swallow the button presses of someone looking at a lit screen.
+  """
+  @spec asleep?() :: boolean()
+  def asleep? do
+    case File.read(path()) do
+      {:ok, contents} ->
+        String.trim(contents) == @off
+
+      {:error, reason} ->
+        Logger.warning("[sleep] #{path()} unreadable: #{inspect(reason)}")
+        false
+    end
+  end
+
+  # Writing the value it already has is a no-op in sysfs and an :ok here, so
+  # both directions are idempotent: two sleeps leave it asleep, two wakes
+  # leave it awake, and neither has any state of its own to disagree with.
+  defp write(value, label) do
+    case File.write(path(), value) do
+      :ok ->
+        Logger.info("[sleep] backlight #{label}")
+        :ok
+
+      {:error, reason} ->
+        # Warning, with the path in it. The plausible failures are a
+        # read-only or absent sysfs node and EACCES, and each of those is a
+        # different mistake in a different file.
+        Logger.warning("[sleep] cannot turn the backlight #{label}: #{path()} #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+end

--- a/test/sleep_test.exs
+++ b/test/sleep_test.exs
@@ -1,0 +1,200 @@
+defmodule MayonnaiOS.SleepTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.{Launcher, Sleep}
+
+  # The backlight is a file, which is the whole reason this is testable on a
+  # laptop: `Sleep` writes "0" or "1" to one sysfs attribute, so pointing
+  # :backlight_brightness at a temp file exercises the same code path the
+  # device runs. What no test can check is whether the panel goes dark -- that
+  # is a GPIO on the other side of the write, and only eyes on the device
+  # answer it.
+
+  setup do
+    path = Path.join(System.tmp_dir!(), "backlight-#{System.unique_integer([:positive])}")
+    File.write!(path, "1")
+    Application.put_env(:mayonnaios, :backlight_brightness, path)
+
+    on_exit(fn ->
+      Application.delete_env(:mayonnaios, :backlight_brightness)
+      File.rm(path)
+    end)
+
+    %{path: path}
+  end
+
+  describe "the backlight write" do
+    test "turns it off and on again", %{path: path} do
+      assert Sleep.sleep() == :ok
+      assert File.read!(path) == "0"
+      assert Sleep.asleep?()
+
+      assert Sleep.wake() == :ok
+      assert File.read!(path) == "1"
+      refute Sleep.asleep?()
+    end
+
+    test "is idempotent in both directions", %{path: path} do
+      assert Sleep.sleep() == :ok
+      assert Sleep.sleep() == :ok
+      assert File.read!(path) == "0"
+      assert Sleep.asleep?()
+
+      assert Sleep.wake() == :ok
+      assert Sleep.wake() == :ok
+      assert File.read!(path) == "1"
+      refute Sleep.asleep?()
+    end
+
+    test "reports a path that is not there rather than claiming success" do
+      # The failure this project keeps producing is an inherited assumption
+      # reported as success. A sysfs node that is absent, read-only, or
+      # EACCES has to come back as an error, because the caller decides
+      # whether to swallow button presses on the strength of the answer.
+      Application.put_env(:mayonnaios, :backlight_brightness, "/nonexistent/dir/brightness")
+
+      assert Sleep.sleep() == {:error, :enoent}
+      assert Sleep.wake() == {:error, :enoent}
+    end
+
+    test "an unreadable brightness file reads as awake, not asleep" do
+      # "We cannot tell" must not become "the screen is off": that reading is
+      # the one that makes a caller eat the presses of someone staring at a
+      # lit panel.
+      Application.put_env(:mayonnaios, :backlight_brightness, "/nonexistent/dir/brightness")
+      refute Sleep.asleep?()
+    end
+
+    test "trailing whitespace from sysfs still reads as asleep", %{path: path} do
+      # Reading back a sysfs attribute normally yields a trailing newline.
+      File.write!(path, "0\n")
+      assert Sleep.asleep?()
+    end
+  end
+
+  describe "the chord" do
+    test "is Select plus a key the launcher does not otherwise bind" do
+      assert Sleep.binding() == {:btn_select, :btn_start}
+      assert Sleep.trigger?(MapSet.new([:btn_select, :btn_start]), :btn_start)
+    end
+
+    test "does not fire on the key alone" do
+      # The point of the modifier: this is a handheld in a pocket, and a bare
+      # Start must not blank the screen.
+      refute Sleep.trigger?(MapSet.new([:btn_start]), :btn_start)
+    end
+
+    test "does not fire on the modifier alone, or on the power-off chord" do
+      refute Sleep.trigger?(MapSet.new([:btn_select]), :btn_select)
+      refute Sleep.trigger?(MapSet.new([:btn_select, :btn_mode]), :btn_mode)
+    end
+  end
+
+  describe "the launcher binding" do
+    setup do
+      programs = [%{path: "/a"}, %{path: "/b"}, %{path: "/c"}]
+      Application.put_env(:mayonnaios, :programs, programs)
+      on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
+
+      # No /dev/input here, so the synthetic reports below stand in for the
+      # pad -- the same route MayonnaiOS.Keyboard uses on a laptop.
+      start_supervised!({Launcher, device: "/nonexistent/event0"})
+      :ok
+    end
+
+    test "Select+Start sleeps, and the next press only wakes", %{path: path} do
+      # A press with no release is a hold, which is all the launcher's held
+      # set records -- so this is Select held down and Start pressed.
+      press(:btn_select)
+      press(:btn_start)
+
+      assert Launcher.asleep?()
+      assert File.read!(path) == "0"
+
+      # The press that wakes must not also do what it usually does: A here
+      # would otherwise launch, and the cursor keys would move the menu.
+      press(:btn_dpad_down)
+
+      refute Launcher.asleep?()
+      assert File.read!(path) == "1"
+      assert Launcher.selected() == 0
+
+      # And the one after it is an ordinary press again.
+      press(:btn_dpad_down)
+      assert Launcher.selected() == 1
+    end
+
+    test "releasing the chord does not wake it", %{path: path} do
+      press(:btn_select)
+      press(:btn_start)
+      assert Launcher.asleep?()
+
+      # Both keys are still down when the device goes to sleep; their
+      # releases arrive a moment later and must not turn the panel straight
+      # back on.
+      release(:btn_start)
+      release(:btn_select)
+
+      assert Launcher.asleep?()
+      assert File.read!(path) == "0"
+    end
+
+    test "the press that wakes cannot be half of a chord" do
+      press(:btn_select)
+      press(:btn_start)
+      assert Launcher.asleep?()
+
+      # Select is still down as far as the kernel is concerned. Waking on it
+      # consumes the press, and the held set goes with it -- otherwise the
+      # very next Start would put the device back to sleep, and the very next
+      # Menu would power it off, from presses nobody meant as chords.
+      press(:btn_select)
+      refute Launcher.asleep?()
+
+      press(:btn_start)
+      refute Launcher.asleep?()
+    end
+
+    test "a backlight that cannot be written does not swallow anything" do
+      Application.put_env(:mayonnaios, :backlight_brightness, "/nonexistent/dir/brightness")
+
+      press(:btn_select)
+      press(:btn_start)
+
+      # The write failed, so the device is not asleep -- and the next press
+      # does its ordinary job instead of being eaten by a sleep that never
+      # happened.
+      refute Launcher.asleep?()
+      press(:btn_dpad_down)
+      assert Launcher.selected() == 1
+    end
+
+    test "sleep from a console returns the write failure" do
+      Application.put_env(:mayonnaios, :backlight_brightness, "/nonexistent/dir/brightness")
+
+      assert Launcher.sleep() == {:error, :enoent}
+      refute Launcher.asleep?()
+    end
+
+    test "sleep and wake from a console are idempotent", %{path: path} do
+      assert Launcher.sleep() == :ok
+      assert Launcher.sleep() == :ok
+      assert Launcher.asleep?()
+      assert File.read!(path) == "0"
+
+      assert Launcher.wake() == :ok
+      assert Launcher.wake() == :ok
+      refute Launcher.asleep?()
+      assert File.read!(path) == "1"
+    end
+  end
+
+  defp press(key), do: send_events([{:ev_key, key, 1}])
+  defp release(key), do: send_events([{:ev_key, key, 0}])
+
+  defp send_events(events) do
+    send(Launcher, {:input_event, "/nonexistent/event0", events})
+    # A call is ordered behind the messages above, so this is the sync point.
+    Launcher.asleep?()
+  end
+end


### PR DESCRIPTION
## Summary

Select+Start turns the panel's backlight off, and any button turns it back on
with that press swallowed so it does not also launch a game. `MayonnaiOS.Sleep`
owns the mechanism and the binding; the launcher owns the waking.

**This is not the power button.** Karl asked for the power button, and Linux
cannot see it on this board: four input devices exist (`adc-joystick`,
`gpio-keys-gamepad`, `gpio-keys-volume`, the headphone-jack switch) and none of
them carries a power key. The button is on the PMIC's PWRON pin, mainline has
the driver, and `CONFIG_INPUT_AXP20X_PEK` appears nowhere in the system repo —
neither `linux/nerves.fragment` nor `linux/linux-6.18.defconfig`. Getting the
real button therefore needs `CONFIG_INPUT_AXP20X_PEK=y` and a 2–3 hour
Buildroot rebuild, which only Karl can run. No DTS change: it is an MFD cell.
The binding is one line (`@binding` in `sleep.ex`) for exactly that day.

**Whether the panel actually goes dark can only be confirmed by someone looking
at it.** The write reaches `gpiod_set_value_cansleep`, but `actual_brightness`
is not a hardware readout (gpio-backlight has no `get_brightness` op; it echoes
what was set), so nothing in this firmware can tell working from
plausible-looking here. Nothing in this branch touched the device — it is
currently wedged.

## Approach

Backlight, not suspend. `/sys/power/mem_sleep` offers only `[s2idle]` (no
`deep`: ATF's `sun50i_h616` has no PSCI SYSTEM_SUSPEND), s2idle aborts inside
rtw88's SDIO suspend handler, there is no cpuidle driver so the cores idle in a
bare WFI either way — and **no button on the front of this device is
wakeup-capable**, only `alarmtimer.0.auto`, `musb-hdrc.2.auto` and
`7000000.rtc`. A suspend that worked would look like a brick in someone's
hands. The backlight is where the ~1.83 W idle actually goes.

`/sys/class/graphics/fb0/blank` is deliberately unused: it is writable and it
lies (`fb_blank()` records the requested value before calling the driver,
`drm_fb_helper_blank()` returns 0 unconditionally, `drm_fb_helper_dpms()` is
`void`), and the device shows it — `fb0/blank` reads `4` while the backlight
reads `1` and DSI-1 dpms reads `On`.

Select+Start rather than another chord: Select is already the modifier, Menu is
power off and stays unambiguous, Y stays unbound, and Start is bound to nothing
so the chord cannot be a fumbled single press. A failed backlight write leaves
the device awake rather than swallowing presses over a lit screen — a sleep
that silently does not sleep is this project's characteristic failure, so that
path is the one with the most tests.

## Follow-ups for reviewer

- cpufreq is not running on this device at all (the driver is a module and
  nothing loads it). That is probably a larger power win than the backlight —
  worth its own change?
- The volume rocker does not wake it, because `Diagnostics` owns that input
  device and the launcher never sees its events. Leave it, or should waking be
  a concern both processes share?
