### PR TITLE
Boot with the audio path open, and make a stop actually stop

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -207,6 +207,13 @@ config :mayonnaios, :programs, [
     # the directory the symlinks actually go into, cannot drift from it, and
     # being last it wins over anything a bundle or an earlier run left behind.
     #
+    # That file now also carries `audio_sync = "false"`, which is a guard
+    # against a stalled codec freezing a game in `poll()` rather than a
+    # preference about audio. It is in this file rather than a bundle's for the
+    # same reason as the directory -- this one can be withdrawn -- and the
+    # withdrawal is a boot-time scrub of the player's own config. See that
+    # function.
+    #
     # The `|` never meets a shell: `Port.open/2` with `:spawn_executable` passes
     # argv straight through, so this is one argument containing a pipe rather
     # than two commands.

--- a/config/target.exs
+++ b/config/target.exs
@@ -449,10 +449,15 @@ config :mayonnaios, autostart_ui: true
 # now that it is answered, a key that makes noise when brushed in a pocket is
 # not worth keeping for a check that belongs in IEx.
 #
-# This flag only gates the tone. The mixer itself is taken to 0% and muted at
-# boot by `MayonnaiOS.Audio.Startup` either way -- volume is something the
-# player asks for, not something the device assumes, and the rocker on the top
-# edge is how they ask: `MayonnaiOS.Volume` walks the mixer up from silence.
+# This flag only gates the tone. The mixer itself is taken to 0% at boot by
+# `MayonnaiOS.Audio.Startup` either way -- volume is something the player asks
+# for, not something the device assumes, and the rocker on the top edge is how
+# they ask: `MayonnaiOS.Volume` walks the mixer up from silence.
+#
+# 0% at boot, but *not* switched off any more. Switched off is a device on
+# which no program can play at all -- ALSA powers the DAC only when the route
+# to the sink is complete, so a closed switch turns a write to the PCM into
+# EIO and turns RetroArch into a game frozen in `poll()`. That was the hang.
 config :mayonnaios, audio_test: true
 
 # Import target specific config. This must remain at the bottom

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -117,10 +117,13 @@ defmodule MayonnaiOS.Application do
         # diagnosable and should not be displaced by a repair.
         MayonnaiOS.AppPartition.Startup,
 
-        # Takes the mixer to 0% and mutes it, so the device starts silent by
-        # decision rather than by inheritance. The hardware happens to power
-        # on that way too -- DAC and Line Out switched off, no ALSA state to
-        # restore -- which is exactly why it is worth setting.
+        # Takes the mixer to 0% with the output path switched on, so the
+        # device starts silent by decision rather than by inheritance -- and
+        # so "silent" means the volume is down rather than the speaker being
+        # disconnected. The hardware powers on with the path *closed*, which
+        # is silent in the way that makes every audio program fail with EIO,
+        # so this step is now the thing that makes audio work at all rather
+        # than a tidy restatement of a default. See MayonnaiOS.Audio.
         MayonnaiOS.Audio.Startup,
 
         # The volume rocker. After Audio.Startup, because it starts believing

--- a/lib/mayonnaios/audio.ex
+++ b/lib/mayonnaios/audio.ex
@@ -20,20 +20,88 @@ defmodule MayonnaiOS.Audio do
   as evidence that the inherited device tree was wrong. It would have been
   evidence about a default. Unmute, *then* play, or the result means nothing.
 
-  ## The device boots silent, on purpose
+  ## The device boots silent, and *how* it does that is the whole story
 
-  `Startup` sets every playback control to 0% and switches it off at boot.
+  `Startup` puts the volume at the bottom of the ladder and leaves the output
+  path **switched on**. Silence at boot is a gain, not a route.
 
-  That is what the hardware does anyway -- there is no
-  `/var/lib/alsa/asound.state` and nothing runs `alsactl restore`, so the
-  mixer returns to `DAC` off and `Line Out` 0% on every power-on. Setting it
-  explicitly rather than inheriting it is the point: a default that happens
-  to be right is the exact shape of thing this board has already been wrong
-  about twice, and a handheld that makes a noise nobody asked for, in a
-  pocket, is a worse failure than one that starts quiet.
+  Booting quiet is still the right intent, and it is the same intent as
+  before: there is no `/var/lib/alsa/asound.state` and nothing runs `alsactl
+  restore`, so the mixer powers on with `DAC` off and `Line Out` at 0%
+  anyway. Setting it explicitly rather than inheriting it is the point -- a
+  default that happens to be right is the exact shape of thing this board has
+  already been wrong about twice, and a handheld that makes a noise nobody
+  asked for, in a pocket, is a worse failure than one that starts quiet.
 
-  Raising the volume is a deliberate act. `MayonnaiOS.Volume` makes the
-  rocker on the shell that act; `unmute/0` is the same thing from IEx.
+  What was wrong was the mechanism. `Startup` used to switch every playback
+  control *off*, which is silent and is also a device on which no program can
+  play anything at all. Two `aplay` runs on the hardware, three weeks apart
+  in understanding and two seconds apart on the wire, both writing
+  `/dev/zero` so that every sample is zero and the test is silent by content
+  rather than by volume:
+
+      # DAC, Line Out and Speaker all switched off -- the old boot state
+      aplay -D hw:0,0 -f S32_LE -r 48000 -c 2 -d 2 /dev/zero
+      aplay: pcm_write:2191: write error: Input/output error     (exit 1)
+
+      # DAC 0% but on, Line Out on, Speaker on -- the new boot state
+      aplay -D hw:0,0 -f S32_LE -r 48000 -c 2 -d 2 /dev/zero     (exit 0)
+
+  ALSA's DAPM only powers a path that has a complete route to an *enabled
+  sink*. Switches off is no sink, so the DAC never powers up and a write to
+  the PCM returns `EIO`. Turning on `DAC` and `Line Out` but leaving
+  `Speaker` off was still not enough: the sink is the part that matters,
+  which is why the amplifier is in the ladder at all.
+
+  ## What the closed path actually cost
+
+  Games hung. Not the display and not the RetroArch build -- both were ruled
+  out separately, and with `audio_enable = false` the emulator ran at a clean
+  60 fps of page flips. What happened instead is that RetroArch filled its
+  3072-frame ALSA buffer, blocked in `poll()` waiting for space that a
+  powered-down DAC would never make, and never returned to its main loop. A
+  hung one showed `state: RUNNING`, `hw_ptr` frozen at 48 frames -- one
+  millisecond of audio -- `appl_ptr: 3091`, `avail: 29`. With the path open
+  and the volume at 0 the same game runs and `hw_ptr` advances 48048 frames a
+  second.
+
+  Nothing about that looks like audio from the outside, which is why it took
+  so long: a frozen game on a frozen screen. And it had been hiding in plain
+  sight, because whoever was testing had usually played a test tone first,
+  and the tone opens the path. Pressing volume up once before launching is
+  the same accident, and it was the workaround nobody knew they were using --
+  the ladder opens the switches on the way up from silence.
+
+  Worth knowing because it is the same failure with the launcher innocent:
+  the device was found with a *running* game frozen because the rocker had
+  been walked back down to 0, and level 0 closed the path underneath it. The
+  ring buffer's own log has `[volume] level 0/10 (0%)` and the PCM's `hw_ptr`
+  stopping in the same second. Silence that cannot be undone by the program
+  making it is not a volume setting, it is a fault.
+
+  ## One silence, and one thing that is not silence
+
+  So there is exactly one notion of quiet here and the rocker owns it: level
+  0, `DAC` at 0%, path open, `silence/1`. `disable_output/1` is the other
+  thing -- it closes the switches, and it is documented as what it is, a
+  device that cannot play rather than one that plays inaudibly. Nothing calls
+  it. It is not the boot state and it is not reachable from the rocker.
+
+  Raising the volume is still a deliberate act. `MayonnaiOS.Volume` makes the
+  rocker on the shell that act; `full/1` is the same thing from IEx.
+
+  ## The cost of leaving Speaker on at boot
+
+  `Speaker` is an amplifier, and it is now on from boot with nothing playing.
+  The plausible costs are idle hiss and idle current, and **neither has been
+  measured** -- nobody has put an ear to a booted device listening for it, or
+  compared battery drain with the switch either way. They are worth a
+  measurement before anyone concludes this is free.
+
+  What is not in doubt is the other side of the trade: with the switch off,
+  every program that opens ALSA fails or hangs, silently, until a human
+  presses a button. A hiss nobody has heard is a better bug than a device
+  that freezes on the first game.
 
   ## Which control is the volume, and which are routing
 
@@ -75,7 +143,7 @@ defmodule MayonnaiOS.Audio do
 
   ## The levels
 
-  `steps/0` levels plus silence, and level 0 is `mute/0` -- the boot state.
+  `steps/0` levels plus silence, and level 0 is `silence/1` -- the boot state.
   Levels are mapped onto the control's percentage range starting at
   `quietest/0` rather than at 0%, because the bottom of a 73 dB range is not
   a quiet setting, it is an inaudible one. Ten presses that do nothing you
@@ -91,7 +159,8 @@ defmodule MayonnaiOS.Audio do
 
   ## The test tone
 
-  `run/0` unmutes and plays one second of sine. It is not bound to a button.
+  `run/0` goes to full volume and plays one second of sine. It is not bound
+  to a button.
   It was bound to Y while audio was the open question; that question is
   closed, and leaving a key on the pad that makes noise is not what the key
   is for. Call it from IEx when the mixer needs checking again:
@@ -151,14 +220,14 @@ defmodule MayonnaiOS.Audio do
   def enabled?, do: Application.get_env(:mayonnaios, :audio_test, false)
 
   @doc """
-  Open the mixer, then play a short test. Refuses unless `enabled?/0`.
+  Go to full volume, then play a short test. Refuses unless `enabled?/0`.
 
   Not bound to any button -- call it from IEx. Returns `{:error, :disabled}`,
   `{:error, {:no_tool, name}}` or `:ok`.
   """
   def run do
     if enabled?() do
-      with :ok <- unmute() do
+      with :ok <- full() do
         play()
       end
     else
@@ -170,16 +239,18 @@ defmodule MayonnaiOS.Audio do
   @doc """
   Put the mixer at `level`, between 0 and `steps/0`.
 
-  Level 0 is the boot state: every playback control at 0% and switched off.
-  Anything above it switches the same three controls on -- volume up from
-  silence unmutes, because a rocker that raises a number behind a closed
-  switch is the "plausible-looking but dead" failure written all over this
-  board's history.
+  Every level, level 0 included, leaves the output path switched on. The only
+  thing a level decides is the `DAC` percentage; the route from the DAC to
+  the speaker is the same at silence as it is at full, which is what makes
+  the bottom of the ladder inaudible rather than impossible. See the
+  moduledoc for what the other arrangement cost.
 
   The whole ladder is written on every call rather than only the control that
   moved. It costs two more `amixer` runs per press and it means one press
-  restores a mixer that something else has changed underneath -- `unmute/0`
-  from IEx, say -- instead of leaving the two disagreeing until a reboot.
+  restores a mixer that something else has changed underneath --
+  `disable_output/1` from IEx, say -- instead of leaving the two disagreeing
+  until a reboot. That is now load-bearing rather than tidy: one press of
+  volume up is what re-opens a path something else closed.
 
   `mixer` is the seam the tests use; see `MayonnaiOS.Audio.Mixer`.
   """
@@ -189,46 +260,81 @@ defmodule MayonnaiOS.Audio do
   end
 
   @doc """
-  Raise and unswitch the playback controls, all the way up.
+  The top of the ladder: full gain, path open.
 
   A deliberate act, not a boot step. Makes no sound by itself. This is the
   state the test tone was heard in, and it is the top of the volume ladder --
   the same thing said two ways, deliberately.
 
+  Named `full/1` rather than `unmute/1`, which is what it used to be called.
+  Nothing here is muted any more, at any level, so a function named for
+  undoing a mute would be describing a state this module no longer produces.
+
   Note that `MayonnaiOS.Volume` does not learn about this: it holds the level
   it last set, so the next press moves from there rather than from full. One
   press puts the two back in agreement.
   """
-  def unmute(mixer \\ Amixer), do: set_level(@steps, mixer)
+  def full(mixer \\ Amixer), do: set_level(@steps, mixer)
 
   @doc """
-  Take every playback control to 0% and switch it off.
+  Level 0: the volume at its minimum, with the output path open.
 
-  This is what `Startup` does at boot, and what level 0 means. It is also
-  what the hardware does on its own -- `DAC` and `Line Out` come up switched
-  off with Line Out at 0%, there is no `/var/lib/alsa/asound.state` and
-  nothing runs `alsactl restore` -- and doing it anyway is the point. An
-  inherited default that happens to be right is indistinguishable from one
-  that is about to stop being right, and this board has already been wrong
-  twice about things read rather than set.
+  This is what `Startup` does at boot and what the rocker reaches at the
+  bottom of its travel. `DAC` at 0% is -73.08 dB, which is inaudible rather
+  than mathematically silent, and that is the trade being made on purpose:
+  something that opens the PCM a moment later can write to it.
+
+  Not what the hardware powers on as -- that is `disable_output/1`'s state,
+  and setting this over it is the point of `Startup` existing.
   """
-  def mute(mixer \\ Amixer), do: set_level(0, mixer)
+  def silence(mixer \\ Amixer), do: set_level(0, mixer)
 
-  # Silence. `Speaker` takes no percentage -- it is a switch and amixer errors
-  # on `0%` for it -- so it only gets muted.
-  #
-  # The amplifier goes off first and comes on last, in the clause below. On a
-  # rising level the gains are already lower than where they are going, so
-  # ordering the writes this way means there is no moment where a switched-on
-  # output carries a level nobody asked for.
-  defp controls_for(0) do
-    [
-      {"Speaker", ["mute"]},
-      {"DAC", ["0%", "mute"]},
-      {"Line Out", ["0%", "mute"]}
-    ]
+  @doc """
+  Switch the output path off: `DAC`, `Line Out` and `Speaker` all off.
+
+  **This makes playback impossible, not merely inaudible.** ALSA's DAPM
+  powers a path only when it has a complete route to an enabled sink, so with
+  these three off the DAC never powers up: a write to the PCM returns `EIO`
+  and a program that waits for buffer space instead -- RetroArch does -- waits
+  in `poll()` for ever. That is a frozen game, and nothing about it looks like
+  audio. The moduledoc has the measurements.
+
+  So this is not "volume 0" and it is deliberately not on the ladder, not at
+  boot, and not reachable from the rocker. It exists because "the amplifier
+  is off" is a real hardware state someone may need on purpose -- listening
+  for idle hiss, measuring idle current, proving the EIO above -- and because
+  `amixer sset Speaker mute` is one line that anybody can type on the device
+  whether or not this function exists. Better that the consequence is written
+  down next to it.
+
+  Any level, `silence/1` included, undoes it: one press of volume up re-opens
+  the path. Nothing in this firmware calls it.
+  """
+  def disable_output(mixer \\ Amixer) do
+    apply_controls(
+      [
+        # The amplifier goes off first, for the same reason it comes on last
+        # below: no moment where a switched-on output carries a level nobody
+        # asked for. `Speaker` takes no percentage -- it is a switch and
+        # amixer errors on `0%` for it -- so it only gets muted.
+        {"Speaker", ["mute"]},
+        {"DAC", ["0%", "mute"]},
+        {"Line Out", ["0%", "mute"]}
+      ],
+      mixer
+    )
   end
 
+  # One clause, and that is the fix. Level 0 differs from level 10 in the
+  # `DAC` percentage and in nothing else: same three controls, all switched
+  # on, at every level. There used to be a second clause for 0 that switched
+  # them off, which is how a device that had never had its volume raised
+  # could not play anything at all.
+  #
+  # The amplifier comes on last. On a rising level the gains are already
+  # lower than where they are going, so ordering the writes this way means
+  # there is no moment where a switched-on output carries a level nobody
+  # asked for.
   defp controls_for(level) do
     [
       {"DAC", ["#{percent(level)}%", "unmute"]},
@@ -265,9 +371,11 @@ defmodule MayonnaiOS.Audio do
 
     `set(control, args)` runs one `amixer sset`. That is the whole interface,
     and it is this small on purpose: the parts of volume that can be wrong
-    without hardware saying so -- clamping, the level ladder, whether raising
-    from silence also unswitches, which control is named -- are then testable
-    on a laptop with a mixer that records what it was asked to do.
+    without hardware saying so -- clamping, the level ladder, whether every
+    level leaves the output path switched on, which control is named -- are
+    then testable on a laptop with a mixer that records what it was asked to
+    do. The one about the switches is not a detail: the device it was wrong
+    on could not play anything, and this seam is where a test says so.
 
     There is deliberately no `get`. Reading the mixer back to decide the next
     level would make the level depend on a parse of `amixer sget` output, and
@@ -318,15 +426,21 @@ defmodule MayonnaiOS.Audio do
 
   defmodule Startup do
     @moduledoc """
-    Closes the mixer once at boot, then stops.
+    Puts the mixer at the bottom of the ladder once at boot, then stops.
 
-    Every playback control to 0% and off, so the device is silent until
-    someone asks it not to be.
+    Volume at its minimum with the output path switched on, so the device is
+    silent until someone asks it not to be *and* anything that opens ALSA can
+    still play. Those are two requirements rather than one, and the first
+    version of this satisfied only the first: see `MayonnaiOS.Audio`.
 
     A `:transient` one-shot rather than a long-lived process: there is nothing
-    to supervise afterwards, and it must not keep the supervisor busy. A
-    failure here should not take the boot down either -- it would leave the
-    mixer at whatever the hardware chose, which today is the same thing.
+    to supervise afterwards, and it must not keep the supervisor busy.
+
+    A failure here must not take the boot down -- but note what it now leaves
+    behind, because this is no longer the harmless case it was. The mixer
+    stays as the hardware powers on, which is every switch off, which is a
+    device where every audio program fails or hangs. Hence the warning, and
+    hence it says what to do about it.
     """
 
     use Task, restart: :transient
@@ -334,10 +448,23 @@ defmodule MayonnaiOS.Audio do
 
     def start_link(_opts), do: Task.start_link(__MODULE__, :run, [])
 
-    def run do
-      case MayonnaiOS.Audio.mute() do
-        :ok -> Logger.info("[audio] mixer muted at 0%")
-        other -> Logger.warning("[audio] could not set the mixer: #{inspect(other)}")
+    @doc """
+    Set the boot state. `mixer` is the seam the tests use.
+
+    Taking a mixer at all is the point: the boot state is the state every
+    audio program on this device has to cope with, and it was wrong for as
+    long as it was only assertable by booting a device and listening.
+    """
+    def run(mixer \\ MayonnaiOS.Audio.Amixer) do
+      case MayonnaiOS.Audio.silence(mixer) do
+        :ok ->
+          Logger.info("[audio] mixer at 0% with the output path open")
+
+        other ->
+          Logger.warning(
+            "[audio] could not set the mixer: #{inspect(other)} -- the output path may still " <>
+              "be closed, in which case playback fails with EIO until the volume is raised"
+          )
       end
     end
   end

--- a/lib/mayonnaios/cores.ex
+++ b/lib/mayonnaios/cores.ex
@@ -77,6 +77,17 @@ defmodule MayonnaiOS.Cores do
   The catalogue lives in config, with the firmware, for the same reason the
   RetroArch spec does: a checksum served from beside the file it describes is
   not evidence of anything.
+
+  ## The one thing in here that is not about cores
+
+  `write_append_config/0` also writes `audio_sync = "false"`, which has
+  nothing to do with cores and everything to do with the mechanism this module
+  already owns: the one file appended after the bundle's, rewritten every
+  boot, paired with a boot-time scrub of the player's config so that nothing
+  it says can outlive it. That pairing is the only way this firmware can
+  assert a RetroArch setting and still be able to take it back, and it exists
+  here because `libretro_directory` needed it first. Splitting it across two
+  modules would mean two writers of one file. See that function.
   """
 
   require Logger
@@ -137,19 +148,56 @@ defmodule MayonnaiOS.Cores do
   a pulled power cable would lose the lot.
   """
   def clear_stale_directory(path \\ nil) do
-    path = path || retroarch_config()
+    strip(path || retroarch_config(), "libretro_directory", &stale_directory?/1)
+  end
 
+  @doc """
+  Remove `audio_sync` from RetroArch's main config, whatever it says.
+
+  This is the other half of `write_append_config/0`'s `audio_sync = "false"`,
+  and it is the half that makes the guard removable. The full account of why
+  the guard exists is on that function; this is how it is taken back out.
+
+  Unconditional, unlike `clear_stale_directory/1`, and the asymmetry is the
+  point. A `libretro_directory` that already names `dir/0` is *correct*, so
+  leaving it costs nothing. A persisted `audio_sync` is never correct and
+  never load-bearing: the value that decides the launch is the one in
+  `append_config/0`, which is merged last on every launch and rewritten on
+  every boot. The copy in the player's config is only ever a fossil of a
+  launch that has already happened.
+
+  So it goes, every boot. Which means the day the codec is trustworthy,
+  deleting the line from `write_append_config/0` is genuinely enough: the next
+  boot removes the fossil and RetroArch falls back to its own default
+  (`audio_sync = true`). No device is left carrying a setting no file in any
+  repository still contains -- which is exactly what happened with
+  `libretro_directory`, and cost two rounds of debugging to find.
+
+  The price is worth stating plainly: this firmware owns `audio_sync`. A value
+  set in RetroArch's own audio menu will not survive a reboot. That is a real
+  loss of control over one setting, accepted because the alternative failure
+  is a frozen game and because nobody can reach that menu while the game is
+  frozen.
+  """
+  def clear_persisted_audio_sync(path \\ nil) do
+    strip(path || retroarch_config(), "audio_sync", &audio_sync?/1)
+  end
+
+  # One read, one rewrite, for any setting this application takes back out of
+  # the player's config. Shared because the mechanism is the same and the
+  # policy -- which lines go -- is the only thing that differs.
+  defp strip(path, setting, drop?) do
     case File.read(path) do
       {:ok, contents} ->
         {stale, keep} =
           contents
           |> String.split("\n")
-          |> Enum.split_with(&stale_directory?/1)
+          |> Enum.split_with(drop?)
 
         if stale == [] do
           {:ok, :unchanged}
         else
-          rewrite(path, keep, Enum.map(stale, &configured_directory/1))
+          rewrite(path, setting, keep, Enum.map(stale, &value_of(setting, &1)))
         end
 
       {:error, :enoent} ->
@@ -161,12 +209,12 @@ defmodule MayonnaiOS.Cores do
     end
   end
 
-  defp rewrite(path, lines, cleared) do
+  defp rewrite(path, setting, lines, cleared) do
     tmp = path <> ".mayonnaios"
 
     with :ok <- File.write(tmp, Enum.join(lines, "\n")),
          :ok <- File.rename(tmp, path) do
-      Logger.info("[cores] cleared libretro_directory #{inspect(cleared)} from #{path}")
+      Logger.info("[cores] cleared #{setting} #{inspect(cleared)} from #{path}")
       {:ok, {:cleared, cleared}}
     else
       {:error, reason} ->
@@ -177,7 +225,7 @@ defmodule MayonnaiOS.Cores do
   end
 
   defp stale_directory?(line) do
-    case configured_directory(line) do
+    case value_of("libretro_directory", line) do
       nil -> false
       # Expanded before comparing: RetroArch writes the value back with the
       # home directory abbreviated to `~`, so the string it saves for the
@@ -186,8 +234,19 @@ defmodule MayonnaiOS.Cores do
     end
   end
 
-  defp configured_directory(line) do
-    case Regex.run(~r/^\s*libretro_directory\s*=\s*"?(.*?)"?\s*$/, line) do
+  # Any `audio_sync` at all, whatever it is set to. See
+  # `clear_persisted_audio_sync/1` for why this one is unconditional and the
+  # directory one is not.
+  defp audio_sync?(line), do: value_of("audio_sync", line) != nil
+
+  # One `key = value` line, or nil if this line is not that key.
+  #
+  # Anchored on both sides of the key, which is not fussiness: RetroArch's
+  # config holds `libretro_info_path`, `libretro_log_level`,
+  # `core_updater_buildbot_cores_url` and a hundred others, and a loose match
+  # would edit lines this application knows nothing about.
+  defp value_of(setting, line) do
+    case Regex.run(~r/^\s*#{Regex.escape(setting)}\s*=\s*"?(.*?)"?\s*$/, line) do
       [_, value] -> value
       nil -> nil
     end
@@ -316,12 +375,66 @@ defmodule MayonnaiOS.Cores do
   a contradiction of the "configure nothing" rule so much as its enforcement:
   the value written here is the default, and `clear_stale_directory/0`
   deliberately leaves a config naming `dir/0` alone.
+
+  ## The other setting: `audio_sync = "false"`
+
+  A guard, not a preference, and the only setting in this firmware that is
+  here to stop a *hang* rather than to name a path.
+
+  RetroArch's ALSA output is blocking by default: when the buffer is full it
+  waits in `poll()` for the card to make space. If the card never does, it
+  waits for ever -- not a dropout, a frozen game on a frozen screen, with the
+  DRM master still held so that every later launch fails with `[KMS] Error
+  when switching mode` and looks like a display bug. That is what a codec with
+  its output path switched off did to this device, and `MayonnaiOS.Audio` is
+  the fix for the cause. This is the belt to that braces: with `audio_sync`
+  off, RetroArch sets the driver non-blocking and drops samples instead of
+  waiting, so a stalled codec costs audio rather than the machine.
+
+  Read that as reasoning about RetroArch's audio driver, not as a measurement.
+  What is measured is the hang and the codec; nobody has yet watched a game
+  survive a deliberately stalled card with this setting on, because producing
+  one means playing audio on a device whose owner has asked for silence.
+
+  ## Why here, and not in the bundle or on the command line
+
+  There is no command line for it -- RetroArch takes settings from config
+  files -- so the only question is which file. It cannot be the bundle's:
+  bundles are separately versioned artifacts, a value one appends is
+  indistinguishable from one the player chose, and RetroArch writes it into
+  the player's own config on exit. That is how `libretro_directory` outlived
+  every file that named it. Anything a bundle asserts, no later bundle can
+  withdraw.
+
+  This file has neither problem, and both halves matter:
+
+    * it is rewritten from this function on every boot, so what it says is
+      whatever this firmware currently says, and
+    * `clear_persisted_audio_sync/1` takes the setting out of the player's
+      config on every boot, so the copy RetroArch persists on exit is scrubbed
+      before the next launch reads anything.
+
+  Retraction is therefore deleting one line from this function. There is no
+  device to go and repair afterwards, which is the property `libretro_directory`
+  did not have.
+
+  One file with two settings rather than a second file with one, because the
+  file has exactly one writer and that is worth keeping. Two modules writing
+  one path is a clobber waiting for the boot order to change; and the
+  `--appendconfig` argument in `config :mayonnaios, :programs` names this path
+  once, so a second file would also mean editing the launch arguments to add
+  it.
   """
   def write_append_config do
     path = append_config()
 
+    contents = """
+    libretro_directory = "#{dir()}"
+    audio_sync = "false"
+    """
+
     with :ok <- File.mkdir_p(Path.dirname(path)),
-         :ok <- File.write(path, "libretro_directory = \"#{dir()}\"\n") do
+         :ok <- File.write(path, contents) do
       :ok
     else
       {:error, reason} ->
@@ -415,7 +528,8 @@ defmodule MayonnaiOS.Cores do
   defmodule Startup do
     @moduledoc """
     Asserts the core arrangement once at boot: RetroArch's config names no core
-    directory, and the default one holds a link per core.
+    directory, carries no `audio_sync` of its own, and the default core
+    directory holds a link per core.
 
     Cheap -- a listing and a handful of symlinks -- and it is the step that
     makes a RetroArch upgrade not lose the installed cores: `current` has
@@ -438,6 +552,9 @@ defmodule MayonnaiOS.Cores do
 
     def run do
       MayonnaiOS.Cores.clear_stale_directory()
+      # Unconditional, every boot, and that is what makes the audio_sync guard
+      # removable rather than permanent. See clear_persisted_audio_sync/1.
+      MayonnaiOS.Cores.clear_persisted_audio_sync()
       MayonnaiOS.Cores.write_append_config()
       MayonnaiOS.Cores.sync()
     rescue

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -49,6 +49,22 @@ defmodule MayonnaiOS.Launcher do
   re-rooting the viewport is itself a write -- pressing X during a game would
   otherwise paint the diagnostics screen into a framebuffer the game owns.
 
+  ## Giving the screen back requires the program to actually be dead
+
+  The other half of that promise, and the one this module got wrong for
+  longer: a program is not stopped because it was sent a signal. RetroArch
+  catches SIGTERM and its handler only sets a flag for a main loop that may
+  never look again, so `kill -TERM` on a hung one returns 0 having achieved
+  nothing -- while the process keeps `/dev/dri/card0` open and the launcher
+  reports it stopped. Every launch after that failed with `[KMS] Error when
+  switching mode`, which reads as a display bug in a completely different
+  place.
+
+  So the stop path escalates to SIGKILL, waits for the process to be gone, and
+  only then releases the hold and repaints. `do_stop/1` has the detail; the
+  part that belongs up here is that "the program owns the panel until it
+  exits" now means *exits*, not *was asked to*.
+
   ## The full set of bindings
 
       D-pad up/down move the menu cursor
@@ -170,6 +186,26 @@ defmodule MayonnaiOS.Launcher do
   @up_button :btn_dpad_up
   @down_button :btn_dpad_down
 
+  # How long a stop waits for the program to go, per signal. See `do_stop/1`.
+  #
+  # SIGTERM gets the larger share because a program that honours it has work to
+  # do first -- RetroArch flushes SRAM and saves its config on the way out --
+  # and killing it in the middle of that loses a save. SIGKILL is not a
+  # request, so the second wait is only the time the kernel needs to tear the
+  # process down and the VM needs to reap it.
+  #
+  # Both are ceilings rather than costs. A program that exits on TERM is gone
+  # in milliseconds and the wait ends when its exit arrives, not when the clock
+  # runs out; only a program that has stopped listening pays the full three
+  # seconds, and that program was going to cost a reboot.
+  @term_timeout 2_000
+  @kill_timeout 1_000
+
+  # How often the wait asks the OS whether the process is still there, in
+  # between watching for the port's exit message. Small enough that the normal
+  # path is not noticeably slower than the old fire-and-forget one.
+  @poll_ms 50
+
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
   @doc """
@@ -190,9 +226,19 @@ defmodule MayonnaiOS.Launcher do
 
   @doc """
   Start or stop it from a console, without pressing anything.
+
+  `stop_program/0` returns `:ok` only when the OS process is confirmed gone.
+  A program that survives both SIGTERM and SIGKILL comes back as
+  `{:error, {:still_running, os_pid}}` and is still on the display -- see
+  `do_stop/1` for why that is reported rather than tidied over.
+
+  It blocks while it waits, which is a call that can take a couple of seconds
+  in the bad case. That is deliberate: the alternative is returning before the
+  program has let go of the display, which is the bug being fixed.
   """
   def launch, do: GenServer.call(__MODULE__, :launch)
-  def stop_program, do: GenServer.call(__MODULE__, :stop)
+
+  def stop_program(timeout \\ 10_000), do: GenServer.call(__MODULE__, :stop, timeout)
 
   @doc """
   The index of the highlighted menu entry.
@@ -227,7 +273,7 @@ defmodule MayonnaiOS.Launcher do
     Panel.release()
 
     Enum.each(devices(opts), &watch/1)
-    {:ok, new_state()}
+    {:ok, new_state(opts)}
   end
 
   # The gamepad, plus whatever device the sleep key is on.
@@ -271,7 +317,7 @@ defmodule MayonnaiOS.Launcher do
     if File.exists?(device), do: InputEvent.start_link(device), else: {:error, :enoent}
   end
 
-  defp new_state,
+  defp new_state(opts),
     do: %{
       port: nil,
       app: nil,
@@ -280,6 +326,14 @@ defmodule MayonnaiOS.Launcher do
       held: MapSet.new(),
       scene: :home,
       selected: 0,
+      # The seam the stop path is tested against: signalling an OS process and
+      # asking whether it is still there. Injectable because the one case that
+      # matters most cannot be produced for real -- a process that survives
+      # SIGKILL is a process stuck in a driver, and a test cannot make one.
+      signals: Keyword.get(opts, :signals, MayonnaiOS.Launcher.Kill),
+      term_timeout: Keyword.get(opts, :term_timeout, @term_timeout),
+      kill_timeout: Keyword.get(opts, :kill_timeout, @kill_timeout),
+      poll_ms: Keyword.get(opts, :poll_ms, @poll_ms),
       # Whether the backlight was turned off by the chord. Kept here rather
       # than read back from sysfs on every event, because it is this process
       # that has to decide whether to swallow a press and because the panel
@@ -301,7 +355,15 @@ defmodule MayonnaiOS.Launcher do
   end
 
   def handle_call(:launch, _from, state), do: {:reply, :ok, do_launch(state)}
-  def handle_call(:stop, _from, state), do: {:reply, :ok, do_stop(state)}
+
+  # The reply is the result rather than a cheerful `:ok`, because there is now
+  # an outcome worth having: `{:error, {:still_running, pid}}` means the
+  # program is still on the display and this process could not shift it.
+  def handle_call(:stop, _from, state) do
+    {result, state} = do_stop(state)
+    {:reply, result, state}
+  end
+
   def handle_call(:selected, _from, state), do: {:reply, state.selected, state}
   def handle_call(:asleep?, _from, state), do: {:reply, state.asleep, state}
 
@@ -419,16 +481,22 @@ defmodule MayonnaiOS.Launcher do
   # Trimmed and length-capped because a chatty program should not be able to
   # push everything else out of a fixed-size ring buffer.
   def handle_info({port, {:data, data}}, %{port: port} = state) do
+    log_output(state, data)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # Trimmed and length-capped because a chatty program should not be able to
+  # push everything else out of a fixed-size ring buffer. Shared with the stop
+  # path, which reads the same pipe while it waits for the program to die.
+  defp log_output(state, data) do
     data
     |> String.split("\n", trim: true)
     |> Enum.each(fn line ->
       Logger.info("[#{program_name(state)}] #{String.slice(line, 0, 300)}")
     end)
-
-    {:noreply, state}
   end
-
-  def handle_info(_msg, state), do: {:noreply, state}
 
   # The running program's name, for log lines. Falls back to "program" rather
   # than crashing the log call if a message arrives after the state is cleared.
@@ -573,7 +641,12 @@ defmodule MayonnaiOS.Launcher do
 
     cond do
       state.port != nil ->
-        do_stop(home)
+        # A program that would not die keeps the screen, and this returns the
+        # state that says so: still running, panel still held, nothing
+        # repainted. Pressing Menu again tries again, which is the only thing
+        # left to offer.
+        {_result, state} = do_stop(home)
+        state
 
       state.scene != :home ->
         show(:home, home)
@@ -717,25 +790,151 @@ defmodule MayonnaiOS.Launcher do
     end
   end
 
-  defp do_stop(%{port: nil} = state), do: state
+  # Stop the running program, and do not come back until it is actually gone.
+  #
+  # ## Why SIGTERM is not enough
+  #
+  # RetroArch **catches** SIGTERM. Read off a running one rather than assumed:
+  # `/proc/<pid>/status` has bit 15 set in `SigCgt` and clear in `SigIgn`. Its
+  # handler only sets a quit flag, which the main loop has to notice -- and a
+  # main loop blocked in `poll()` on a stalled audio device never gets back to
+  # looking. `kill -TERM` on that process returns 0, having done nothing at
+  # all. Verified on the device: TERM delivered, four seconds later the process
+  # was still there, still sleeping.
+  #
+  # So the signal escalates. TERM first, because a program that honours it
+  # exits cleanly and saves what it was holding; SIGKILL after, which cannot be
+  # caught, ignored or blocked.
+  #
+  # ## Why it waits, and why the wait is the point
+  #
+  # The old code signalled, closed the port, released the panel and repainted,
+  # in that order, without ever asking whether the program had gone. Every one
+  # of those steps is wrong about a program that has not died yet:
+  #
+  #   * A hung RetroArch keeps `/dev/dri/card0` and `card1` open. The launcher
+  #     reported it stopped, and then every later launch failed with `[KMS]
+  #     Error when switching mode` / `Cannot open video driver` -- which from
+  #     the outside looks like a completely different bug in a completely
+  #     different subsystem.
+  #   * The repaint is a write to a framebuffer whose DRM master is still that
+  #     program, which is the thing `MayonnaiOS.Panel` exists to prevent and
+  #     which hangs this SoC. Raised as a follow-up on the panel-ownership PR;
+  #     this is that follow-up.
+  #
+  # And if even SIGKILL does not land, the honest thing is to report that
+  # rather than tidy up around it. Nothing is closed, nothing is released,
+  # `running?/0` stays true, and the state is returned untouched -- so the port
+  # is still open, its `:exit_status` still arrives if the process ever dies,
+  # and pressing Menu again tries again. A launcher that reports a program
+  # stopped while its process is alive is how a display bug gets invented.
+  defp do_stop(%{port: nil} = state), do: {:ok, state}
 
   defp do_stop(%{port: port} = state) do
-    # Closing the port shuts the pipes but does not reliably stop a program
-    # that never reads stdin, and kmscube does not. Signal the OS process.
-    case Port.info(port, :os_pid) do
-      {:os_pid, os_pid} -> System.cmd("kill", ["-TERM", Integer.to_string(os_pid)])
-      _ -> :ok
-    end
+    case os_pid(port) do
+      nil ->
+        # No OS pid to signal: the VM has already reaped the process, so the
+        # only thing left is the bookkeeping.
+        {:ok, finish_stop(state)}
 
+      os_pid ->
+        case terminate_process(state, os_pid) do
+          :gone ->
+            {:ok, finish_stop(state)}
+
+          :alive ->
+            Logger.error(
+              "[launcher] #{name_of(state.running)} (pid #{os_pid}) survived SIGKILL: " <>
+                "still holding the display, not reporting it stopped"
+            )
+
+            {{:error, {:still_running, os_pid}}, state}
+        end
+    end
+  end
+
+  # The bookkeeping, and only ever after the process is confirmed gone.
+  #
+  # Closing the port means no `:exit_status` message will arrive, so this is
+  # the only place the hold can be lifted on the Menu-out-of-a-game path.
+  defp finish_stop(%{port: port} = state) do
     _ = try do: Port.close(port), rescue: (_ -> :ok)
 
     Logger.info("[launcher] stopped #{name_of(state.running)}")
 
-    # Closing the port means no `:exit_status` message will arrive, so this is
-    # the only place the hold can be lifted on the Menu-out-of-a-game path.
     Panel.release()
     repaint(state)
     %{state | port: nil, running: nil}
+  end
+
+  # Named for the OS process rather than as `terminate/2`, which is a GenServer
+  # callback and would be silently taken for one.
+  defp terminate_process(state, os_pid) do
+    case signal_and_wait(state, os_pid, "TERM", state.term_timeout) do
+      :gone -> :gone
+      :alive -> signal_and_wait(state, os_pid, "KILL", state.kill_timeout)
+    end
+  end
+
+  defp signal_and_wait(state, os_pid, signal, timeout) do
+    Logger.info("[launcher] SIG#{signal} to #{name_of(state.running)} (pid #{os_pid})")
+
+    # A signal that will not send is not a reason to stop waiting: the usual
+    # reason is that the process has already gone, which the wait below is
+    # exactly the thing that finds out.
+    case state.signals.signal(signal, os_pid) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("[launcher] SIG#{signal} to #{os_pid} failed: #{inspect(reason)}")
+    end
+
+    await_exit(state, os_pid, System.monotonic_time(:millisecond) + timeout)
+  end
+
+  # Two independent answers to "is it gone", because neither is sufficient
+  # alone. The port's `:exit_status` is authoritative -- it means the VM has
+  # reaped the process -- but it only arrives for a program this VM spawned and
+  # only once. Asking the OS covers the rest, and has to be a fallback rather
+  # than the primary: between a process exiting and being reaped it is a zombie,
+  # and a zombie answers signal 0 exactly like a live process.
+  #
+  # The exit message is consumed here rather than left for `handle_info/2`.
+  # Deliberately: `finish_stop/1` is about to do everything that clause would
+  # do, and a leftover message would repaint the panel a second time.
+  defp await_exit(state, os_pid, deadline) do
+    port = state.port
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      if state.signals.alive?(os_pid), do: :alive, else: :gone
+    else
+      receive do
+        {^port, {:exit_status, status}} ->
+          Logger.info("[launcher] #{name_of(state.running)} exited (#{status})")
+          :gone
+
+        # Still worth reading. A program's dying words are the only thing it
+        # can say about why it would not go, and dropping them here is what
+        # cost an evening the last time this module discarded port output.
+        {^port, {:data, data}} ->
+          log_output(state, data)
+          await_exit(state, os_pid, deadline)
+      after
+        min(remaining, state.poll_ms) ->
+          if state.signals.alive?(os_pid),
+            do: await_exit(state, os_pid, deadline),
+            else: :gone
+      end
+    end
+  end
+
+  defp os_pid(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} -> os_pid
+      _ -> nil
+    end
   end
 
   defp name_of(%{name: name}), do: name
@@ -800,5 +999,72 @@ defmodule MayonnaiOS.Launcher do
 
   defp default_scene do
     get_in(Application.get_env(:mayonnaios, :viewport), [:default_scene])
+  end
+
+  defmodule Signals do
+    @moduledoc """
+    The two things the stop path needs from the operating system.
+
+    `signal/2` sends one signal; `alive?/1` says whether a pid is still there.
+    That is the whole interface, and it is a seam rather than a direct
+    `System.cmd/3` for one reason: the case that matters most cannot be
+    produced for real. A process that survives `SIGKILL` is a process wedged
+    in a driver, a test cannot make one, and "what does the launcher do when
+    the program will not die" is precisely the question that was answered
+    wrongly before -- it reported the program stopped.
+
+    So a test supplies a module whose signals go nowhere and whose `alive?/1`
+    keeps saying yes, and asserts that the launcher does *not* release the
+    panel, does *not* repaint, and does *not* report success. Everything else
+    in the stop path is tested against real OS processes, which the host has.
+    """
+
+    @callback signal(signal :: String.t(), os_pid :: pos_integer()) :: :ok | {:error, term()}
+    @callback alive?(os_pid :: pos_integer()) :: boolean()
+  end
+
+  defmodule Kill do
+    @moduledoc """
+    Signals, through `kill(1)`.
+
+    `kill -0` for the liveness check: it sends nothing and only reports whether
+    the signal *could* be sent, which is the cheapest question there is. Not
+    `/proc/<pid>`, even though this is Linux, because the host these tests run
+    on has no procfs and a seam that only works on the target is a seam that
+    only gets exercised on the target.
+
+    One thing it cannot distinguish, and the caller has to know it: a process
+    that has exited but has not yet been reaped -- a zombie -- answers signal 0
+    exactly like a live one. `MayonnaiOS.Launcher.await_exit/3` handles that by
+    treating the port's own exit message as the authoritative answer and this
+    as the fallback.
+    """
+
+    @behaviour MayonnaiOS.Launcher.Signals
+
+    @impl MayonnaiOS.Launcher.Signals
+    def signal(signal, os_pid) when is_binary(signal) and is_integer(os_pid) do
+      case kill(["-" <> signal, Integer.to_string(os_pid)]) do
+        {:ok, _out} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+
+    @impl MayonnaiOS.Launcher.Signals
+    def alive?(os_pid) when is_integer(os_pid) do
+      match?({:ok, _out}, kill(["-0", Integer.to_string(os_pid)]))
+    end
+
+    # `System.cmd/3` raises when the executable is not on the path, and a stop
+    # that takes the launcher down with it would leave the buttons dead as well
+    # as the program running.
+    defp kill(args) do
+      case System.cmd("kill", args, stderr_to_stdout: true) do
+        {out, 0} -> {:ok, out}
+        {out, status} -> {:error, {:exit, status, String.trim(out)}}
+      end
+    rescue
+      _ -> {:error, {:no_tool, "kill"}}
+    end
   end
 end

--- a/lib/mayonnaios/volume.ex
+++ b/lib/mayonnaios/volume.ex
@@ -73,12 +73,29 @@ defmodule MayonnaiOS.Volume do
   (`repeat_delay`/`repeat_period`, an `EVIOCSREP` on the shared fd) if it
   turns out to be wanted, and that would change what Diagnostics sees too.
 
-  Level 0 is silence *and* muted, which is the state `MayonnaiOS.Audio.Startup`
-  leaves at boot -- so this process starts believing the mixer, rather than
-  asserting anything over it. Volume up from there unswitches the outputs on
-  the way to level 1; volume down to 0 switches them off again. A rocker whose
-  first press raises a number behind a closed switch would look exactly like
-  one that is not wired up.
+  Level 0 is silence and nothing else: the `DAC` at 0%, with the output path
+  still switched on. That is the state `MayonnaiOS.Audio.Startup` leaves at
+  boot, so this process starts believing the mixer rather than asserting
+  anything over it.
+
+  Level 0 used to mean muted as well, and that was a bug with a much larger
+  blast radius than a volume control has any business having. The switches
+  are the route to the sink, ALSA powers the DAC only when the route is
+  complete, so closing them makes playback *impossible* rather than
+  inaudible: a write to the PCM returns `EIO`, and a program that waits for
+  buffer space instead waits in `poll()` for ever.
+
+  The device was found demonstrating exactly that -- a game frozen mid-play,
+  the ring buffer holding `[volume] level 0/10 (0%)` and the PCM's `hw_ptr`
+  stopping in the same second. The rocker had walked down to the bottom of its
+  travel, which is the one thing a volume control must always be allowed to
+  do. `MayonnaiOS.Audio` has the measurements; the part that belongs here is
+  that this process no longer has a level that can take the audio path away
+  from whatever is playing.
+
+  Which leaves one notion of silence in one place. `Audio.disable_output/1`
+  closes the path and is not a level, not the boot state, and not reachable
+  from these two keys.
 
   ## No on-screen indicator, yet
 
@@ -139,10 +156,16 @@ defmodule MayonnaiOS.Volume do
         Logger.warning("[volume] #{device} unavailable: #{inspect(reason)}")
     end
 
-    # Silence, because that is what `MayonnaiOS.Audio.Startup` has just set
-    # and what the hardware powers on as. Nothing is written here: the boot
-    # state is already correct, and re-asserting it would make this process
-    # the second thing that decides how loud a freshly booted device is.
+    # Silence, because that is what `MayonnaiOS.Audio.Startup` has just set.
+    # Nothing is written here: the boot state is already correct, and
+    # re-asserting it would make this process the second thing that decides
+    # how loud a freshly booted device is.
+    #
+    # Note that this is no longer also what the hardware powers on as. The
+    # hardware comes up with the output path closed and `Startup` opens it, so
+    # believing the mixer here is believing `Startup` -- and if `Startup`
+    # failed, its warning is the thing that says so. Writing a level from here
+    # to be sure would hide that.
     {:ok, %{level: Keyword.get(opts, :level, 0), mixer: Keyword.get(opts, :mixer, Audio.Amixer)}}
   end
 

--- a/test/cores_test.exs
+++ b/test/cores_test.exs
@@ -276,8 +276,29 @@ defmodule MayonnaiOS.CoresTest do
     test "names the directory the symlinks go into", %{core_dir: core_dir} do
       assert :ok = Cores.write_append_config()
 
-      assert File.read!(Cores.append_config()) ==
+      assert File.read!(Cores.append_config()) =~
                ~s(libretro_directory = "#{core_dir}"\n)
+    end
+
+    test "turns RetroArch's blocking audio off" do
+      # The guard: with audio_sync on, a card that stops consuming leaves
+      # RetroArch in poll() for ever -- a frozen game, and the DRM master still
+      # held, so every later launch fails with something that looks like a
+      # display bug. Off, it drops samples instead.
+      assert :ok = Cores.write_append_config()
+
+      assert File.read!(Cores.append_config()) =~ ~s(audio_sync = "false")
+    end
+
+    test "is rewritten from scratch, so a setting removed here leaves the device" do
+      # The property that makes the guard retractable rather than permanent:
+      # this file is generated, not edited, so it cannot accumulate.
+      File.write!(Cores.append_config(), "audio_sync = \"true\"\nsomething_else = \"1\"\n")
+      Cores.write_append_config()
+
+      contents = File.read!(Cores.append_config())
+      refute contents =~ "something_else"
+      refute contents =~ ~s(audio_sync = "true")
     end
 
     test "follows core_dir rather than repeating it", %{base: base} do
@@ -316,6 +337,106 @@ defmodule MayonnaiOS.CoresTest do
       Cores.Startup.run()
 
       assert File.read!(Cores.append_config()) =~ core_dir
+    end
+  end
+
+  # The retraction half of the audio_sync guard. Asserting a RetroArch setting
+  # is easy; being able to stop asserting it is the hard part, and the reason
+  # is `--appendconfig`: RetroArch merges it into its main config handle before
+  # reading anything, so it persists the value on exit as though the player had
+  # chosen it. Without this, `audio_sync = "false"` would outlive every file
+  # that names it -- which is exactly what `libretro_directory` did.
+  describe "clear_persisted_audio_sync/1" do
+    setup %{core_dir: core_dir} do
+      cfg = Path.join(Path.dirname(core_dir), "retroarch.cfg")
+      prev = Application.get_env(:mayonnaios, :retroarch_config)
+      Application.put_env(:mayonnaios, :retroarch_config, cfg)
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:mayonnaios, :retroarch_config, prev),
+          else: Application.delete_env(:mayonnaios, :retroarch_config)
+      end)
+
+      %{cfg: cfg}
+    end
+
+    test "removes the value RetroArch persisted, and leaves the rest alone", %{cfg: cfg} do
+      File.write!(cfg, """
+      video_driver = "gl"
+      audio_sync = "false"
+      audio_volume = "0.000000"
+      """)
+
+      assert {:ok, {:cleared, ["false"]}} = Cores.clear_persisted_audio_sync()
+
+      after_ = File.read!(cfg)
+      refute after_ =~ "audio_sync"
+      assert after_ =~ ~s(video_driver = "gl")
+      assert after_ =~ ~s(audio_volume = "0.000000")
+    end
+
+    test "removes it even when it agrees with what the launch appends", %{cfg: cfg} do
+      # The asymmetry with clear_stale_directory/1, and the whole retraction
+      # story. A directory that already names dir/0 is correct and is left; a
+      # persisted audio_sync is never load-bearing, because the file appended
+      # last decides the launch. Leaving the ones that "look right" is what
+      # would strand the setting on the device after this firmware stopped
+      # asking for it.
+      File.write!(cfg, ~s(audio_sync = "false"\n))
+
+      assert {:ok, {:cleared, ["false"]}} = Cores.clear_persisted_audio_sync()
+      refute File.read!(cfg) =~ "audio_sync"
+    end
+
+    test "an unquoted value is recognised too", %{cfg: cfg} do
+      File.write!(cfg, "audio_sync = true\n")
+      assert {:ok, {:cleared, ["true"]}} = Cores.clear_persisted_audio_sync()
+    end
+
+    test "a key that merely contains the name is left alone", %{cfg: cfg} do
+      contents = """
+      audio_sync_extra = "true"
+      video_audio_sync = "true"
+      audio_enable = "true"
+      """
+
+      File.write!(cfg, contents)
+      assert {:ok, :unchanged} = Cores.clear_persisted_audio_sync()
+      assert File.read!(cfg) == contents
+    end
+
+    test "no config at all is not a failure", %{cfg: cfg} do
+      refute File.exists?(cfg)
+      assert {:ok, :no_config} = Cores.clear_persisted_audio_sync()
+    end
+
+    test "runs at boot, alongside the directory repair", %{cfg: cfg} do
+      File.write!(cfg, ~s(libretro_directory = "/gone"\naudio_sync = "false"\n))
+
+      Cores.Startup.run()
+
+      after_ = File.read!(cfg)
+      refute after_ =~ "audio_sync"
+      refute after_ =~ "libretro_directory"
+    end
+
+    test "the boot pass leaves the guard asserted where it is read from", %{cfg: cfg} do
+      # Both halves in one place: the player's config carries nothing, and the
+      # file the launch appends last carries the guard. Retracting the guard is
+      # deleting that line, and this test is what would then fail.
+      File.write!(cfg, ~s(audio_sync = "false"\n))
+
+      Cores.Startup.run()
+
+      refute File.read!(cfg) =~ "audio_sync"
+      assert File.read!(Cores.append_config()) =~ ~s(audio_sync = "false")
+    end
+
+    test "the rewrite leaves no temporary file behind", %{cfg: cfg} do
+      File.write!(cfg, ~s(audio_sync = "false"\n))
+      assert {:ok, {:cleared, _}} = Cores.clear_persisted_audio_sync()
+      refute File.exists?(cfg <> ".mayonnaios")
     end
   end
 end

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -163,4 +163,247 @@ defmodule MayonnaiOS.LauncherTest do
       Launcher.selected()
     end
   end
+
+  # Stopping a program, which is the half of the handover that was taken on
+  # trust. These tests run real OS processes -- `/bin/sh` blocking on a pipe
+  # that nothing writes -- because the thing being asserted is that a *process*
+  # is gone, and a fake cannot be gone. The only fake here is for the case no
+  # host can produce: a process that survives SIGKILL.
+  describe "stopping a program" do
+    alias MayonnaiOS.Panel
+
+    setup do
+      Unkillable.reset()
+
+      on_exit(fn ->
+        Panel.release()
+        Unkillable.reset()
+      end)
+
+      :ok
+    end
+
+    # A program that blocks for ever, and the shape of it matters.
+    #
+    # It deliberately does not read stdin. The obvious `sh -c` script that
+    # waits on a `read` blocks just as well, and it also exits the moment
+    # `Port.close/1` shuts the pipe -- so a stop path that only sent SIGTERM
+    # and then closed the port would still leave no process behind, and every
+    # test below would pass against the bug. RetroArch does not read stdin
+    # either, which is the whole point.
+    #
+    # A short `sleep` in a loop instead. The shell is the port's process and
+    # the one these tests signal; a loop iteration's `sleep` can outlive it by
+    # up to a second, which is why the sleep is short.
+    @blocks_for_ever "while :; do sleep 1; done"
+
+    defp sh(script) do
+      [%{name: "sh", path: "/bin/sh", args: ["-c", script]}]
+    end
+
+    defp start(script, opts) do
+      Application.put_env(:mayonnaios, :programs, sh(script))
+      on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
+
+      start_supervised!({Launcher, [device: "/nonexistent/event0"] ++ opts})
+
+      Launcher.launch()
+      assert Launcher.running?()
+      os_pid = Launcher.os_pid()
+      assert is_integer(os_pid)
+
+      # The pid has to outlive a test that fails, or a stray process sits on
+      # the host holding a pipe for the rest of the run.
+      on_exit(fn -> System.cmd("kill", ["-KILL", Integer.to_string(os_pid)]) end)
+
+      os_pid
+    end
+
+    defp drain_observations(acc) do
+      receive do
+        {:checked, alive, held} -> drain_observations([{alive, held} | acc])
+      after
+        0 -> Enum.reverse(acc)
+      end
+    end
+
+    defp alive?(os_pid) do
+      match?(
+        {_, 0},
+        System.cmd("kill", ["-0", Integer.to_string(os_pid)], stderr_to_stdout: true)
+      )
+    end
+
+    defp gone?(os_pid, attempts \\ 100) do
+      cond do
+        not alive?(os_pid) -> true
+        attempts == 0 -> false
+        true -> Process.sleep(10) && gone?(os_pid, attempts - 1)
+      end
+    end
+
+    test "a program that honours SIGTERM is stopped by it" do
+      os_pid = start(@blocks_for_ever, term_timeout: 2_000, kill_timeout: 500, poll_ms: 10)
+
+      assert Launcher.stop_program() == :ok
+      refute Launcher.running?()
+      assert gone?(os_pid)
+    end
+
+    test "a program that ignores SIGTERM is killed anyway" do
+      # This is RetroArch. It catches SIGTERM -- `SigCgt` bit 15 set, `SigIgn`
+      # clear, read off a running one -- and the handler only sets a quit flag
+      # that a main loop stuck in poll() never notices. Verified on the device:
+      # TERM delivered, four seconds later the process was still there.
+      #
+      # With a TERM-only stop this test is the whole bug in one line: the
+      # launcher says :ok and the process is still alive, still holding the
+      # display.
+      os_pid =
+        start(~s(trap "" TERM; #{@blocks_for_ever}),
+          term_timeout: 200,
+          kill_timeout: 1_000,
+          poll_ms: 10
+        )
+
+      assert Launcher.stop_program() == :ok
+      assert gone?(os_pid), "the program survived a stop that reported success"
+      refute Launcher.running?()
+    end
+
+    test "the panel is handed back only after the process is gone" do
+      # The repaint is a write to a framebuffer whose DRM master is the program
+      # being stopped, so releasing the hold before it dies is the hang this
+      # firmware already has a module to prevent. Raised as a follow-up on the
+      # panel-ownership PR; asserted here.
+      os_pid =
+        start(~s(trap "" TERM; #{@blocks_for_ever}),
+          term_timeout: 100,
+          kill_timeout: 1_000,
+          poll_ms: 10
+        )
+
+      assert Panel.held?()
+      assert Launcher.stop_program() == :ok
+      refute Panel.held?()
+      assert gone?(os_pid)
+    end
+
+    test "the hold is still held every time the OS says the program is alive" do
+      # The ordering, asserted from inside the wait rather than from after it.
+      # Nothing outside this process can see the interleaving of "release the
+      # panel" and "the program is still there", and that interleaving is the
+      # bug: a repaint is a write to a framebuffer whose DRM master is the
+      # program being stopped.
+      Process.register(self(), PanelRecorder)
+
+      os_pid =
+        start(~s(trap "" TERM; #{@blocks_for_ever}),
+          signals: Watching,
+          term_timeout: 150,
+          kill_timeout: 1_000,
+          poll_ms: 10
+        )
+
+      assert Launcher.stop_program() == :ok
+      assert gone?(os_pid)
+
+      observations = drain_observations([])
+
+      assert Enum.any?(observations, &match?({true, _held}, &1)),
+             "the wait never observed the program alive, so this proves nothing"
+
+      for {alive, held} <- observations, alive do
+        assert held, "the panel was handed back while the program was still running"
+      end
+    end
+
+    test "a program that survives SIGKILL is not reported as stopped" do
+      # No host can produce one -- a process that ignores SIGKILL is wedged in
+      # a driver -- so the signals seam stands in for the operating system and
+      # simply never lets go.
+      os_pid =
+        start(@blocks_for_ever,
+          signals: Unkillable,
+          term_timeout: 60,
+          kill_timeout: 60,
+          poll_ms: 10
+        )
+
+      assert Launcher.stop_program() == {:error, {:still_running, os_pid}}
+
+      # Everything the old code did unconditionally, and none of it is right
+      # here: the program still has the display, so the launcher must not claim
+      # otherwise and must not draw.
+      assert Launcher.running?()
+      assert Panel.held?()
+      assert alive?(os_pid)
+    end
+
+    test "a stop that failed can be retried, and the retry works" do
+      # Which is the reason nothing is torn down on the failure path: the port
+      # is still open and the pid is still known, so Menu is still the way out.
+      os_pid =
+        start(@blocks_for_ever,
+          signals: Unkillable,
+          term_timeout: 60,
+          kill_timeout: 60,
+          poll_ms: 10
+        )
+
+      assert Launcher.stop_program() == {:error, {:still_running, os_pid}}
+
+      # The seam now behaves like an operating system again.
+      Unkillable.relent()
+
+      assert Launcher.stop_program() == :ok
+      refute Launcher.running?()
+      assert gone?(os_pid)
+    end
+  end
+end
+
+# An operating system that will not kill anything: signals are accepted and
+# dropped, and the process is always still there. Toggled through an agent-free
+# persistent term so the launcher process and the test see the same answer.
+defmodule Unkillable do
+  @behaviour MayonnaiOS.Launcher.Signals
+
+  @key {__MODULE__, :relented?}
+
+  def relent, do: :persistent_term.put(@key, true)
+  def reset, do: :persistent_term.erase(@key)
+
+  @impl MayonnaiOS.Launcher.Signals
+  def signal(signal, os_pid) do
+    if relented?(), do: MayonnaiOS.Launcher.Kill.signal(signal, os_pid), else: :ok
+  end
+
+  @impl MayonnaiOS.Launcher.Signals
+  def alive?(os_pid) do
+    if relented?(), do: MayonnaiOS.Launcher.Kill.alive?(os_pid), else: true
+  end
+
+  defp relented?, do: :persistent_term.get(@key, false)
+end
+
+# An operating system that answers honestly and says what the panel looked like
+# at the moment it was asked. The only way to see the order of two things that
+# both happen inside one call.
+defmodule Watching do
+  @behaviour MayonnaiOS.Launcher.Signals
+
+  @impl MayonnaiOS.Launcher.Signals
+  defdelegate signal(signal, os_pid), to: MayonnaiOS.Launcher.Kill
+
+  @impl MayonnaiOS.Launcher.Signals
+  def alive?(os_pid) do
+    alive = MayonnaiOS.Launcher.Kill.alive?(os_pid)
+
+    if pid = Process.whereis(PanelRecorder) do
+      send(pid, {:checked, alive, MayonnaiOS.Panel.held?()})
+    end
+
+    alive
+  end
 end

--- a/test/volume_test.exs
+++ b/test/volume_test.exs
@@ -9,9 +9,14 @@ defmodule MayonnaiOS.VolumeTest do
   # There is no ALSA on the machine these tests run on, so the mixer is a
   # module that records what it was asked to do. That is the whole seam:
   # everything that can be wrong about volume without the hardware saying so
-  # -- the ladder, the clamping, whether raising from silence also unswitches
-  # the outputs, which control gets named -- is arithmetic and argument lists,
-  # and both are readable from here.
+  # -- the ladder, the clamping, whether any level closes the route to the
+  # sink, which control gets named -- is arithmetic and argument lists, and
+  # both are readable from here.
+  #
+  # That middle one is the reason this file grew: the argument list `["0%",
+  # "mute"]` and the argument list `["0%", "unmute"]` are the difference
+  # between a quiet handheld and one where every game freezes, and a test that
+  # only counted percentages could not tell them apart.
   defmodule FakeMixer do
     @behaviour MayonnaiOS.Audio.Mixer
 
@@ -124,20 +129,50 @@ defmodule MayonnaiOS.VolumeTest do
   end
 
   describe "Audio.set_level/2" do
-    test "level 0 mutes every playback control and drops it to 0%" do
+    test "level 0 is 0% with the output path left switched on" do
+      # The bug this replaces: level 0 used to switch DAC, Line Out and
+      # Speaker off, and a closed route to the sink is not a quiet device, it
+      # is one where ALSA never powers the DAC. Writes to the PCM then return
+      # EIO, and a program that waits for buffer space instead -- RetroArch --
+      # waits in poll() for ever. Measured on the device: `aplay /dev/zero`
+      # fails with "Input/output error" in that state and succeeds in this
+      # one.
       assert Audio.set_level(0, FakeMixer) == :ok
 
       assert writes() == [
-               {"Speaker", ["mute"]},
-               {"DAC", ["0%", "mute"]},
-               {"Line Out", ["0%", "mute"]}
+               {"DAC", ["0%", "unmute"]},
+               {"Line Out", ["100%", "unmute"]},
+               {"Speaker", ["unmute"]}
              ]
     end
 
-    test "an audible level unmutes as well as setting the gain" do
-      # The mute interaction is the failure mode being fixed: this device
-      # boots muted, so a volume-up that only moved a percentage would move a
-      # number behind a closed switch and make no sound at all.
+    test "no level, anywhere on the ladder, ever closes a switch" do
+      # The invariant, stated once over the whole range rather than at the two
+      # ends: silence is a gain here and nothing else. `mute` appearing in any
+      # of these argument lists is the whole failure coming back.
+      for level <- -3..(Audio.steps() + 3) do
+        Audio.set_level(level, FakeMixer)
+
+        for {control, args} <- writes() do
+          refute "mute" in args, "level #{level} closed #{control}"
+          assert "unmute" in args
+        end
+      end
+    end
+
+    test "every level writes the same three controls, differing only in the gain" do
+      # Which is the shape of the fix: one clause, and the level decides a
+      # percentage rather than a route.
+      shapes =
+        for level <- 0..Audio.steps() do
+          Audio.set_level(level, FakeMixer)
+          Enum.map(writes(), fn {control, args} -> {control, List.last(args)} end)
+        end
+
+      assert length(Enum.uniq(shapes)) == 1
+    end
+
+    test "an audible level sets the gain with the path already open" do
       assert Audio.set_level(1, FakeMixer) == :ok
 
       writes = writes()
@@ -146,14 +181,13 @@ defmodule MayonnaiOS.VolumeTest do
       assert {"Speaker", ["unmute"]} in writes
     end
 
-    test "the amplifier is switched on last and off first" do
+    test "the amplifier is switched on last" do
       # Nothing here can hear the difference, but the ordering is why there is
       # no moment where a switched-on output carries a level nobody asked for.
-      Audio.set_level(Audio.steps(), FakeMixer)
-      assert {"Speaker", ["unmute"]} = List.last(writes())
-
-      Audio.set_level(0, FakeMixer)
-      assert [{"Speaker", ["mute"]} | _] = writes()
+      for level <- 0..Audio.steps() do
+        Audio.set_level(level, FakeMixer)
+        assert {"Speaker", ["unmute"]} = List.last(writes())
+      end
     end
 
     test "volume lives on the DAC control, named and not indexed" do
@@ -188,7 +222,7 @@ defmodule MayonnaiOS.VolumeTest do
       assert {"DAC", ["100%", "unmute"]} in writes()
 
       Audio.set_level(-99, FakeMixer)
-      assert {"DAC", ["0%", "mute"]} in writes()
+      assert {"DAC", ["0%", "unmute"]} in writes()
     end
 
     test "stops at the first control that will not set" do
@@ -196,25 +230,111 @@ defmodule MayonnaiOS.VolumeTest do
     end
   end
 
-  describe "Audio.mute/1 and Audio.unmute/1" do
-    test "mute is level 0 and unmute is the top of the ladder" do
-      Audio.mute(FakeMixer)
-      muted = writes()
+  describe "Audio.silence/1 and Audio.full/1" do
+    test "silence is level 0 and full is the top of the ladder" do
+      Audio.silence(FakeMixer)
+      quiet = writes()
       Audio.set_level(0, FakeMixer)
-      assert writes() == muted
+      assert writes() == quiet
 
-      Audio.unmute(FakeMixer)
+      Audio.full(FakeMixer)
       loud = writes()
       Audio.set_level(Audio.steps(), FakeMixer)
       assert writes() == loud
     end
 
-    test "unmute is the state the test tone was heard in" do
-      Audio.unmute(FakeMixer)
+    test "full is the state the test tone was heard in" do
+      Audio.full(FakeMixer)
       writes = writes()
       assert {"DAC", ["100%", "unmute"]} in writes
       assert {"Line Out", ["100%", "unmute"]} in writes
       assert {"Speaker", ["unmute"]} in writes
+    end
+
+    test "silence leaves a device that can still play" do
+      # The one sentence this whole change is about: after the boot step, the
+      # three switches that make up the route to the sink are on. On the
+      # hardware that is the difference between `aplay /dev/zero` returning
+      # EIO and returning 0.
+      Audio.silence(FakeMixer)
+
+      assert Enum.sort(writes()) ==
+               Enum.sort([
+                 {"DAC", ["0%", "unmute"]},
+                 {"Line Out", ["100%", "unmute"]},
+                 {"Speaker", ["unmute"]}
+               ])
+    end
+  end
+
+  describe "Audio.disable_output/1" do
+    test "closes all three switches, which is the state nothing can play in" do
+      # Kept as an explicit act and named for what it does. It is not a volume
+      # level, nothing in the firmware calls it, and the rocker cannot reach
+      # it -- but `amixer sset Speaker mute` is one line anybody can type, so
+      # the consequence is written down next to a function rather than nowhere.
+      assert Audio.disable_output(FakeMixer) == :ok
+
+      assert writes() == [
+               {"Speaker", ["mute"]},
+               {"DAC", ["0%", "mute"]},
+               {"Line Out", ["0%", "mute"]}
+             ]
+    end
+
+    test "the amplifier goes off first" do
+      Audio.disable_output(FakeMixer)
+      assert [{"Speaker", ["mute"]} | _] = writes()
+    end
+
+    test "any level undoes it, silence included" do
+      Audio.disable_output(FakeMixer)
+      _ = writes()
+
+      Audio.set_level(0, FakeMixer)
+
+      for {_control, args} <- writes(), do: assert("unmute" in args)
+    end
+  end
+
+  describe "the boot state" do
+    # The state a freshly powered device is in is the one state every audio
+    # program has to cope with, and until now it was only assertable by
+    # booting a device and listening. `Startup.run/1` takes the mixer for
+    # exactly that reason.
+
+    test "is 0% with the output path open, not 0% with it closed" do
+      assert Audio.Startup.run(FakeMixer) == :ok
+
+      assert writes() == [
+               {"DAC", ["0%", "unmute"]},
+               {"Line Out", ["100%", "unmute"]},
+               {"Speaker", ["unmute"]}
+             ]
+    end
+
+    test "is not disable_output/1" do
+      # These were the same call, and that was the bug.
+      Audio.Startup.run(FakeMixer)
+      booted = writes()
+
+      Audio.disable_output(FakeMixer)
+      refute writes() == booted
+    end
+
+    test "closes nothing, so a program that opens ALSA after boot can play" do
+      Audio.Startup.run(FakeMixer)
+
+      for {control, args} <- writes() do
+        refute "mute" in args, "boot closed #{control}"
+      end
+    end
+
+    test "a mixer that cannot be reached is a warning and not a crash" do
+      # It must not take the boot down. What it leaves behind is worse than it
+      # used to be -- the hardware's own closed path -- which is why the
+      # warning says so, and why this returns rather than raising.
+      assert Audio.Startup.run(BrokenMixer) == :ok
     end
   end
 
@@ -239,7 +359,7 @@ defmodule MayonnaiOS.VolumeTest do
       assert writes() == []
     end
 
-    test "volume up from silence goes to level 1, unmuting on the way", %{volume: pid} do
+    test "volume up from silence goes to level 1 with the path still open", %{volume: pid} do
       press(pid, :key_volumeup)
       assert Volume.level(pid) == 1
       assert {"Speaker", ["unmute"]} in writes()
@@ -262,17 +382,37 @@ defmodule MayonnaiOS.VolumeTest do
       assert Volume.level(pid) == 0
     end
 
-    test "down from level 1 is silence, and mutes", %{volume: pid} do
+    test "down from level 1 is silence, and does not close the path", %{volume: pid} do
+      # The rocker walking back to the bottom of its travel must not be able
+      # to take audio away from a program that is playing. It could, and the
+      # device was found with a game frozen in poll() because of it.
       press(pid, :key_volumeup)
       _ = writes()
       press(pid, :key_volumedown)
+
       assert Volume.level(pid) == 0
-      assert {"Speaker", ["mute"]} in writes()
+      writes = writes()
+      assert {"DAC", ["0%", "unmute"]} in writes
+      assert {"Speaker", ["unmute"]} in writes
+      refute Enum.any?(writes, fn {_control, args} -> "mute" in args end)
+    end
+
+    test "no sequence of presses can ever close the path", %{volume: pid} do
+      # Whatever someone does with the two keys -- squeezing both, running the
+      # ladder to either end and back -- the route to the sink stays open.
+      for key <- [:key_volumedown, :key_volumeup, :key_volumedown, :key_volumeup],
+          _ <- 1..(Audio.steps() + 2) do
+        press(pid, key)
+
+        for {control, args} <- writes() do
+          refute "mute" in args, "#{key} closed #{control}"
+        end
+      end
     end
 
     test "a press at the end of the travel still re-asserts the mixer", %{volume: pid} do
       # Deliberate: one press repairs a mixer that something else has moved --
-      # `Audio.unmute/0` from IEx, say -- rather than leaving the two
+      # `Audio.disable_output/0` from IEx, say -- rather than leaving the two
       # disagreeing until a reboot.
       _ = writes()
       press(pid, :key_volumedown)


### PR DESCRIPTION
## Summary

Games hung on this device because the mixer boots with the codec's output path switched off. ALSA's DAPM powers a path only when it has a complete route to an enabled sink, so with `DAC`, `Line Out` and `Speaker` all off the DAC never powers up: a write to the PCM returns EIO, and RetroArch — which waits for buffer space rather than erroring — fills its 3072-frame buffer and blocks in `poll()` for ever. A frozen game on a frozen screen, with nothing in it that looks like audio.

Three commits: boot silent by volume instead of by cutting the path; give RetroArch `audio_sync = "false"` so it can never block on a card again; and make the launcher's stop escalate to SIGKILL and confirm the process is gone before it reports anything or repaints.

Verified on the device today, with `/dev/zero` so every sample is zero — silence by content, not by volume:

    # all three switches off — the old boot state
    aplay -D hw:0,0 -f S32_LE -r 48000 -c 2 -d 2 /dev/zero
    aplay: pcm_write:2191: write error: Input/output error   (exit 1)

    # DAC 0% but on, Line Out on, Speaker on — the new boot state
    aplay -D hw:0,0 -f S32_LE -r 48000 -c 2 -d 2 /dev/zero   (exit 0)

## Why silence has to be a volume and not a route

Booting quiet is right and stays. What was wrong is that "quiet" was implemented as disconnecting the speaker, which is not a quieter device but a broken one — and it broke silently, because the failure surfaces three layers away as a hung emulator. It had been hiding for weeks behind an accident: a test tone, or one press of volume up, opens the path, so anyone who had made a sound that boot never saw it.

`Volume` had the same bug with a larger blast radius, and the device demonstrated it while I was reading state off it. I found a game frozen mid-play, `[volume] level 0/10 (0%)` in the ring buffer and the PCM's `hw_ptr` stopping in the same second: the rocker had walked back to the bottom of its travel and level 0 closed the path underneath a program that was playing. Walking to the bottom of its travel is the one thing a volume control must always be allowed to do. So level 0 is now `DAC` at 0% — -73.08 dB, inaudible rather than mathematically silent — with the path open, and `set_level/2` collapses to a single clause because a level decides a percentage and nothing else.

The judgement calls, all three of them:

- **A true mute is kept, as `disable_output/1`, and renamed for what it does.** Deleting it would not delete `amixer sset Speaker mute` from the device, and someone will type that; better the consequence is written beside a function than nowhere. It is documented as making playback *impossible*, not inaudible, is not the boot state, not a level, not reachable from the rocker, and nothing calls it.
- **`Speaker` on from boot has an unmeasured cost.** Idle hiss and idle current are both plausible for an amplifier and neither has been checked — recorded in the moduledoc as worth measuring. The other side of the trade is a device where every audio program fails until a human presses a button, so an unheard hiss is the better bug.
- **The two notions of silence are now one.** `mute/0` is gone, `unmute/0` is `full/1`, since nothing is muted at any level and a function named for undoing a mute would describe a state the module no longer produces.

`Startup.run/1` takes a mixer now, which is the smaller but more durable half: the boot state was previously only assertable by booting a device and listening, and it was wrong for exactly as long as that was true.

## Where the audio_sync guard lives, and how it comes back out

Not in the bundle's config — that is the trap this project has already paid for twice. `--appendconfig` is merged into the player's config handle before any setting is read, so RetroArch cannot tell an appended value from one the player chose and writes it into its own config on exit. Anything a bundle asserts outlives that bundle, and no later bundle can withdraw it; `Cores.clear_stale_directory/0` exists because of precisely that.

There is no command-line switch for it, so it goes in `mayonnaios.cfg` — the file this application generates — and the retraction is asserted on the device rather than merely shipped:

- `write_append_config/0` rewrites that file from scratch every boot, and it is appended last on every launch, so it has the final word.
- `clear_persisted_audio_sync/1` strips `audio_sync` out of the player's own config every boot, **unconditionally** — unlike the directory scrub, which deliberately leaves a value that is already correct alone.

That asymmetry is the whole retraction story. A `libretro_directory` naming the right place is correct and costs nothing to leave. A persisted `audio_sync` is never load-bearing, because the appended file decides the launch, so it is only ever a fossil of a launch that already happened. Scrubbing it unconditionally means that the day the codec is trustworthy, deleting one line from `write_append_config/0` is genuinely enough: the next boot removes the fossil and RetroArch falls back to its own default. No device is left carrying a setting no file in any repository still contains, which is what happened last time.

The price, stated in the docstring rather than discovered later: this firmware owns `audio_sync`, so a value set in RetroArch's own audio menu will not survive a reboot. Accepted, because the alternative failure is a frozen game and nobody can reach that menu while the game is frozen.

Two settings in one file rather than a second file with one, because the file has exactly one writer and the launch arguments name its path once. It does sit oddly in `Cores`; the moduledoc says so and says why splitting it would mean two writers of one path.

## On the stop path

RetroArch catches SIGTERM — `SigCgt` bit 15 set, `SigIgn` clear, read off a live one — and its handler only sets a flag a blocked main loop never looks at. Confirmed on the device before writing the fix: TERM delivered to the hung one, four seconds later still there, still sleeping; SIGKILL removed it at once. The expensive part was not the signal but the assumption after it — the old path closed the port, released the panel hold and repainted without asking, so a program still holding `/dev/dri/card0` was reported stopped and every launch after that failed with `[KMS] Error when switching mode`. This also closes the `do_stop/1` follow-up from #8, since the repaint racing a program that has not finished dying is the same seam.

One test detail worth knowing because it nearly made the tests worthless: a `sh -c` script blocking on `read` also dies when `Port.close/1` shuts the pipe, so every one of these tests passed against the old TERM-only code until they were changed to loop on a short sleep instead. RetroArch does not read stdin either.

## Follow-ups for reviewer

- The device had a hung RetroArch on it holding the PCM and both DRM cards. I needed the PCM for the `aplay` check above, so I killed it — TERM first as evidence, then KILL, then let the launcher reap it normally so the repaint happened after the process was gone rather than under it. The mixer is back in the exact state I found it (all three switches off, everything 0%). Say if you would rather I had left it stuck.
- `audio_sync = "false"` is reasoned from RetroArch's ALSA driver, not measured. Watching a game survive a deliberately stalled card means playing audio on a device whose owner asked for silence, so I did not. Worth doing once with headphones out, or leave it?
- A stop now blocks the launcher for up to 3 s in the worst case, which also delays anything calling `Launcher.os_pid/0` (the diagnostics screen, once a second). Synchronous because the repaint has to be ordered after the death; the async alternative is a half-stopped state to reason about. Right trade?
- Idle hiss and idle current with `Speaker` on at boot are the one thing here nobody has measured. Worth an ear and a multimeter before this ships?