### PR TITLE
Put battery, WiFi and the clock on every screen in one bar

### DIFF
--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -18,15 +18,8 @@ defmodule MayonnaiOS.Application do
     #
     # Set `config :mayonnaios, autostart_ui: true` once it is known good.
     children =
-      if Application.get_env(:mayonnaios, :autostart_ui, false) do
-        # fbcon owns /dev/fb0 too, and repaints over the UI on every kernel
-        # message. Release it before Scenic draws, or the scene appears for a
-        # few seconds and is then buried under scrolling kernel log.
-        MayonnaiOS.Console.release()
-        [{Scenic, [Application.get_env(:mayonnaios, :viewport)]}]
-      else
-        []
-      end ++
+      [status()] ++
+        viewport() ++
         [controller_sessions(), file_manager_sessions(), pairing_sessions()] ++
         target_children()
 
@@ -35,6 +28,34 @@ defmodule MayonnaiOS.Application do
     opts = [strategy: :one_for_one, name: MayonnaiOS.Supervisor]
     Supervisor.start_link(children, opts)
   end
+
+  defp viewport do
+    if Application.get_env(:mayonnaios, :autostart_ui, false) do
+      # fbcon owns /dev/fb0 too, and repaints over the UI on every kernel
+      # message. Release it before Scenic draws, or the scene appears for a
+      # few seconds and is then buried under scrolling kernel log.
+      MayonnaiOS.Console.release()
+      [{Scenic, [Application.get_env(:mayonnaios, :viewport)]}]
+    else
+      []
+    end
+  end
+
+  # The battery, WiFi and clock readings behind the shared top bar. On the
+  # host as well as on the device, and not in `target_children/0` with the
+  # other pollers, because the UI is run on a laptop during development and a
+  # bar with no reader behind it would spend that whole session saying "no
+  # reading" -- which is true, and not what anyone is trying to look at.
+  #
+  # First in the list, ahead of Scenic, so the bar the root scene mounts has
+  # something to subscribe to at boot. Order is not the only thing keeping
+  # that working -- the bar knocks again whenever its reading has gone stale,
+  # which is also what recovers it if this process is restarted -- but a
+  # subscription that succeeds first time is one less thing to explain.
+  #
+  # It is a poller, not a device: nothing else waits on it, and if it dies the
+  # panel says so rather than going blank.
+  defp status, do: MayonnaiOS.Status
 
   # Empty until someone starts the controller app, and on the host as well as
   # on the device: an empty DynamicSupervisor is one process and no radio, and

--- a/lib/mayonnaios/diagnostics.ex
+++ b/lib/mayonnaios/diagnostics.ex
@@ -49,8 +49,6 @@ defmodule MayonnaiOS.Diagnostics do
 
   alias MayonnaiOS.Bluetooth.HCISocket
 
-  @battery "/sys/class/power_supply/axp20x-battery"
-  @usb "/sys/class/power_supply/axp20x-usb"
   # Looked up by name at startup, with these as the fallback; see
   # `MayonnaiOS.Input` for why the numbering is not something to rely on.
   @volume_name "gpio-keys-volume"
@@ -84,6 +82,9 @@ defmodule MayonnaiOS.Diagnostics do
             # same as having asked and got nothing. See probe_bluetooth/0.
             bt_probe: {:error, :not_run},
             ticks: 0
+
+  @typedoc "One reading of everything this collector watches."
+  @type t :: %__MODULE__{}
 
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
@@ -275,17 +276,13 @@ defmodule MayonnaiOS.Diagnostics do
     end
   end
 
-  defp read_battery do
-    %{
-      capacity: read_int("#{@battery}/capacity"),
-      status: read_str("#{@battery}/status"),
-      # Microvolts and microamps; divided for display, not here.
-      voltage_uv: read_int("#{@battery}/voltage_now"),
-      current_ua: read_int("#{@battery}/current_now"),
-      health: read_str("#{@battery}/health"),
-      usb_online: read_int("#{@usb}/online") == 1
-    }
-  end
+  # The parsing lives in `MayonnaiOS.Power` rather than here, because the
+  # status bar reads the same four files and two parsers of one sysfs
+  # directory is how two screens end up disagreeing about the battery with no
+  # way to tell which is lying. This screen keeps the flat shape -- a map with
+  # nils in it -- because it colours each row separately and a partial answer
+  # is worth drawing as long as the missing half is drawn as missing.
+  defp read_battery, do: MayonnaiOS.Power.values()
 
   defp read_thermal do
     "/sys/class/thermal/thermal_zone*"

--- a/lib/mayonnaios/power.ex
+++ b/lib/mayonnaios/power.ex
@@ -1,0 +1,126 @@
+defmodule MayonnaiOS.Power do
+  @moduledoc """
+  What the AXP20x power supply says, parsed once for everyone who asks.
+
+  This used to be a private function inside `MayonnaiOS.Diagnostics`, and it
+  moved out here when the status bar needed the same four files. A second
+  parser reading the same sysfs directory is the kind of duplication that
+  ends with two screens disagreeing about the battery and no way to tell
+  which one is lying, so there is one, and `Diagnostics` calls it too.
+
+  Verified on hardware, both directions: charge and discharge both move
+  `status` and the sign of `current_now`. A sample taken while idle read
+  437000 µA at 4175000 µV, which is where the units come from -- microamps
+  and microvolts, divided at the point of display and never here.
+
+  ## An unreadable file is not a zero
+
+  `read/1` returns `{:error, :unavailable}` when the supply says nothing at
+  all, rather than a map full of zeroes or a remembered value. That
+  distinction is the whole reason this module has a return tuple: on a
+  development laptop there is no `/sys/class/power_supply`, and a status bar
+  that drew "0%" there would be indistinguishable from a flat battery. This
+  project's characteristic failure is a plausible reading that never moves,
+  so absence is reported as absence.
+
+  `values/1` is the older, flatter shape -- a map whose fields are `nil` for
+  whatever could not be read -- kept because the diagnostics screen colours
+  each row separately and wants the partial answer.
+  """
+
+  # The names are the driver's, not the chip's: mainline binds this PMIC's
+  # fuel gauge as axp20x-battery even though the part is an axp2202. Matching
+  # on the directory name is what the rest of this project does; see the note
+  # about regulator indices in the journal for why matching on a number would
+  # be worse.
+  @battery "/sys/class/power_supply/axp20x-battery"
+  @usb "/sys/class/power_supply/axp20x-usb"
+
+  @type values :: %{
+          capacity: non_neg_integer() | nil,
+          status: String.t() | nil,
+          voltage_uv: integer() | nil,
+          current_ua: integer() | nil,
+          health: String.t() | nil,
+          usb_online: boolean()
+        }
+
+  @typedoc """
+  What the supply is doing, reduced to the cases a screen draws differently.
+
+  `:unknown` is a real answer and is kept apart from `{:error, :unavailable}`:
+  the first is a supply that answered without saying which way the current is
+  going, the second is a supply that was not there.
+  """
+  @type state :: :charging | :discharging | :full | :not_charging | :unknown
+
+  @doc """
+  Every field, with `nil` for whatever could not be read.
+
+  Pass `:battery` and `:usb` to read somewhere else; that is what the tests
+  do, and it is the only way to exercise a partial or malformed supply
+  without a device.
+  """
+  @spec values(keyword()) :: values()
+  def values(opts \\ []) do
+    battery = Keyword.get(opts, :battery, @battery)
+    usb = Keyword.get(opts, :usb, @usb)
+
+    %{
+      capacity: read_int("#{battery}/capacity"),
+      status: read_str("#{battery}/status"),
+      # Microvolts and microamps; divided for display, not here.
+      voltage_uv: read_int("#{battery}/voltage_now"),
+      current_ua: read_int("#{battery}/current_now"),
+      health: read_str("#{battery}/health"),
+      usb_online: read_int("#{usb}/online") == 1
+    }
+  end
+
+  @doc """
+  The supply, or `{:error, :unavailable}` when it said nothing.
+
+  "Nothing" means neither a capacity nor a status: either one on its own is a
+  supply that is present and answering, and half an answer is worth drawing
+  as long as the missing half is drawn as missing.
+  """
+  @spec read(keyword()) :: {:ok, values()} | {:error, :unavailable}
+  def read(opts \\ []) do
+    case values(opts) do
+      %{capacity: nil, status: nil} -> {:error, :unavailable}
+      values -> {:ok, values}
+    end
+  end
+
+  @doc """
+  Which way the current is going, from the supply's own `status` file.
+
+  The string is the driver's; this maps only the values seen on this board
+  and calls anything else `:unknown` rather than guessing from the sign of
+  `current_now`. The sign is a fine cross-check and a poor primary source:
+  it reads 437000 µA while idle on a battery that is neither charging nor
+  discharging in any way a person would recognise.
+  """
+  @spec state(values() | map()) :: state()
+  def state(%{status: "Charging"}), do: :charging
+  def state(%{status: "Discharging"}), do: :discharging
+  def state(%{status: "Full"}), do: :full
+  def state(%{status: "Not charging"}), do: :not_charging
+  def state(_values), do: :unknown
+
+  defp read_str(path) do
+    case File.read(path) do
+      {:ok, v} -> String.trim(v)
+      _ -> nil
+    end
+  end
+
+  defp read_int(path) do
+    with v when is_binary(v) <- read_str(path),
+         {n, _} <- Integer.parse(v) do
+      n
+    else
+      _ -> nil
+    end
+  end
+end

--- a/lib/mayonnaios/scene/controller.ex
+++ b/lib/mayonnaios/scene/controller.ex
@@ -34,12 +34,23 @@ defmodule MayonnaiOS.Scene.Controller do
   use Scenic.Scene
 
   alias MayonnaiOS.Controller
+  alias MayonnaiOS.Scene.StatusBar
   alias Scenic.Graph
 
   import Scenic.Primitives
 
   @width 640
   @height 480
+
+  # The shared top bar owns the top of the panel on every screen, so the title
+  # starts below it. The height comes from the bar rather than being copied.
+  @status_bar StatusBar.height()
+  @title_y @status_bar + 20
+  @rule_y @status_bar + 30
+
+  @headline_y @rule_y + 52
+  @subtitle_y @headline_y + 28
+  @column_y @headline_y + 70
 
   @bg {12, 14, 22}
   @title {235, 238, 245}
@@ -65,7 +76,7 @@ defmodule MayonnaiOS.Scene.Controller do
   def handle_info(_message, scene), do: {:noreply, scene}
 
   defp refresh(scene) do
-    push_graph(scene, render(status(), scene.assigns[:error]))
+    push_graph(scene, graph(status(), scene.assigns[:error]))
   end
 
   # The app not running is a state this scene has to render rather than crash
@@ -81,28 +92,52 @@ defmodule MayonnaiOS.Scene.Controller do
 
   # -- rendering --------------------------------------------------------------
 
-  defp render(:stopped, error) do
+  @doc """
+  Build the graph for one `MayonnaiOS.Controller.status/0` reading.
+
+  Public because it is the tested surface, the same way the other screens'
+  builders are: no viewport, no driver and no framebuffer, so a host test can
+  assert what the panel says. `:stopped` with a reason renders the "not
+  running" page.
+  """
+  @spec graph(map() | :stopped, term()) :: Scenic.Graph.t()
+  def graph(status, error \\ nil)
+
+  def graph(:stopped, error) do
     base()
-    |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, 90})
-    |> text(reason(error), font_size: 16, fill: {:color, @label}, translate: {20, 120})
-    |> column(20, 160, explain(error))
+    |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, @headline_y})
+    |> text(reason(error), font_size: 16, fill: {:color, @label}, translate: {20, @subtitle_y})
+    |> column(20, @column_y, explain(error))
     |> footer("Menu goes back.")
   end
 
-  defp render(status, _error) do
+  def graph(status, _error) do
     base()
-    |> text(headline(status), font_size: 26, fill: {:color, colour(status)}, translate: {20, 90})
-    |> text(subtitle(status), font_size: 16, fill: {:color, @label}, translate: {20, 118})
-    |> column(20, 160, stages(status))
-    |> column(330, 160, facts(status))
+    |> text(headline(status),
+      font_size: 26,
+      fill: {:color, colour(status)},
+      translate: {20, @headline_y}
+    )
+    |> text(subtitle(status),
+      font_size: 16,
+      fill: {:color, @label},
+      translate: {20, @subtitle_y}
+    )
+    |> column(20, @column_y, stages(status))
+    |> column(330, @column_y, facts(status))
     |> footer("Menu leaves. Until then every button goes to the host.")
   end
 
   defp base do
     Graph.build(font: :roboto, font_size: 14)
     |> rect({@width, @height}, fill: {:color, @bg})
-    |> text("Bluetooth controller", font_size: 20, fill: {:color, @title}, translate: {20, 28})
-    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, 38})
+    |> StatusBar.mount()
+    |> text("Bluetooth controller",
+      font_size: 20,
+      fill: {:color, @title},
+      translate: {20, @title_y}
+    )
+    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, @rule_y})
   end
 
   defp footer(graph, message) do

--- a/lib/mayonnaios/scene/diagnostics.ex
+++ b/lib/mayonnaios/scene/diagnostics.ex
@@ -21,10 +21,22 @@ defmodule MayonnaiOS.Scene.Diagnostics do
 
   alias Scenic.Graph
   alias MayonnaiOS.{Audio, Diagnostics}
+  alias MayonnaiOS.Scene.StatusBar
   import Scenic.Primitives
 
   @width 640
   @height 480
+
+  # The shared top bar owns the top of the panel on every screen, so the title
+  # starts below it. The height comes from the bar rather than being copied.
+  @status_bar StatusBar.height()
+  @title_y @status_bar + 20
+  @rule_y @status_bar + 30
+
+  # Where the two columns start. The 22 px the bar took came off the top of
+  # both, and the right-hand column is the tight one: its four sections come
+  # to 374 px, which from here ends at 458 on a 480 px panel.
+  @column_y @rule_y + 24
 
   @bg {12, 14, 22}
   @title {235, 238, 245}
@@ -40,11 +52,11 @@ defmodule MayonnaiOS.Scene.Diagnostics do
   @impl Scenic.Scene
   def init(scene, _param, _opts) do
     :timer.send_interval(@refresh_ms, :refresh)
-    {:ok, push_graph(scene, render(snapshot()))}
+    {:ok, push_graph(scene, graph(snapshot()))}
   end
 
   @impl GenServer
-  def handle_info(:refresh, scene), do: {:noreply, push_graph(scene, render(snapshot()))}
+  def handle_info(:refresh, scene), do: {:noreply, push_graph(scene, graph(snapshot()))}
   def handle_info(_msg, scene), do: {:noreply, scene}
 
   # The scene must survive the collector not running -- on the host it never
@@ -65,16 +77,27 @@ defmodule MayonnaiOS.Scene.Diagnostics do
 
   # -- rendering -------------------------------------------------------------
 
-  defp render(nil) do
+  @doc """
+  Build the graph for one `MayonnaiOS.Diagnostics.snapshot/0`, or for `nil`.
+
+  Public for the same reason the other screens' builders are: it needs no
+  viewport, no driver and no framebuffer, so a host test can assert what the
+  panel says -- including that nothing is drawn in the strip the shared top
+  bar owns.
+  """
+  @spec graph(Diagnostics.t() | nil) :: Scenic.Graph.t()
+  def graph(snapshot)
+
+  def graph(nil) do
     base()
     |> text("Diagnostics collector is not running.",
       font_size: 18,
       fill: {:color, @fail},
-      translate: {20, 80}
+      translate: {20, @column_y + 18}
     )
   end
 
-  defp render(s) do
+  def graph(s) do
     base()
     |> column(20, left_rows(s))
     |> column(330, right_rows(s))
@@ -83,15 +106,20 @@ defmodule MayonnaiOS.Scene.Diagnostics do
   defp base do
     Graph.build(font: :roboto, font_size: 14)
     |> rect({@width, @height}, fill: {:color, @bg})
-    |> text("RG40XXV diagnostics", font_size: 20, fill: {:color, @title}, translate: {20, 28})
-    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, 38})
+    |> StatusBar.mount()
+    |> text("RG40XXV diagnostics",
+      font_size: 20,
+      fill: {:color, @title},
+      translate: {20, @title_y}
+    )
+    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, @rule_y})
   end
 
   # Walk a column of entries, advancing a y cursor. Headings get extra space
   # above them, so sections read as sections.
   defp column(graph, x, entries) do
     {graph, _y} =
-      Enum.reduce(entries, {graph, 62}, fn
+      Enum.reduce(entries, {graph, @column_y}, fn
         {:head, label}, {g, y} ->
           {text(g, label, font_size: 14, fill: {:color, @head}, translate: {x, y + 8}), y + 26}
 

--- a/lib/mayonnaios/scene/file_manager.ex
+++ b/lib/mayonnaios/scene/file_manager.ex
@@ -14,12 +14,13 @@ defmodule MayonnaiOS.Scene.FileManager do
   press would be a `GenServer.call` every few frames for the whole time the app
   is open, for a screen that changes only when someone presses something.
 
-  ## The top strip is left alone
+  ## The top strip belongs to the shared bar
 
-  Every app is going to get a shared top bar -- battery, WiFi, clock, at the
-  top right. It is not built here and it is not faked here; what this scene
-  does is not paint above `@status_bar`, so that when the bar arrives this
-  screen does not have to be re-laid-out around it.
+  It arrived: `MayonnaiOS.Scene.StatusBar`, mounted by every screen in this
+  firmware, drawing battery, WiFi and the clock at the top right. This scene
+  reserved the strip before there was anything in it and still does not paint
+  above `@status_bar` -- the number now comes from the bar itself rather than
+  being a second copy of it, so the reservation and the bar cannot drift.
 
   ## Why the footer says what the buttons do, on every screen
 
@@ -34,6 +35,7 @@ defmodule MayonnaiOS.Scene.FileManager do
   use Scenic.Scene
 
   alias MayonnaiOS.FileManager
+  alias MayonnaiOS.Scene.StatusBar
   alias Scenic.Graph
 
   import Scenic.Primitives
@@ -53,12 +55,11 @@ defmodule MayonnaiOS.Scene.FileManager do
   @dim {110, 125, 155}
   @row_bg {26, 34, 52}
 
-  # Reserved for the shared top bar that every app will get: battery, WiFi,
-  # clock. Nothing is drawn above this line, which is why this screen starts
-  # its own title lower than `Scene.Home` does. Text is positioned by its
-  # baseline, so the first baseline is far enough below the line that the
-  # ascenders clear it too.
-  @status_bar 30
+  # The strip the shared top bar draws in: battery, WiFi, clock. Nothing is
+  # drawn above this line. Text is positioned by its baseline, so the first
+  # baseline is far enough below the line that the ascenders clear it too --
+  # which is where every other screen's title sits now as well.
+  @status_bar StatusBar.height()
 
   @title_y 50
   @path_y 74
@@ -115,10 +116,10 @@ defmodule MayonnaiOS.Scene.FileManager do
   @doc """
   The height of the strip this scene leaves for the shared top bar.
 
-  Public so a test can assert that nothing is drawn above it -- which is the
-  only way to keep that true through later edits -- and so the status bar,
-  when someone builds it, has a number to fit into rather than a screenshot to
-  measure.
+  Public so a test can assert that nothing is drawn above it, which is the
+  only way to keep that true through later edits. The number is
+  `MayonnaiOS.Scene.StatusBar.height/0`: the bar owns its own height, and this
+  screen asks rather than remembering.
   """
   @spec status_bar() :: pos_integer()
   def status_bar, do: @status_bar
@@ -260,7 +261,8 @@ defmodule MayonnaiOS.Scene.FileManager do
   defp base(title) do
     Graph.build(font: :roboto, font_size: 16)
     |> rect({@width, @height}, fill: {:color, @bg})
-    # The title sits below the reserved strip, not in it.
+    |> StatusBar.mount()
+    # The title sits below the bar's strip, not in it.
     |> text(title, font_size: 20, fill: {:color, @title}, translate: {20, @title_y})
   end
 

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -30,10 +30,18 @@ defmodule MayonnaiOS.Scene.Home do
 
   alias Scenic.Graph
   alias MayonnaiOS.Programs
+  alias MayonnaiOS.Scene.StatusBar
   import Scenic.Primitives
 
   @width 640
   @height 480
+
+  # The shared top bar owns the top of the panel on every screen, so this one
+  # starts its title below it rather than at the top edge. The height comes
+  # from the bar rather than being copied, so moving it moves every screen.
+  @status_bar StatusBar.height()
+  @title_y @status_bar + 20
+  @rule_y @status_bar + 30
 
   # Same palette as MayonnaiOS.Scene.Diagnostics, so the two screens read
   # as one device rather than two programs that happen to share a panel.
@@ -46,8 +54,9 @@ defmodule MayonnaiOS.Scene.Home do
   @row_bg {26, 34, 52}
 
   # 34 px of pitch at font_size 20 leaves the rows legible at arm's length on
-  # a 640x480 panel held in two hands.
-  @top 64
+  # a 640x480 panel held in two hands. Ten rows from 86 end at 426, which
+  # still clears the bottom of the panel now that the top strip is the bar's.
+  @top 86
   @pitch 34
   @visible 10
 
@@ -77,11 +86,15 @@ defmodule MayonnaiOS.Scene.Home do
 
   def graph([], _selected) do
     base()
-    |> text("No programs configured.", font_size: 20, fill: {:color, @title}, translate: {20, 90})
+    |> text("No programs configured.",
+      font_size: 20,
+      fill: {:color, @title},
+      translate: {20, @top + 26}
+    )
     |> text("Set config :mayonnaios, :programs in config/target.exs.",
       font_size: 14,
       fill: {:color, @label},
-      translate: {20, 116}
+      translate: {20, @top + 52}
     )
   end
 
@@ -110,8 +123,9 @@ defmodule MayonnaiOS.Scene.Home do
   defp base do
     Graph.build(font: :roboto, font_size: 20)
     |> rect({@width, @height}, fill: {:color, @bg})
-    |> text("RG40XXV", font_size: 20, fill: {:color, @title}, translate: {20, 28})
-    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, 38})
+    |> StatusBar.mount()
+    |> text("RG40XXV", font_size: 20, fill: {:color, @title}, translate: {20, @title_y})
+    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, @rule_y})
   end
 
   defp row(graph, program, y, selected?) do
@@ -154,7 +168,7 @@ defmodule MayonnaiOS.Scene.Home do
     text(graph, "#{start + 1}-#{min(start + @visible, count)} of #{count}",
       font_size: 14,
       fill: {:color, @dim},
-      translate: {520, 28}
+      translate: {520, @title_y}
     )
   end
 end

--- a/lib/mayonnaios/scene/pairing.ex
+++ b/lib/mayonnaios/scene/pairing.ex
@@ -41,12 +41,19 @@ defmodule MayonnaiOS.Scene.Pairing do
   use Scenic.Scene
 
   alias MayonnaiOS.Pairing
+  alias MayonnaiOS.Scene.StatusBar
   alias Scenic.Graph
 
   import Scenic.Primitives
 
   @width 640
   @height 480
+
+  # The shared top bar owns the top of the panel on every screen, so the title
+  # starts below it. The height comes from the bar rather than being copied.
+  @status_bar StatusBar.height()
+  @title_y @status_bar + 20
+  @rule_y @status_bar + 30
 
   # The palette every other screen on this device uses.
   @bg {12, 14, 22}
@@ -59,9 +66,17 @@ defmodule MayonnaiOS.Scene.Pairing do
   @dim {110, 125, 155}
   @row_bg {26, 34, 52}
 
-  @top 148
+  @notice_y @rule_y + 28
+  @heading_y @notice_y + 66
+
+  @top @heading_y + 16
   @pitch 34
-  @visible 8
+  # Seven rows rather than eight. The bar took 22 px off the top of this
+  # screen, and eight rows plus the "n of m" line under them would have put
+  # that line through the footer rule -- which is the failure this scene
+  # already guards against for long names. A row of a list is a cheaper thing
+  # to give up than a line drawn over another line.
+  @visible 7
 
   @left 20
   @right 330
@@ -124,8 +139,13 @@ defmodule MayonnaiOS.Scene.Pairing do
   defp base do
     Graph.build(font: :roboto, font_size: 14)
     |> rect({@width, @height}, fill: {:color, @bg})
-    |> text("Bluetooth devices", font_size: 20, fill: {:color, @title}, translate: {20, 28})
-    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, 38})
+    |> StatusBar.mount()
+    |> text("Bluetooth devices",
+      font_size: 20,
+      fill: {:color, @title},
+      translate: {20, @title_y}
+    )
+    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, @rule_y})
   end
 
   # The one thing this screen exists to be honest about.
@@ -134,24 +154,28 @@ defmodule MayonnaiOS.Scene.Pairing do
     |> text("Headphones cannot be connected from here.",
       font_size: 18,
       fill: {:color, @wait},
-      translate: {20, 66}
+      translate: {20, @notice_y}
     )
     |> text("Audio is A2DP over BR/EDR, and this firmware has no BR/EDR host at all.",
       font_size: 13,
       fill: {:color, @label},
-      translate: {20, 88}
+      translate: {20, @notice_y + 22}
     )
     |> text("What works: seeing what is nearby, and managing pairings made as a gamepad.",
       font_size: 13,
       fill: {:color, @dim},
-      translate: {20, 106}
+      translate: {20, @notice_y + 40}
     )
   end
 
   defp heading(graph, x, title, count) do
     graph
-    |> text("#{title} (#{count})", font_size: 15, fill: {:color, @head}, translate: {x, 132})
-    |> rect({@column_width, 1}, fill: {:color, @dim}, translate: {x, 138})
+    |> text("#{title} (#{count})",
+      font_size: 15,
+      fill: {:color, @head},
+      translate: {x, @heading_y}
+    )
+    |> rect({@column_width, 1}, fill: {:color, @dim}, translate: {x, @heading_y + 6})
   end
 
   # -- the bonds, which are the only selectable thing here --------------------

--- a/lib/mayonnaios/scene/status_bar.ex
+++ b/lib/mayonnaios/scene/status_bar.ex
@@ -1,0 +1,411 @@
+defmodule MayonnaiOS.Scene.StatusBar do
+  @moduledoc """
+  The strip across the top of every screen: battery, WiFi, clock.
+
+  One component, mounted by every scene in this firmware, drawing readings
+  from `MayonnaiOS.Status`. It is a `Scenic.Component`, so each scene adds one
+  line to its graph and gets its own instance -- and because a component is a
+  scene in its own right, the bar repaints on its own clock without the screen
+  underneath it being rebuilt. The launcher menu still redraws only when
+  somebody presses something.
+
+  ## "Every app" means every Scenic scene, and RetroArch is not one
+
+  The five screens in this firmware are the launcher, diagnostics, the file
+  manager, the Bluetooth devices app and the Bluetooth controller app. All
+  five mount this. What the launcher *launches* is a different matter:
+  RetroArch and kmscube are external processes that open the display and hold
+  it until they exit. Nothing in this VM is drawing while they run, there is
+  no compositor on this device, and a bar over a game is not something this
+  code could provide by trying harder. So while a program owns the screen
+  there is no status bar, and that is a property of the arrangement rather
+  than a gap to be filled later.
+
+  ## Nothing is drawn from a reading that has gone quiet
+
+  `MayonnaiOS.Status` stamps every reading with the time it was taken. Once a
+  reading is older than `@stale_ms` -- six seconds, three missed polls -- this
+  stops drawing the number and says `no reading` instead.
+
+  That is the point of the whole arrangement rather than a nicety. This
+  project's characteristic failure is a plausible value that never moves: an
+  `hci0` that existed while Bluetooth was dead, CI green on an image with no
+  GPU, a battery percentage that looked right and was a memory. A bar that
+  kept drawing 87% after the reader wedged would be the same bug in a more
+  prominent place, and it would be believed, because it is next to a clock
+  that is still ticking.
+
+  So the two are separated deliberately: the clock is read here, at the
+  moment of drawing, and cannot be stale in this sense; the battery and the
+  WiFi state come from another process and are drawn only while they are
+  fresh. If the panel itself freezes, everything on it is stale and nothing
+  in here can say so -- that is what the heartbeat LED is for.
+
+  ## The clock says UTC because the clock is UTC
+
+  There is no timezone database in this image -- no `tzdata`, nothing for
+  `DateTime.shift_zone/2` to resolve -- and the RTC keeps UTC, which the
+  kernel copies into system time at boot (`hctosys`, and the diagnostics
+  screen has the row that proves it). So the bar shows UTC and says so. A bar
+  showing `15:42` with no qualifier, an hour or two off whoever is holding it,
+  is worse than one that admits which clock it is reading.
+
+  A year before 2020 is drawn as `clock unset` rather than as a time, because
+  that is what an RTC that lost its charge looks like, and 1970 rendered as
+  `01:34` is a confident lie.
+  """
+
+  use Scenic.Component, has_children: false
+
+  alias MayonnaiOS.{Power, Status}
+  alias Scenic.Assets.Static
+  alias Scenic.Graph
+
+  import Scenic.Primitives
+
+  @width 640
+
+  # The height of the strip. `MayonnaiOS.Scene.FileManager` reserved this
+  # before the bar existed and its test asserts the reservation; the number
+  # now lives here, and that scene takes it from `height/0`, so there is one
+  # place to change it.
+  @height 30
+
+  # Same palette as every scene, so the bar reads as part of the device rather
+  # than as a widget bolted onto it. The background is two shades lighter than
+  # the screens' own so the strip is visible as a strip.
+  @bar_bg {20, 25, 38}
+  @title {235, 238, 245}
+  @label {150, 165, 195}
+  @pass {120, 220, 150}
+  @fail {245, 110, 120}
+  @wait {235, 190, 90}
+  @dim {110, 125, 155}
+
+  # A reading older than this is not drawn. Three missed polls of
+  # `MayonnaiOS.Status`, which polls every two seconds: long enough that a
+  # busy moment does not make the panel flicker into "no reading", short
+  # enough that a wedged reader is visible before anyone acts on the number.
+  @stale_ms 6_000
+
+  # Once a second, for the clock and for noticing that the reader has gone
+  # quiet. Most ticks change nothing, and `render/1` compares what it is about
+  # to draw with what it drew and pushes nothing when they match -- so the
+  # steady state is one graph push a minute, when the minute changes.
+  @tick_ms 1_000
+
+  # Laid out from the right edge leftwards, because the right edge is the
+  # thing that has to stay put: the fields grow and shrink with their own
+  # text, and a fixed left origin would let a long word walk off the panel.
+  @right 626
+  @gap 16
+  @baseline 20
+  @font 13
+  # 12 is the smallest size anything on this device draws at; the word "wifi"
+  # is context rather than a reading, so it gets the floor and not less.
+  @small 12
+
+  @doc "The height of the strip. Scenes leave this much room and draw below it."
+  @spec height() :: pos_integer()
+  def height, do: @height
+
+  @doc """
+  Add the bar to a scene's graph.
+
+  Every scene calls this from whatever builds its background, so a screen
+  cannot exist without it.
+  """
+  @spec mount(Graph.t(), keyword()) :: Graph.t()
+  def mount(graph, opts \\ []) do
+    add_to_graph(graph, Map.new(opts), id: :status_bar)
+  end
+
+  @impl Scenic.Component
+  def validate(nil), do: {:ok, %{}}
+  def validate(opts) when is_map(opts), do: {:ok, opts}
+  def validate(opts) when is_list(opts), do: {:ok, Map.new(opts)}
+
+  def validate(other) do
+    {:error, "#{inspect(other)} is not status bar options; pass nil or a map"}
+  end
+
+  @impl Scenic.Scene
+  def init(scene, param, _opts) do
+    server = server(param)
+
+    # A cast, so a reader that is missing or wedged cannot stop the root scene
+    # from starting. See `MayonnaiOS.Status.subscribe/1`.
+    Status.subscribe(server)
+    :timer.send_interval(@tick_ms, :tick)
+
+    {:ok, scene |> assign(server: server, reading: nil, drawn: nil) |> render()}
+  end
+
+  @impl GenServer
+  def handle_info({:mayonnaios_status, reading}, scene) do
+    {:noreply, scene |> assign(reading: reading) |> render()}
+  end
+
+  def handle_info(:tick, scene) do
+    knock(scene)
+    {:noreply, render(scene)}
+  end
+
+  def handle_info(_message, scene), do: {:noreply, scene}
+
+  defp server(%{server: server}), do: server
+  defp server(_param), do: Status
+
+  # While there is nothing fresh to draw, ask again -- once a second, as a
+  # cast, which costs a message.
+  #
+  # A subscription is held by the reader, so it is lost whenever the reader is
+  # lost: a `MayonnaiOS.Status` that crashed and was restarted by the
+  # supervisor has no subscribers, and the scenes mounted before it would
+  # otherwise say "no reading" until the launcher next tore them down. Knocking
+  # while stale also covers the reverse ordering at boot, a bar mounted before
+  # the reader exists. It stops as soon as a reading arrives, so a healthy
+  # device sends none of these.
+  defp knock(scene) do
+    if stale?(scene.assigns.reading) do
+      Status.subscribe(scene.assigns.server)
+    end
+
+    :ok
+  end
+
+  # The same freshness rule the drawing uses, so there is no way for the bar to
+  # be knocking while it draws numbers or drawing dashes while it sits quiet.
+  defp stale?(reading) do
+    now = System.monotonic_time(:millisecond)
+    Enum.any?([:battery, :wifi], &(fresh(reading, &1, now) == :stale))
+  end
+
+  defp render(scene) do
+    fields = fields(scene.assigns.reading)
+
+    if fields == scene.assigns.drawn do
+      scene
+    else
+      scene |> assign(drawn: fields) |> push_graph(graph(fields))
+    end
+  end
+
+  # -- what the bar says ------------------------------------------------------
+
+  @doc """
+  What the bar would draw for a reading, as words.
+
+  Public because it is the tested surface, and because the words are the
+  interesting part: whether a stale battery reads `no reading` rather than
+  `87%` is a property worth asserting without a framebuffer.
+
+  Options are for the tests: `:now` is a monotonic millisecond reading to
+  measure the reading's age against, `:utc` is the `DateTime` to draw as the
+  clock.
+  """
+  @spec fields(Status.reading() | nil, keyword()) :: map()
+  def fields(reading, opts \\ []) do
+    now = Keyword.get_lazy(opts, :now, fn -> System.monotonic_time(:millisecond) end)
+    utc = Keyword.get_lazy(opts, :utc, fn -> DateTime.utc_now() end)
+
+    %{
+      battery: battery(fresh(reading, :battery, now)),
+      wifi: wifi(fresh(reading, :wifi, now)),
+      clock: clock(utc)
+    }
+  end
+
+  # A source is only itself while it is fresh. Anything else -- never heard
+  # from, heard from too long ago -- collapses to :stale here, once, so that
+  # no drawing code further down can accidentally reach a remembered value.
+  defp fresh(nil, _key, _now), do: :stale
+
+  defp fresh(reading, key, now) do
+    case Map.get(reading, key) do
+      %{at: at} = source when is_integer(at) ->
+        if now - at > @stale_ms, do: :stale, else: source
+
+      _missing ->
+        :stale
+    end
+  end
+
+  defp battery(:stale), do: %{percent: "--", level: nil, word: "no reading", colour: @fail}
+
+  defp battery(%{error: reason}) when not is_nil(reason) do
+    %{percent: "--", level: nil, word: "no battery", colour: @wait}
+  end
+
+  defp battery(%{value: values}) do
+    {word, colour} = state_word(Power.state(values))
+
+    %{
+      percent: percent(values[:capacity]),
+      level: level(values[:capacity]),
+      word: word,
+      colour: colour
+    }
+  end
+
+  defp percent(nil), do: "--"
+  defp percent(capacity), do: "#{capacity}%"
+
+  defp level(capacity) when is_integer(capacity), do: min(max(capacity, 0), 100)
+  defp level(_capacity), do: nil
+
+  # The state is always shown, including the boring one. "on battery" that
+  # never becomes "charging" while the cable is in is a fault someone can see;
+  # a bar that only marks charging leaves the same fault looking like normal.
+  defp state_word(:charging), do: {"charging", @pass}
+  defp state_word(:discharging), do: {"on battery", @label}
+  defp state_word(:full), do: {"full", @pass}
+  defp state_word(:not_charging), do: {"not charging", @wait}
+  defp state_word(:unknown), do: {"no state", @wait}
+
+  defp wifi(:stale), do: %{word: "no reading", colour: @fail}
+  defp wifi(%{error: :not_managed}), do: %{word: "not managed", colour: @dim}
+  defp wifi(%{error: :no_interface}), do: %{word: "no wlan0", colour: @wait}
+  defp wifi(%{error: reason}) when not is_nil(reason), do: %{word: "unavailable", colour: @wait}
+  defp wifi(%{value: :internet}), do: %{word: "internet", colour: @pass}
+  defp wifi(%{value: :lan}), do: %{word: "lan only", colour: @wait}
+  defp wifi(%{value: :disconnected}), do: %{word: "no network", colour: @fail}
+  defp wifi(%{value: other}), do: %{word: clip(to_string(other), 12), colour: @wait}
+
+  # An RTC that lost its charge comes up in 1970, and 1970 drawn as a time is
+  # a clock that is confidently wrong. 2020 rather than the build year because
+  # any plausible date is fine here; the check is for a clock that was never
+  # set at all.
+  defp clock(%DateTime{year: year}) when year < 2020, do: %{text: "clock unset", colour: @wait}
+
+  defp clock(utc) do
+    %{text: "#{pad(utc.hour)}:#{pad(utc.minute)} UTC", colour: @title}
+  end
+
+  defp pad(n), do: String.pad_leading(to_string(n), 2, "0")
+
+  defp clip(text, limit) do
+    if String.length(text) > limit, do: String.slice(text, 0, limit - 1) <> "…", else: text
+  end
+
+  # -- drawing ----------------------------------------------------------------
+
+  @doc """
+  Build the bar's graph for a set of fields.
+
+  Takes the output of `fields/2` so that the words and the drawing can be
+  tested apart: what the bar says is arithmetic on a reading, where it says it
+  is arithmetic on font metrics.
+  """
+  @spec graph(map()) :: Graph.t()
+  def graph(fields) do
+    graph =
+      Graph.build(font: :roboto, font_size: @font)
+      |> rect({@width, @height}, fill: {:color, @bar_bg})
+      # A one-pixel rule rather than a border, and in the dim grey the footers
+      # use, so the strip is separated from the screen without competing with
+      # the blue rule each scene draws under its own title.
+      |> rect({@width, 1}, fill: {:color, @dim}, translate: {0, @height - 1})
+
+    {graph, left} = clock_field(graph, fields.clock, @right)
+    {graph, left} = wifi_field(graph, fields.wifi, left - @gap)
+    {graph, _left} = battery_field(graph, fields.battery, left - @gap)
+
+    graph
+  end
+
+  defp clock_field(graph, clock, right) do
+    x = right - width(clock.text, @font)
+
+    {text(graph, clock.text,
+       font_size: @font,
+       fill: {:color, clock.colour},
+       translate: {x, @baseline}
+     ), x}
+  end
+
+  # The word "wifi" in front of the state, small and grey. No signal bars:
+  # what VintageNet publishes here is whether the interface has a network and
+  # whether that network reaches the internet, not a signal strength, and
+  # three bars mean strength to everyone who has ever seen a phone.
+  defp wifi_field(graph, wifi, right) do
+    label_w = width("wifi", @small)
+    word_w = width(wifi.word, @font)
+    x = right - (label_w + 5 + word_w)
+
+    graph =
+      graph
+      |> text("wifi", font_size: @small, fill: {:color, @dim}, translate: {x, @baseline})
+      |> text(wifi.word,
+        font_size: @font,
+        fill: {:color, wifi.colour},
+        translate: {x + label_w + 5, @baseline}
+      )
+
+    {graph, x}
+  end
+
+  defp battery_field(graph, battery, right) do
+    percent_w = width(battery.percent, @font)
+    word_w = width(battery.word, @font)
+    icon_w = 25
+    x = right - (icon_w + 6 + percent_w + 6 + word_w)
+
+    graph =
+      graph
+      |> icon(x, battery)
+      |> text(battery.percent,
+        font_size: @font,
+        fill: {:color, @title},
+        translate: {x + icon_w + 6, @baseline}
+      )
+      |> text(battery.word,
+        font_size: @font,
+        fill: {:color, battery.colour},
+        translate: {x + icon_w + 6 + percent_w + 6, @baseline}
+      )
+
+    {graph, x}
+  end
+
+  # The outline is always drawn; the fill only when there is a level to draw.
+  # An empty outline is the honest picture of "no reading", and it is a
+  # different picture from a flat battery, which draws a red sliver.
+  defp icon(graph, x, %{level: nil} = battery) do
+    body(graph, x, battery.colour)
+  end
+
+  defp icon(graph, x, %{level: level}) do
+    graph
+    |> body(x, @label)
+    |> rect({max(round(18 * level / 100), 1), 9},
+      fill: {:color, level_colour(level)},
+      translate: {x + 2, 10}
+    )
+  end
+
+  defp body(graph, x, colour) do
+    graph
+    |> rect({22, 13}, stroke: {1, colour}, translate: {x, 8})
+    |> rect({3, 5}, fill: {:color, colour}, translate: {x + 22, 12})
+  end
+
+  # Colour by charge, not by whether it is charging: a battery at 8% is worth
+  # a red bar whether or not the cable is in, and the word next to it already
+  # says which.
+  defp level_colour(level) when level < 15, do: @fail
+  defp level_colour(level) when level < 40, do: @wait
+  defp level_colour(_level), do: @pass
+
+  # Measured rather than estimated, using the same metrics Scenic's own
+  # components use, because the layout runs right to left and an estimate that
+  # is 10% short puts two fields on top of each other. The fallback is for a
+  # host with no asset library compiled -- a wrong-looking bar in a test is
+  # better than a scene that cannot build a graph.
+  defp width(text, size) do
+    case Static.meta(:roboto) do
+      {:ok, {Static.Font, metrics}} -> FontMetrics.width(text, size, metrics)
+      _other -> String.length(text) * size * 0.55
+    end
+  end
+end

--- a/lib/mayonnaios/status.ex
+++ b/lib/mayonnaios/status.ex
@@ -1,0 +1,252 @@
+defmodule MayonnaiOS.Status do
+  @moduledoc """
+  One process that reads the battery and the network, and pushes what it got.
+
+  `MayonnaiOS.Scene.StatusBar` draws this. Every scene mounts that component,
+  so whatever is on screen, the same readings are behind it and there is one
+  place that does the reading.
+
+  ## Why the scenes do not read sysfs themselves
+
+  Because a file read on this device has been observed to block forever. A
+  `:prim_file.read_file_nif/1` stuck in the kernel filled the dirty-IO
+  schedulers one at a time while pure Elixir kept evaluating over SSH, and
+  every filesystem operation after that hung. A status bar that read
+  `/sys/class/power_supply` from the scene process would, in that state, take
+  the whole panel down with it: no menu, no file manager, no diagnostics, and
+  no clue why.
+
+  So the read happens here, and the readings arrive at the scenes as
+  messages. A poll that never returns costs the bar its battery reading and
+  costs the rest of the screen nothing -- and because every reading carries
+  the time it was taken, the bar can say that it has stopped hearing from
+  this process instead of drawing the last number as though it were current.
+
+  ## Why not ask Diagnostics
+
+  `MayonnaiOS.Diagnostics` already reads the same four files once a second,
+  and the parsing *is* shared -- both go through `MayonnaiOS.Power`, so there
+  is one place that knows what `current_now` means. What is not shared is the
+  process, and that is deliberate. `Diagnostics.snapshot/0` is a
+  `GenServer.call`, and that collector has a handler which holds it for
+  seconds by design: the Bluetooth probe owns hci0 for as long as it runs. The
+  diagnostics screen already carries a rescue and a catch for exactly that. A
+  bar on every screen, calling into that process once a second, would make the
+  most-glanced-at thing on the panel depend on the least available process on
+  the device.
+
+  So: one parser, two callers, and this caller cannot be blocked by anything
+  but its own read.
+
+  ## What is pushed
+
+  Subscribers receive `{:mayonnaios_status, reading}` where a reading is
+
+      %{
+        battery: %{value: MayonnaiOS.Power.values() | nil, error: term | nil, at: integer | nil},
+        wifi:    %{value: atom, error: term | nil, at: integer | nil},
+        at: integer
+      }
+
+  `at` is `System.monotonic_time(:millisecond)`, which is only comparable
+  within one VM -- which is all it has to be, since the process that draws it
+  is a scene in this VM. Wall-clock time would be the wrong choice here: the
+  RTC is set at boot and NTP may step it afterwards, and an age computed
+  across a step is exactly the kind of number that looks fine and is wrong.
+
+  ## WiFi is both subscribed and polled, on purpose
+
+  `VintageNet.subscribe/1` delivers property changes as they happen, which is
+  how a disconnection reaches the panel within a frame instead of within a
+  poll. But a subscription that has stopped arriving is indistinguishable
+  from a network that has stopped changing, and "the WiFi state has not
+  changed for an hour" is the normal case. So each poll also re-reads the
+  property with `VintageNet.get/1`. That is an ETS read of a table this VM
+  owns, not an I/O call -- it cannot block on hardware -- and it means the
+  freshness of the WiFi reading is a statement about this process still
+  running rather than about the radio still changing its mind.
+  """
+
+  use GenServer
+  require Logger
+
+  alias MayonnaiOS.Power
+
+  # Two seconds. The battery moves in percent over minutes, and the point of
+  # polling faster than that is not the battery: it is that a subscriber can
+  # only notice this process has gone quiet against some expected rhythm, and
+  # a slow rhythm means a long wait before the panel admits it.
+  @poll_ms 2_000
+
+  # The interface the bar reports on. The device-wide ["connection"] property
+  # would also count usb0, which is up whenever the cable is in and would
+  # make a dead radio look like a working network.
+  @interface "wlan0"
+
+  defstruct [:battery_opts, :poll_ms, :timer, battery: nil, wifi: nil, subscribers: %{}]
+
+  @typedoc "A single reading, with the time it was taken."
+  @type source :: %{value: term() | nil, error: term() | nil, at: integer() | nil}
+
+  @type reading :: %{battery: source(), wifi: source(), at: integer()}
+
+  @doc """
+  Start the reader.
+
+  Options: `:name`, `:poll_ms`, and `:battery`/`:usb` paths passed through to
+  `MayonnaiOS.Power`. The tests use all of them; the application uses none.
+  """
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Ask to be sent every reading, starting with the one it has now.
+
+  A cast rather than a call, and that is the whole design of this function. It
+  is invoked from `MayonnaiOS.Scene.StatusBar.init/3`, which runs while the
+  ViewPort is starting the root scene at boot: a call there would block the
+  panel behind this process, and a call to a name nobody has registered would
+  raise and take the root scene -- and therefore the whole screen -- with it.
+  A cast to a dead name is a no-op, and a bar that never hears anything says
+  so, which is the correct thing for it to say.
+  """
+  @spec subscribe(GenServer.server()) :: :ok
+  def subscribe(server \\ __MODULE__) do
+    GenServer.cast(server, {:subscribe, self()})
+  end
+
+  @doc """
+  The current reading, for a person at an IEx prompt.
+
+  Deliberately not what the status bar uses: this is a call, and a call is
+  the thing the bar must not do. The default timeout is short so that a
+  wedged reader answers a human with an exit rather than a hang.
+  """
+  @spec reading(GenServer.server(), timeout()) :: reading()
+  def reading(server \\ __MODULE__, timeout \\ 1_000) do
+    GenServer.call(server, :reading, timeout)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    poll_ms = Keyword.get(opts, :poll_ms, @poll_ms)
+    battery_opts = Keyword.take(opts, [:battery, :usb])
+
+    subscribe_to_vintage_net()
+
+    state =
+      %__MODULE__{battery_opts: battery_opts, poll_ms: poll_ms}
+      |> poll()
+
+    {:ok, %{state | timer: schedule(poll_ms)}}
+  end
+
+  @impl GenServer
+  def handle_call(:reading, _from, state), do: {:reply, snapshot(state), state}
+
+  @impl GenServer
+  def handle_cast({:subscribe, pid}, state) do
+    # Monitored rather than linked: a scene that dies while a program is
+    # launched must not take the reader with it, and the reader must not
+    # accumulate the ghosts of every scene the launcher has ever mounted.
+    state =
+      if Map.has_key?(state.subscribers, pid) do
+        state
+      else
+        %{state | subscribers: Map.put(state.subscribers, pid, Process.monitor(pid))}
+      end
+
+    send(pid, {:mayonnaios_status, snapshot(state)})
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info(:poll, state) do
+    state = poll(state)
+    publish(state)
+    {:noreply, %{state | timer: schedule(state.poll_ms)}}
+  end
+
+  # A property changed. Taken as a fresh WiFi reading -- it is one -- and
+  # published immediately, so a disconnection does not wait for the next poll.
+  def handle_info({VintageNet, [_, @interface, "connection"], _old, new, _meta}, state) do
+    state = %{state | wifi: source(new)}
+    publish(state)
+    {:noreply, state}
+  end
+
+  def handle_info({VintageNet, _property, _old, _new, _meta}, state), do: {:noreply, state}
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | subscribers: Map.delete(state.subscribers, pid)}}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # -- reading ---------------------------------------------------------------
+
+  defp poll(state) do
+    %{state | battery: read_battery(state.battery_opts), wifi: read_wifi()}
+  end
+
+  defp read_battery(opts) do
+    case Power.read(opts) do
+      {:ok, values} -> source(values)
+      {:error, reason} -> error(reason)
+    end
+  end
+
+  # VintageNet is a target-only dependency, so on a development laptop there
+  # is nothing to ask. That is reported as an error rather than as
+  # "disconnected": a laptop running this UI has a network, and a bar claiming
+  # otherwise would be a bar nobody believes when it matters.
+  defp read_wifi do
+    if Code.ensure_loaded?(VintageNet) do
+      case apply(VintageNet, :get, [["interface", @interface, "connection"]]) do
+        nil -> error(:no_interface)
+        value -> source(value)
+      end
+    else
+      error(:not_managed)
+    end
+  rescue
+    # get/1 reads a property table owned by the vintage_net application. If
+    # that application is not running the table is not there, and this is a
+    # bar, not a supervisor -- it says it does not know.
+    error -> error(error)
+  end
+
+  defp subscribe_to_vintage_net do
+    if Code.ensure_loaded?(VintageNet) do
+      apply(VintageNet, :subscribe, [["interface", @interface, "connection"]])
+    end
+  rescue
+    error ->
+      Logger.warning("[status] VintageNet.subscribe failed: #{inspect(error)}")
+      :error
+  end
+
+  # -- plumbing --------------------------------------------------------------
+
+  defp source(value), do: %{value: value, error: nil, at: now()}
+  defp error(reason), do: %{value: nil, error: reason, at: now()}
+
+  defp snapshot(state) do
+    %{battery: state.battery, wifi: state.wifi, at: now()}
+  end
+
+  defp publish(state) do
+    reading = snapshot(state)
+    for {pid, _ref} <- state.subscribers, do: send(pid, {:mayonnaios_status, reading})
+    :ok
+  end
+
+  # send_after rather than send_interval: if a poll ever does block forever,
+  # an interval timer would queue a message every two seconds behind it, and
+  # the mailbox would grow for as long as the device stayed up.
+  defp schedule(poll_ms), do: Process.send_after(self(), :poll, poll_ms)
+
+  defp now, do: System.monotonic_time(:millisecond)
+end

--- a/test/pairing_test.exs
+++ b/test/pairing_test.exs
@@ -313,7 +313,7 @@ defmodule MayonnaiOS.PairingTest do
       assert "Nothing has advertised yet." in texts
     end
 
-    test "windows the paired hosts so a selection past the eighth is still drawn" do
+    test "windows the paired hosts so a selection past the last visible one is drawn" do
       bonds =
         for i <- 1..12 do
           %{
@@ -336,7 +336,12 @@ defmodule MayonnaiOS.PairingTest do
 
       assert "012:00:00:00:00:00" in texts
       refute "01:00:00:00:00:00" in texts
-      assert "5-12 of 12" in texts
+      # Seven rows, not eight: the shared top bar took 22 px off the top of
+      # this screen and the eighth row's counter would have landed on the
+      # footer rule. The number is here rather than read from the scene on
+      # purpose -- if the window shrinks again, this test is what should
+      # notice.
+      assert "6-12 of 12" in texts
     end
 
     test "a long name is clipped rather than drawn over the footer" do

--- a/test/status_bar_test.exs
+++ b/test/status_bar_test.exs
@@ -1,0 +1,441 @@
+defmodule MayonnaiOS.StatusBarTest do
+  # Not async: it starts named processes and reads the application
+  # environment, both of which are one global.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.{Power, Programs, Status}
+  alias MayonnaiOS.Scene.StatusBar
+
+  # A sysfs battery directory, with the values read off this device: 437000 µA
+  # at 4175000 µV while idle. Written to a temp directory rather than mocked,
+  # because the thing being tested is the parsing of files whose format is the
+  # kernel's, and a mock would only assert that this test agrees with itself.
+  setup do
+    id = System.unique_integer([:positive])
+    battery = Path.join(System.tmp_dir!(), "battery-#{id}")
+    usb = Path.join(System.tmp_dir!(), "usb-#{id}")
+
+    File.mkdir_p!(battery)
+    File.mkdir_p!(usb)
+
+    write = fn dir, name, value -> File.write!(Path.join(dir, name), "#{value}\n") end
+
+    write.(battery, "capacity", 62)
+    write.(battery, "status", "Discharging")
+    write.(battery, "voltage_now", 4_175_000)
+    write.(battery, "current_now", 437_000)
+    write.(battery, "health", "Good")
+    write.(usb, "online", 0)
+
+    on_exit(fn ->
+      File.rm_rf(battery)
+      File.rm_rf(usb)
+    end)
+
+    %{battery: battery, usb: usb, write: write}
+  end
+
+  describe "Power" do
+    test "reads what the supply says", %{battery: battery, usb: usb} do
+      assert {:ok, values} = Power.read(battery: battery, usb: usb)
+
+      assert values.capacity == 62
+      assert values.status == "Discharging"
+      # Microvolts and microamps, undivided: the display divides, the reader
+      # does not, so nothing downstream has to guess which it was given.
+      assert values.voltage_uv == 4_175_000
+      assert values.current_ua == 437_000
+      assert values.usb_online == false
+      assert Power.state(values) == :discharging
+    end
+
+    test "a supply that is not there is unavailable, not empty" do
+      # The distinction the whole status bar rests on. A laptop has no
+      # /sys/class/power_supply, and "0%" there would be indistinguishable
+      # from a flat battery on the device.
+      assert Power.read(battery: "/nonexistent/battery", usb: "/nonexistent/usb") ==
+               {:error, :unavailable}
+
+      assert Power.values(battery: "/nonexistent/battery", usb: "/nonexistent/usb") == %{
+               capacity: nil,
+               status: nil,
+               voltage_uv: nil,
+               current_ua: nil,
+               health: nil,
+               usb_online: false
+             }
+    end
+
+    test "half an answer is still an answer", %{battery: battery, usb: usb, write: write} do
+      File.rm!(Path.join(battery, "capacity"))
+      write.(battery, "status", "Charging")
+
+      assert {:ok, values} = Power.read(battery: battery, usb: usb)
+      assert values.capacity == nil
+      assert Power.state(values) == :charging
+    end
+
+    test "a status this board has never produced is unknown, not guessed", %{
+      battery: battery,
+      write: write
+    } do
+      write.(battery, "status", "Quantum")
+      assert Power.state(Power.values(battery: battery)) == :unknown
+
+      # And the sign of current_now is not used to fill the gap: it reads
+      # 437000 µA on an idle battery, which is neither charging nor
+      # discharging in any sense a person would recognise.
+      refute Power.state(Power.values(battery: battery)) == :discharging
+    end
+  end
+
+  describe "Status" do
+    test "pushes a reading to whoever subscribed", %{battery: battery, usb: usb} do
+      server = start_reader(battery: battery, usb: usb)
+
+      Status.subscribe(server)
+
+      assert_receive {:mayonnaios_status, reading}
+      assert reading.battery.value.capacity == 62
+      assert reading.battery.error == nil
+      # Stamped with the time it was taken. Without this the bar cannot tell a
+      # reading from a memory of one.
+      assert is_integer(reading.battery.at)
+    end
+
+    test "keeps pushing on its own clock", %{battery: battery, usb: usb} do
+      server = start_reader(battery: battery, usb: usb, poll_ms: 20)
+
+      Status.subscribe(server)
+      assert_receive {:mayonnaios_status, first}
+      assert_receive {:mayonnaios_status, second}
+
+      assert second.battery.at >= first.battery.at
+    end
+
+    test "an absent supply is reported as absent" do
+      server = start_reader(battery: "/nonexistent/battery", usb: "/nonexistent/usb")
+
+      Status.subscribe(server)
+
+      assert_receive {:mayonnaios_status, reading}
+      assert reading.battery.value == nil
+      assert reading.battery.error == :unavailable
+    end
+
+    test "WiFi says it is not managed rather than saying disconnected" do
+      # VintageNet is a target-only dependency, so this is the host case: no
+      # radio to ask. Reporting :disconnected here would be a bar that cries
+      # wolf on every development machine.
+      refute Code.ensure_loaded?(VintageNet)
+
+      server = start_reader([])
+      Status.subscribe(server)
+
+      assert_receive {:mayonnaios_status, reading}
+      assert reading.wifi.error == :not_managed
+    end
+
+    test "a subscriber that dies does not take the reader with it", %{
+      battery: battery,
+      usb: usb
+    } do
+      server = start_reader(battery: battery, usb: usb)
+
+      subscriber = spawn(fn -> Status.subscribe(server) end)
+      ref = Process.monitor(subscriber)
+      assert_receive {:DOWN, ^ref, :process, ^subscriber, _reason}
+
+      Status.subscribe(server)
+      assert_receive {:mayonnaios_status, _reading}
+      assert Process.alive?(Process.whereis(server))
+    end
+  end
+
+  describe "what the bar says" do
+    test "a fresh reading is drawn as a reading", %{battery: battery, usb: usb, write: write} do
+      write.(battery, "status", "Charging")
+      reading = one_reading(battery: battery, usb: usb)
+
+      fields = StatusBar.fields(reading)
+
+      assert fields.battery.percent == "62%"
+      assert fields.battery.word == "charging"
+      assert fields.battery.level == 62
+    end
+
+    test "a reading that has gone quiet is not drawn at all", %{battery: battery, usb: usb} do
+      reading = one_reading(battery: battery, usb: usb)
+
+      # Six seconds and one millisecond after the reading was taken: the
+      # reader has missed three polls. This is the test the whole design is
+      # for -- the failure this project keeps repeating is a plausible value
+      # that never moves, and the bar is the most believed place on the panel
+      # to repeat it.
+      stale = StatusBar.fields(reading, now: reading.battery.at + 6_001)
+
+      assert stale.battery.percent == "--"
+      assert stale.battery.word == "no reading"
+      assert stale.battery.level == nil
+      assert stale.wifi.word == "no reading"
+
+      # And a reading a millisecond inside the window is still drawn, so the
+      # bar does not flicker into "no reading" on a busy device.
+      fresh = StatusBar.fields(reading, now: reading.battery.at + 5_999)
+      assert fresh.battery.percent == "62%"
+    end
+
+    test "a bar that has never heard anything says so" do
+      fields = StatusBar.fields(nil)
+
+      assert fields.battery.word == "no reading"
+      assert fields.wifi.word == "no reading"
+    end
+
+    test "the state is shown even when it is the boring one" do
+      # A bar that only marks charging leaves "the cable is in and nothing is
+      # happening" looking exactly like a normal discharge.
+      assert words(:discharging).battery.word == "on battery"
+      assert words(:charging).battery.word == "charging"
+      assert words(:full).battery.word == "full"
+      assert words(:unknown).battery.word == "no state"
+    end
+
+    test "the clock says which clock it is" do
+      {:ok, noon} = DateTime.new(~D[2026-08-22], ~T[14:32:07], "Etc/UTC")
+
+      # There is no timezone database in this image, so UTC is the only honest
+      # thing the panel can claim -- and it claims it in the text rather than
+      # in a moduledoc nobody holding the device can read.
+      assert StatusBar.fields(nil, utc: noon).clock.text == "14:32 UTC"
+    end
+
+    test "an RTC that was never set is not drawn as a time" do
+      {:ok, epoch} = DateTime.new(~D[1970-01-01], ~T[01:34:00], "Etc/UTC")
+
+      assert StatusBar.fields(nil, utc: epoch).clock.text == "clock unset"
+    end
+
+    test "a WiFi state is a word, and an unknown one is not invented" do
+      assert wifi(%{value: :internet, error: nil}).word == "internet"
+      assert wifi(%{value: :lan, error: nil}).word == "lan only"
+      assert wifi(%{value: :disconnected, error: nil}).word == "no network"
+      assert wifi(%{value: :configuring, error: nil}).word == "configuring"
+
+      # Clipped rather than allowed to grow leftwards into the scene's title:
+      # the fields are laid out from the right edge, so a long word pushes the
+      # ones beside it rather than running off the panel.
+      assert wifi(%{value: :some_state_nobody_has_seen, error: nil}).word == "some_state_…"
+    end
+  end
+
+  describe "the strip" do
+    test "the bar draws inside its own height and nowhere else" do
+      for fields <- [StatusBar.fields(nil), StatusBar.fields(nil, utc: DateTime.utc_now())] do
+        for {y, primitive} <- placements(StatusBar.graph(fields)) do
+          assert y >= 0 and y < StatusBar.height(),
+                 "#{inspect(primitive)} is at y=#{y}, outside the #{StatusBar.height()} px strip"
+        end
+      end
+    end
+
+    test "every scene mounts the bar" do
+      for {name, graph} <- scenes() do
+        assert Enum.any?(components(graph), &(&1 == StatusBar)),
+               "#{name} does not mount the status bar"
+      end
+    end
+
+    test "no scene draws in the strip the bar owns" do
+      # The file manager reserved this strip before the bar existed and has
+      # its own test for every one of its views; this is the same assertion
+      # for the other four screens, so a new one cannot be added under the
+      # bar without something noticing.
+      for {name, graph} <- scenes(), {y, primitive} <- placements(graph) do
+        assert y >= StatusBar.height(),
+               "#{name} draws #{inspect(primitive)} at y=#{y}, inside the bar's strip"
+      end
+    end
+
+    test "the reserved height is the bar's own, not a copy of it" do
+      assert MayonnaiOS.Scene.FileManager.status_bar() == StatusBar.height()
+    end
+  end
+
+  describe "under a real viewport" do
+    test "every scene starts the bar, and the bar subscribes to the reader" do
+      # A ViewPort with no drivers: no window, no framebuffer, and everything
+      # else real -- the graphs are compiled, the component is started as a
+      # child scene, and its init/3 runs. That is the half of this feature the
+      # pure graph tests cannot reach, and on this project it is the half that
+      # has historically been wrong: a scene that builds a graph in a test and
+      # crashes on the device is exactly the shape of "CI green on a GPU-less
+      # image".
+      {:ok, _scenic} = Scenic.start_link([])
+
+      {:ok, viewport} =
+        Scenic.ViewPort.start(%{
+          name: :status_bar_test_viewport,
+          size: {640, 480},
+          default_scene: MayonnaiOS.Scene.Home,
+          drivers: []
+        })
+
+      # The bar the boot scene mounted, started and asking the reader for
+      # readings. Nothing in the graph tests proves this happens.
+      assert wait_for_subscribers(1)
+
+      for {module, param} <- [
+            {MayonnaiOS.Scene.Diagnostics, nil},
+            {MayonnaiOS.Scene.FileManager, %{error: nil}},
+            {MayonnaiOS.Scene.Pairing, %{error: nil}},
+            {MayonnaiOS.Scene.Controller, %{error: nil}},
+            {MayonnaiOS.Scene.Home, %{selected: 0}}
+          ] do
+        :ok = Scenic.ViewPort.set_root(viewport, module, param)
+
+        # Back to exactly one: the outgoing scene's bar is gone and the
+        # incoming one's has subscribed. Two would mean the reader is
+        # accumulating the ghosts of every screen ever opened.
+        assert wait_for_subscribers(1), "#{inspect(module)} did not leave one bar subscribed"
+      end
+
+      Scenic.ViewPort.stop(viewport)
+
+      # And the monitor is what cleans up, not a message from the scene: a
+      # scene that is killed mid-repaint has no chance to say goodbye.
+      assert wait_for_subscribers(0)
+    end
+  end
+
+  # -- fixtures ---------------------------------------------------------------
+
+  defp wait_for_subscribers(count, attempts \\ 50) do
+    cond do
+      subscribers() == count -> true
+      attempts > 0 -> Process.sleep(20) && wait_for_subscribers(count, attempts - 1)
+      true -> flunk("expected #{count} subscribers, found #{subscribers()}")
+    end
+  end
+
+  defp subscribers do
+    Status |> :sys.get_state() |> Map.fetch!(:subscribers) |> map_size()
+  end
+
+  defp start_reader(opts) do
+    name = :"status-#{System.unique_integer([:positive])}"
+    start_supervised!({Status, Keyword.put(opts, :name, name)})
+    name
+  end
+
+  # One real reading, through the real reader, so that what the bar is asked
+  # to draw is the shape the reader actually sends rather than a guess at it.
+  defp one_reading(opts) do
+    server = start_reader(opts)
+    Status.subscribe(server)
+    assert_receive {:mayonnaios_status, reading}
+    reading
+  end
+
+  defp words(state) do
+    status =
+      case state do
+        :charging -> "Charging"
+        :discharging -> "Discharging"
+        :full -> "Full"
+        :unknown -> "Anything Else"
+      end
+
+    at = System.monotonic_time(:millisecond)
+
+    StatusBar.fields(%{
+      battery: %{value: %{capacity: 62, status: status}, error: nil, at: at},
+      wifi: %{value: :internet, error: nil, at: at},
+      at: at
+    })
+  end
+
+  defp wifi(source) do
+    at = System.monotonic_time(:millisecond)
+
+    StatusBar.fields(%{
+      battery: %{value: %{capacity: 62, status: "Discharging"}, error: nil, at: at},
+      wifi: Map.put(source, :at, at),
+      at: at
+    }).wifi
+  end
+
+  # One graph from every scene in this firmware. Both the populated page and
+  # the "not running" page where a scene has one, because they are built by
+  # different clauses and only one of them would notice a title moved back up
+  # into the strip.
+  defp scenes do
+    [
+      {"Scene.Home", MayonnaiOS.Scene.Home.graph(Programs.list([%{path: "/bin/sh"}]), 0)},
+      {"Scene.Home (empty)", MayonnaiOS.Scene.Home.graph([], 0)},
+      {"Scene.Diagnostics", MayonnaiOS.Scene.Diagnostics.graph(%MayonnaiOS.Diagnostics{})},
+      {"Scene.Diagnostics (no collector)", MayonnaiOS.Scene.Diagnostics.graph(nil)},
+      {"Scene.FileManager", MayonnaiOS.Scene.FileManager.graph(:stopped)},
+      {"Scene.Pairing", MayonnaiOS.Scene.Pairing.graph(pairing_status())},
+      {"Scene.Pairing (stopped)", MayonnaiOS.Scene.Pairing.graph(:stopped, :enodev)},
+      {"Scene.Controller", MayonnaiOS.Scene.Controller.graph(controller_status())},
+      {"Scene.Controller (stopped)", MayonnaiOS.Scene.Controller.graph(:stopped, :eusers)}
+    ]
+  end
+
+  defp pairing_status do
+    %{
+      scan: %{scanning: true, error: nil, devices: 1, undecodable: 0},
+      devices: [%{label: "Speaker", name: "Speaker", rssi: -60, dual_mode?: true, age_ms: 500}],
+      bonds: [%{address: "00:11:22:33:44:55", random?: false, key_size: 16}],
+      selected: 0,
+      armed: false
+    }
+  end
+
+  defp controller_status do
+    %{
+      name: "MayonnaiOS Controller",
+      address: "00:11:22:33:44:55",
+      advertising: true,
+      connected: true,
+      encrypted: true,
+      subscribed: true,
+      report_map_read: true,
+      interval_ms: 15.0,
+      paired: true,
+      mtu: 65,
+      bonds: 1,
+      sent: 12,
+      dropped: %{}
+    }
+  end
+
+  # Every primitive's y, except the full-screen background the bar paints over
+  # and the bar itself, which is the one thing allowed up there.
+  defp placements(graph) do
+    Scenic.Graph.reduce(graph, [], fn
+      %Scenic.Primitive{data: {640, 480}}, acc ->
+        acc
+
+      %Scenic.Primitive{module: Scenic.Primitive.Component}, acc ->
+        acc
+
+      %Scenic.Primitive{} = primitive, acc ->
+        case get_in(primitive.transforms, [:translate]) do
+          {_x, y} -> [{y, primitive.module} | acc]
+          _none -> acc
+        end
+    end)
+  end
+
+  defp components(graph) do
+    Scenic.Graph.reduce(graph, [], fn
+      %Scenic.Primitive{module: Scenic.Primitive.Component, data: {module, _param, _name}}, acc ->
+        [module | acc]
+
+      _primitive, acc ->
+        acc
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

One `Scenic.Component` — `MayonnaiOS.Scene.StatusBar` — mounted by all five
screens in this firmware: the launcher, diagnostics, the file manager, the
Bluetooth devices app and the Bluetooth controller app. Battery with its
charge state, WiFi, and a clock, in the 30 px strip the file manager already
reserved. It takes that height from the bar now rather than keeping a second
copy of the number.

"Every app" here means every Scenic scene. RetroArch and kmscube are external
processes that open the display and hold it; nothing in this VM draws while
they run and there is no compositor on this board, so there is no bar over a
game and that is a property of the arrangement rather than a gap. Said in the
moduledoc too, so the next person does not go looking for the missing half.

## Approach

**Why the readings come from another process.** A file read on this device has
been observed to block forever — that is the state the handheld is in right
now, a `:prim_file.read_file_nif/1` stuck in the kernel while pure Elixir
still evaluates over SSH. A bar that read sysfs from the scene process would,
in that state, take the whole panel with it: no menu, no file manager, no
diagnostics. `MayonnaiOS.Status` reads and pushes; a poll that never returns
costs the bar its battery number and costs the rest of the screen nothing.

**Why not read through `Diagnostics`, which already polls the same files.** The
*parsing* is shared — it moved to `MayonnaiOS.Power` and both go through it,
because two parsers of one sysfs directory is how two screens end up
disagreeing about the battery. The *process* is not: `Diagnostics.snapshot/0`
is a call, and that collector has a handler which holds it for seconds by
design (the Bluetooth probe owns hci0 while it runs, which is why the
diagnostics scene already carries a rescue and a catch). A bar on every screen
calling into it once a second would make the most-glanced-at thing on the
panel depend on the least available process on the device.

**Why a stale reading is drawn as no reading.** The failure this project keeps
repeating is a plausible value that never moves — `hci0` alive while Bluetooth
was dead, CI green on a GPU-less image, a battery percentage that was a
memory. A status bar is the most believed place on the panel to repeat it,
sitting next to a clock that is still ticking. So every reading is stamped
with the monotonic time it was taken and past six seconds the number is
replaced by `no reading`, tested by moving the clock rather than by waiting.
The clock is read at draw time and so cannot go stale the same way; it says
UTC in the text, because there is no tz database in this image, and a year
before 2020 draws as `clock unset` rather than as `01:34`.

**Why a component rather than a helper each scene calls.** A component is a
scene in its own right, so the bar repaints on its own clock without the
screen underneath being rebuilt — the launcher menu still redraws only on a
keypress — and a sixth screen costs one line.

The test worth looking at starts a real `Scenic.ViewPort` with no drivers and
sets the root to each scene in turn, asserting exactly one bar is subscribed
after each and none after teardown. A scene that builds a graph in a test and
crashes on the device is the shape of "CI green on a GPU-less image", and that
is the half a graph assertion cannot reach.

## Follow-ups for reviewer

- The Bluetooth devices screen went from eight visible rows to seven: eight
  plus the "n of m" line would have put that line through the footer rule
  after the bar took 22 px. One row, or should that screen have tightened its
  three-line notice instead?
- WiFi reads `["interface", "wlan0", "connection"]` (path and event shape taken
  from vintage_net's own source), deliberately not the device-wide
  `["connection"]` you verified by hand — that one counts usb0, so the cable
  being in would read as a working radio. Is per-interface the state you want
  on the bar, or the device-wide one with wlan0 named separately?
- Nothing here has been on the panel; the device was not touched. The strip's
  slightly lighter background, a 22×13 px battery outline, and 13 px text in
  the strip are all judgement calls only eyes on the glass can settle.
