### PR TITLE
Make saves survive a kill and a pulled cable

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,37 @@ Fixing the bundle would be tidier and is worth doing in
 is versioned separately and installed independently, so relying on it to *not*
 set something is the arrangement that already failed once.
 
+### Saves
+
+RetroArch writes a game's SRAM every ten seconds
+(`autosave_interval`), and this firmware asserts that in the same
+appended config as the core directory — because the device was found with
+`autosave_interval = "0"`, RetroArch's own default, which writes the `.srm`
+only when content closes cleanly. On a handheld with no clean shutdown, that
+means a kill or a pulled cable discards every in-game save made since the ROM
+was loaded. It did, repeatedly, to a Chrono Trigger file.
+
+Ten seconds costs almost nothing in writes: RetroArch compares the SRAM
+against its last copy and writes only when it differs, so the interval decides
+how *soon* a save reaches the card, not how often anything is written.
+
+The setting is scrubbed out of the player's own config at every boot by
+`MayonnaiOS.Cores.clear_persisted_autosave/0`, for the same reason
+`libretro_directory` is: RetroArch persists whatever `--appendconfig` supplied
+as though the player had chosen it, so without the scrub, a value could not be
+changed later by any firmware. Changing the interval is editing one line;
+there is no device to go and repair afterwards. The cost is that this firmware
+owns the setting — changing it in RetroArch's Saving menu does not survive a
+reboot.
+
+RetroArch flushes those writes to the kernel and never fsyncs them, and there
+is no `sync` on this device, so `MayonnaiOS.Saves.flush/1` fsyncs the save
+files when a program the launcher started has exited. Deliberately only then:
+fsyncing while a game runs could catch an autosave between its truncate and
+its write, which is the one way this could destroy the file it exists to
+protect. A cable pulled mid-game is covered by the interval and by f2fs
+writeback, and by nothing else.
+
 ## Using it as a Bluetooth controller
 
 The handheld can be the gamepad instead of the console. Pick **Bluetooth

--- a/lib/mayonnaios/cores.ex
+++ b/lib/mayonnaios/cores.ex
@@ -77,6 +77,17 @@ defmodule MayonnaiOS.Cores do
   The catalogue lives in config, with the firmware, for the same reason the
   RetroArch spec does: a checksum served from beside the file it describes is
   not evidence of anything.
+
+  ## The one thing in here that is not about cores
+
+  `write_append_config/0` also writes `autosave_interval`, which has nothing
+  to do with cores and everything to do with the mechanism this module already
+  owns: the one file appended after the bundle's, rewritten every boot, paired
+  with a boot-time scrub of the player's config so that nothing it says can
+  outlive it. That pairing is the only way this firmware can assert a RetroArch
+  setting and still be able to take it back, and it exists here because
+  `libretro_directory` needed it first. Splitting it across two modules would
+  mean two writers of one file. See that function.
   """
 
   require Logger
@@ -87,6 +98,11 @@ defmodule MayonnaiOS.Cores do
   # Overridable so the tests can point somewhere writable; the device never
   # needs to.
   @retroarch_config "/root/.config/retroarch/retroarch.cfg"
+
+  # Seconds between SRAM autosaves. The number is argued in
+  # `write_append_config/0`; overridable so a test can assert that the value
+  # travels rather than hard-coding it twice.
+  @autosave_interval 10
 
   @doc """
   Where core bundles are installed, one versioned directory per core.
@@ -118,6 +134,15 @@ defmodule MayonnaiOS.Cores do
   end
 
   @doc """
+  Seconds between SRAM autosaves, as `write_append_config/0` will assert it.
+
+  See that function for why the number is what it is.
+  """
+  def autosave_interval do
+    Application.get_env(:mayonnaios, :retroarch_autosave_interval, @autosave_interval)
+  end
+
+  @doc """
   Remove `libretro_directory` from RetroArch's main config unless it already
   names `dir/0`.
 
@@ -137,19 +162,60 @@ defmodule MayonnaiOS.Cores do
   a pulled power cable would lose the lot.
   """
   def clear_stale_directory(path \\ nil) do
-    path = path || retroarch_config()
+    strip(path || retroarch_config(), "libretro_directory", &stale_directory?/1)
+  end
 
+  @doc """
+  Remove `autosave_interval` from RetroArch's main config, whatever it says.
+
+  This is the other half of the `autosave_interval` that
+  `write_append_config/0` writes, and it is the half that makes the setting
+  removable. The full account of why the setting exists is on that function;
+  this is how it is taken back out.
+
+  Unconditional, unlike `clear_stale_directory/1`, and the asymmetry is the
+  point. A `libretro_directory` that already names `dir/0` is *correct*, so
+  leaving it costs nothing. A persisted `autosave_interval` is never
+  load-bearing: the value that decides the launch is the one in
+  `append_config/0`, which is merged last on every launch and rewritten on
+  every boot. The copy in the player's config is only ever a fossil of a
+  launch that has already happened -- and the one fossil that actually caused
+  today's loss, `autosave_interval = "0"`, is indistinguishable from a value
+  the player chose.
+
+  So it goes, every boot. Which means the day this policy changes, editing the
+  number in `write_append_config/0` -- or deleting the line -- is genuinely
+  enough: the next boot removes the fossil and RetroArch falls back to what
+  the appended file says, or to its own default when the line is gone. No
+  device is left carrying a setting no file in any repository still contains,
+  which is exactly what happened with `libretro_directory` and cost two rounds
+  of debugging to find.
+
+  The price is worth stating plainly: this firmware owns `autosave_interval`.
+  A value set in RetroArch's own Saving menu will not survive a reboot. That
+  is a real loss of control over one setting, accepted because the setting
+  being wrong costs a save file and the person it costs it to is the one who
+  cannot see that it is wrong.
+  """
+  def clear_persisted_autosave(path \\ nil) do
+    strip(path || retroarch_config(), "autosave_interval", &autosave_interval?/1)
+  end
+
+  # One read, one rewrite, for any setting this application takes back out of
+  # the player's config. Shared because the mechanism is the same and the
+  # policy -- which lines go -- is the only thing that differs.
+  defp strip(path, setting, drop?) do
     case File.read(path) do
       {:ok, contents} ->
         {stale, keep} =
           contents
           |> String.split("\n")
-          |> Enum.split_with(&stale_directory?/1)
+          |> Enum.split_with(drop?)
 
         if stale == [] do
           {:ok, :unchanged}
         else
-          rewrite(path, keep, Enum.map(stale, &configured_directory/1))
+          rewrite(path, setting, keep, Enum.map(stale, &value_of(setting, &1)))
         end
 
       {:error, :enoent} ->
@@ -161,12 +227,12 @@ defmodule MayonnaiOS.Cores do
     end
   end
 
-  defp rewrite(path, lines, cleared) do
+  defp rewrite(path, setting, lines, cleared) do
     tmp = path <> ".mayonnaios"
 
     with :ok <- File.write(tmp, Enum.join(lines, "\n")),
          :ok <- File.rename(tmp, path) do
-      Logger.info("[cores] cleared libretro_directory #{inspect(cleared)} from #{path}")
+      Logger.info("[cores] cleared #{setting} #{inspect(cleared)} from #{path}")
       {:ok, {:cleared, cleared}}
     else
       {:error, reason} ->
@@ -176,8 +242,13 @@ defmodule MayonnaiOS.Cores do
     end
   end
 
+  # Any `autosave_interval` at all, whatever it is set to. See
+  # `clear_persisted_autosave/1` for why this one is unconditional and the
+  # directory one is not.
+  defp autosave_interval?(line), do: value_of("autosave_interval", line) != nil
+
   defp stale_directory?(line) do
-    case configured_directory(line) do
+    case value_of("libretro_directory", line) do
       nil -> false
       # Expanded before comparing: RetroArch writes the value back with the
       # home directory abbreviated to `~`, so the string it saves for the
@@ -186,8 +257,14 @@ defmodule MayonnaiOS.Cores do
     end
   end
 
-  defp configured_directory(line) do
-    case Regex.run(~r/^\s*libretro_directory\s*=\s*"?(.*?)"?\s*$/, line) do
+  # One `key = value` line, or nil if this line is not that key.
+  #
+  # Anchored on both sides of the key, which is not fussiness: RetroArch's
+  # config holds `libretro_info_path`, `libretro_log_level`,
+  # `autosave_interval` next to `savestate_auto_save`, and a hundred others,
+  # and a loose match would edit lines this application knows nothing about.
+  defp value_of(setting, line) do
+    case Regex.run(~r/^\s*#{Regex.escape(setting)}\s*=\s*"?(.*?)"?\s*$/, line) do
       [_, value] -> value
       nil -> nil
     end
@@ -316,12 +393,114 @@ defmodule MayonnaiOS.Cores do
   a contradiction of the "configure nothing" rule so much as its enforcement:
   the value written here is the default, and `clear_stale_directory/0`
   deliberately leaves a config naming `dir/0` alone.
+
+  ## The other setting: `autosave_interval`
+
+  The device was found with `autosave_interval = "0"` in the player's config,
+  which is RetroArch's own default and means *never autosave*. With it off,
+  the SRAM `.srm` is written when content closes cleanly and at no other time,
+  so every kill, every hang and every pulled power cable discards the whole
+  session -- including in-game saves the player made at a save point an hour
+  earlier. That is not a hypothetical: it happened repeatedly in one
+  afternoon, to a Chrono Trigger file, while a hung RetroArch was being
+  SIGKILLed to diagnose something else entirely.
+
+  This device cannot rely on a clean close. It is switched off by pulling the
+  power, there is no clean shutdown in normal use, and a program that hangs
+  holding DRM master has to be killed. A save mechanism that only runs on a
+  clean exit is therefore a save mechanism that runs on the good days.
+
+  ### Ten seconds, and what that number actually buys
+
+  `autosave_interval = "10"`. Read the guarantee carefully, because it is
+  narrower than "you lose at most ten seconds of play": SRAM holds what the
+  *game* has written to its battery-backed memory, so what is being protected
+  is the player's own in-game saves, not the walk between them. What ten
+  seconds buys is that an in-game save is on its way to the card about ten
+  seconds later instead of surviving only if RetroArch is allowed to exit
+  cleanly -- which today it was not.
+
+  Ten rather than sixty because the cost is bounded by the game rather than by
+  the clock: RetroArch's autosave thread compares the SRAM against its last
+  copy and writes only when it differs, so a shorter interval does not mean
+  more writes on a card that times out on erase (`mmc_erase: group start error
+  -110`, the reason `/root` is mounted `nodiscard` -- see
+  `MayonnaiOS.AppPartition`). It means the write happens sooner after the
+  game's own save, and 8 KB of `.srm` is one f2fs write either way. Ten
+  rather than one because a burst of SRAM writes -- some games rewrite a
+  checksum region repeatedly -- should coalesce into one write, and because
+  ten seconds of extra exposure is not worth a tenfold write rate in the
+  pathological case.
+
+  That the writes are change-gated is read from RetroArch's autosave thread,
+  not measured here. If it turns out to write unconditionally, the number to
+  change is `@autosave_interval` and nothing else moves.
+
+  What this setting does *not* do is make the write durable. RetroArch flushes
+  the file to the kernel and does not fsync it, so an autosaved `.srm` lives
+  in the page cache until f2fs writes it back on its own schedule -- and this
+  device has no `sync` binary and no clean shutdown. `MayonnaiOS.Saves` is the
+  other half of that, and it is the half that can only run when the program
+  that owns the file is gone.
+
+  ### What was considered and not done: a save state on stop
+
+  `savestate_auto_save = "true"` would write a full machine state when content
+  closes, and `savestate_auto_load` would put the player back exactly where
+  they were. It is rejected, and not narrowly.
+
+  It writes on a *clean close*, which is the code path that already works and
+  the one that was never the problem: a SIGKILLed or unplugged RetroArch does
+  not reach it either. So it adds nothing to the failure being fixed, while
+  adding a multi-megabyte write to every ordinary exit on a card whose erase
+  times out. And a state is tied to the core that wrote it -- upgrade
+  snes9x2010 and the automatic load either fails or, worse, restores something
+  subtly wrong -- so it would make a core upgrade able to break a game that
+  had been fine, in exchange for convenience nobody asked for.
+
+  SRAM is the opposite of that: 8 KB, the format the game itself defined, and
+  portable across cores and RetroArch versions. It is the thing worth making
+  durable.
+
+  ## Why here, and not in the bundle or on the command line
+
+  There is no command line for it -- RetroArch takes settings from config
+  files -- so the only question is which file. It cannot be the bundle's:
+  bundles are separately versioned artifacts, a value one appends is
+  indistinguishable from one the player chose, and RetroArch writes it into
+  the player's own config on exit. That is how `libretro_directory` outlived
+  every file that named it. Anything a bundle asserts, no later bundle can
+  withdraw.
+
+  This file has neither problem, and both halves matter:
+
+    * it is rewritten from this function on every boot, so what it says is
+      whatever this firmware currently says, and
+    * `clear_persisted_autosave/1` takes the setting out of the player's
+      config on every boot, so the copy RetroArch persists on exit is scrubbed
+      before the next launch reads anything.
+
+  Retraction is therefore editing one line in this function. There is no
+  device to go and repair afterwards, which is the property
+  `libretro_directory` did not have.
+
+  One file with two settings rather than a second file with one, because the
+  file has exactly one writer and that is worth keeping. Two modules writing
+  one path is a clobber waiting for the boot order to change; and the
+  `--appendconfig` argument in `config :mayonnaios, :programs` names this path
+  once, so a second file would also mean editing the launch arguments to add
+  it.
   """
   def write_append_config do
     path = append_config()
 
+    contents = """
+    libretro_directory = "#{dir()}"
+    autosave_interval = "#{autosave_interval()}"
+    """
+
     with :ok <- File.mkdir_p(Path.dirname(path)),
-         :ok <- File.write(path, "libretro_directory = \"#{dir()}\"\n") do
+         :ok <- File.write(path, contents) do
       :ok
     else
       {:error, reason} ->
@@ -415,7 +594,8 @@ defmodule MayonnaiOS.Cores do
   defmodule Startup do
     @moduledoc """
     Asserts the core arrangement once at boot: RetroArch's config names no core
-    directory, and the default one holds a link per core.
+    directory, carries no `autosave_interval` of its own, and the default core
+    directory holds a link per core.
 
     Cheap -- a listing and a handful of symlinks -- and it is the step that
     makes a RetroArch upgrade not lose the installed cores: `current` has
@@ -438,6 +618,9 @@ defmodule MayonnaiOS.Cores do
 
     def run do
       MayonnaiOS.Cores.clear_stale_directory()
+      # Unconditional, every boot, and that is what makes the autosave setting
+      # editable rather than permanent. See clear_persisted_autosave/1.
+      MayonnaiOS.Cores.clear_persisted_autosave()
       MayonnaiOS.Cores.write_append_config()
       MayonnaiOS.Cores.sync()
     rescue

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -27,6 +27,15 @@ defmodule MayonnaiOS.Launcher do
   program exits the panel still shows whatever that program left there. The
   viewport has to be told to repaint; `Scenic.ViewPort.set_root/3` does it.
 
+  ## Getting the saves onto the card
+
+  Reaping a program is also the only moment this VM knows that nobody is
+  writing to RetroArch's save files, and on a handheld switched off by pulling
+  its power that moment is worth using: RetroArch flushes the SRAM to the
+  kernel and never fsyncs it. So the two places this module learns that a
+  program has stopped both call `MayonnaiOS.Saves.flush/1`. That module has the
+  reasoning, including why the flush must not run while a program is up.
+
   ## The full set of bindings
 
       D-pad up/down move the menu cursor
@@ -148,6 +157,10 @@ defmodule MayonnaiOS.Launcher do
   @up_button :btn_dpad_up
   @down_button :btn_dpad_down
 
+  # How long after a deliberate stop to fsync the save files. See `do_stop/1`
+  # for why a stop needs a delay and a program exiting on its own does not.
+  @flush_delay 1_000
+
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
   @doc """
@@ -198,7 +211,7 @@ defmodule MayonnaiOS.Launcher do
   @impl GenServer
   def init(opts) do
     Enum.each(devices(opts), &watch/1)
-    {:ok, new_state()}
+    {:ok, new_state(opts)}
   end
 
   # The gamepad, plus whatever device the sleep key is on.
@@ -242,7 +255,7 @@ defmodule MayonnaiOS.Launcher do
     if File.exists?(device), do: InputEvent.start_link(device), else: {:error, :enoent}
   end
 
-  defp new_state,
+  defp new_state(opts),
     do: %{
       port: nil,
       app: nil,
@@ -251,6 +264,13 @@ defmodule MayonnaiOS.Launcher do
       held: MapSet.new(),
       scene: :home,
       selected: 0,
+      # Pushing the save files onto the card, at the one moment it is safe to:
+      # after the program that owns them has been reaped. Injectable because
+      # what a test can check is that it happens then and not at other times,
+      # and an fsync itself has no observable result from in here.
+      flush_saves: Keyword.get(opts, :flush_saves, &MayonnaiOS.Saves.flush/0),
+      # How long after a deliberate stop to flush. See `do_stop/1`.
+      flush_delay: Keyword.get(opts, :flush_delay, @flush_delay),
       # Whether the backlight was turned off by the chord. Kept here rather
       # than read back from sysfs on every event, because it is this process
       # that has to decide whether to swallow a press and because the panel
@@ -365,9 +385,28 @@ defmodule MayonnaiOS.Launcher do
   # and a log line that names the wrong binary is worse than none.
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
     Logger.info("[launcher] #{name_of(state.running)} exited (#{status})")
+
+    # The program is gone, which is what makes this safe: RetroArch's autosave
+    # hands the SRAM to the kernel and never fsyncs it, so on a device with no
+    # `sync` and no clean shutdown the save it just wrote is only as durable as
+    # the page cache. This is the moment nobody is writing to those files.
+    # MayonnaiOS.Saves has the full account, including why it must not happen
+    # while a program runs.
+    state.flush_saves.()
+
     repaint(state)
     {:noreply, %{state | port: nil, running: nil}}
   end
+
+  # A deliberate stop, one flush_delay later. See `do_stop/1`.
+  def handle_info(:flush_saves, %{port: nil} = state) do
+    state.flush_saves.()
+    {:noreply, state}
+  end
+
+  # Something is running again. Whatever the stop left in the page cache waits
+  # for that program's own exit rather than being fsynced underneath it.
+  def handle_info(:flush_saves, state), do: {:noreply, state}
 
   # Log what the program says, rather than dropping it.
   #
@@ -676,6 +715,18 @@ defmodule MayonnaiOS.Launcher do
     end
 
     _ = try do: Port.close(port), rescue: (_ -> :ok)
+
+    # Closing the port also throws away the exit message, so the clause above
+    # -- where the save flush belongs, because there the program is known to be
+    # gone -- never runs for a stop the player asked for. Hence a delay: one
+    # second after SIGTERM, RetroArch has either honoured it and written its
+    # SRAM, or it is hung and nothing is writing at all. Both are safe to
+    # fsync; fsyncing immediately would race the write itself.
+    #
+    # It is an approximation of "the program is gone" and it is only needed
+    # because this path does not wait for that. A stop path that waits for the
+    # process to actually die should flush there instead and drop the timer.
+    Process.send_after(self(), :flush_saves, state.flush_delay)
 
     Logger.info("[launcher] stopped #{name_of(state.running)}")
     repaint(state)

--- a/lib/mayonnaios/saves.ex
+++ b/lib/mayonnaios/saves.ex
@@ -1,0 +1,236 @@
+defmodule MayonnaiOS.Saves do
+  @moduledoc """
+  Pushes RetroArch's save files onto the card at the one moment this
+  application is allowed to: after the program that owns them has exited.
+
+  ## What this is for, and what it is not
+
+  `MayonnaiOS.Cores.write_append_config/0` makes RetroArch write the SRAM
+  `.srm` every ten seconds instead of only on a clean close. That fixes *when
+  the bytes are handed to the kernel*. It does not make them durable.
+
+  RetroArch's autosave writes through libretro-common's `filestream`, which
+  flushes to the kernel and does not fsync. The bytes then sit in the page
+  cache until f2fs writes them back on its own schedule -- and this device is
+  switched off by pulling its power, has no clean shutdown in normal use, and
+  has no `sync` binary, not even a busybox applet. A write that is not fsynced
+  is a write that survives exactly as long as the page cache. That has already
+  cost a set of ROMs once, which is why `MayonnaiOS.Files` fsyncs every copy it
+  makes.
+
+  The application cannot fsync RetroArch's handle -- it is RetroArch's, in
+  another process, and there is no syscall to reach it. What it can do is open
+  those files itself, once, and fsync them. On Linux `fsync(2)` takes any
+  descriptor for the file and flushes the *inode's* dirty pages, whoever
+  dirtied them, so a read-only handle opened after the writer is gone is
+  enough. That is the whole mechanism.
+
+  ## Why "after the program has exited" is load-bearing rather than convenient
+
+  Doing this while RetroArch runs would be worse than not doing it. An
+  autosave is a truncate followed by one 8 KB write; fsyncing in the middle of
+  that pair would make the truncation durable and the contents not, which is a
+  way of turning "a save from ten seconds ago" into "no save at all". The
+  window is microseconds wide and this would be a real bug in exchange for
+  nothing, because the next autosave rewrites the file anyway.
+
+  So there is no timer here. `MayonnaiOS.Launcher` calls `flush/1` when the
+  program it started has been reaped, which is the only moment this VM knows
+  that nobody is writing to those files. Two consequences worth stating:
+
+    * A power cable pulled *during* a game is not covered by this module at
+      all. What covers that is the autosave interval plus whatever f2fs has
+      already written back, and nothing in this firmware can do better without
+      an fsync it is not allowed to make.
+    * A flush runs after kmscube too. Nothing here models which programs write
+      saves, and an fsync of a file with no dirty pages is close to free, so
+      the launcher is not given a list to get wrong.
+
+  ## What is honestly not guaranteed
+
+  The *directory entry* is not fsynced: OTP cannot open a directory, so
+  `File.open/2` on one fails and there is no handle to sync. For a save file
+  that already existed this does not matter -- the name is old and only the
+  data is new. For a game's very first save the entry itself is new, and on
+  f2fs `fsync` of a newly created inode forces a checkpoint that persists the
+  parent directory with it. That last sentence is read from f2fs's behaviour
+  in `posix` fsync mode, not measured on this card, and it is the one claim
+  here that a power-pull test could falsify.
+
+  Nothing in this module is verified against a real power cut. What is
+  verified is that it opens the right directory, fsyncs every file in it, and
+  survives a directory that does not exist yet -- which is the state of a
+  device where nobody has saved anything.
+
+  ## Why savestates are not touched
+
+  `savestate_directory` holds megabyte-sized files written only when the
+  player explicitly asks, and no save state has yet been lost on this device.
+  Adding it would put multi-megabyte fsyncs on the path back from a game to
+  the menu for a failure nobody has had. If that changes, the directory
+  resolution below is the part to reuse.
+  """
+
+  require Logger
+
+  alias MayonnaiOS.{Bundle, Cores}
+
+  # A ceiling on the work one flush can do, most recently modified first.
+  #
+  # There is no bound on how many save files a card can accumulate, and this
+  # runs on the way back to the menu, where a long stall reads as the launcher
+  # having hung. Sorting by mtime is what makes a cap safe rather than
+  # arbitrary: a file that could still be dirty is a file that was written
+  # recently, and the ones past the cap were written in some earlier session
+  # and have long since been written back.
+  @max_files 64
+
+  @doc """
+  The directory RetroArch writes SRAM into.
+
+  Resolved rather than assumed, because getting it wrong would be invisible:
+  fsyncing an empty directory succeeds, logs a cheerful zero and protects
+  nothing. The order below is RetroArch's own precedence -- the main config is
+  read first and each `--appendconfig` file is merged over it, so the last
+  file to set the value wins.
+
+  A value of `"default"` or `""` is RetroArch saying it has no opinion, and a
+  value naming a directory that does not exist is one RetroArch itself would
+  drop on load, so both fall through to the default: `saves` beside the main
+  config, which is where `Snes9x 2010/Chrono Trigger (U) [!].srm` actually is
+  on the device.
+  """
+  def dir do
+    Application.get_env(:mayonnaios, :retroarch_save_dir) || configured_dir() || default_dir()
+  end
+
+  @doc """
+  Where RetroArch puts saves when nothing configures it: `saves` next to its
+  own config.
+  """
+  def default_dir, do: Path.join(Path.dirname(Cores.retroarch_config()), "saves")
+
+  @doc """
+  Fsync every save file, and answer with how many were synced.
+
+  `{:ok, 0}` for a directory that is not there yet or holds nothing -- a
+  device where no game has saved is not a device with a problem.
+
+  A file that cannot be opened or synced is logged and skipped rather than
+  aborting the rest: this runs on the way back to the menu, and one unreadable
+  file must not cost the flush of the save that matters.
+
+  Options are the test seams: `:dir` to point somewhere writable, and `:sync`
+  to stand in for `:file.sync/1` -- there is no way to observe from Elixir
+  whether an fsync reached the card, so what the tests check is that every
+  file gets one.
+  """
+  def flush(opts \\ []) do
+    dir = Keyword.get(opts, :dir, dir())
+    sync = Keyword.get(opts, :sync, &:file.sync/1)
+
+    case files(dir) do
+      [] ->
+        {:ok, 0}
+
+      files ->
+        synced = Enum.count(files, &(flush_file(&1, sync) == :ok))
+        Logger.info("[saves] fsynced #{synced}/#{length(files)} file(s) in #{dir}")
+        {:ok, synced}
+    end
+  end
+
+  # Read-only and :raw. Read-only because this must not be able to change a
+  # save file even by accident -- an fsync needs a descriptor, not write
+  # access. :raw because there is nothing to read: the handle exists solely to
+  # be synced, so there is no reason to put an IO server in front of it.
+  defp flush_file(path, sync) do
+    case File.open(path, [:read, :binary, :raw]) do
+      {:ok, handle} ->
+        result = sync.(handle)
+        File.close(handle)
+
+        case result do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("[saves] could not fsync #{path}: #{inspect(reason)}")
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        Logger.warning("[saves] could not open #{path}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  # Every regular file below the save directory, newest first, capped.
+  #
+  # Recursive because `sort_savefiles_enable = "true"` puts each core's saves
+  # in its own subdirectory, so the interesting file is one level down and a
+  # flat listing would find nothing.
+  defp files(dir) do
+    dir
+    |> Path.join("**")
+    |> Path.wildcard()
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.sort_by(&mtime/1, :desc)
+    |> Enum.take(@max_files)
+  end
+
+  # A file that cannot be stat'd sorts last rather than raising; it is still
+  # attempted, and the open will report whatever is actually wrong with it.
+  defp mtime(path) do
+    case File.stat(path, time: :posix) do
+      {:ok, %File.Stat{mtime: mtime}} -> mtime
+      {:error, _} -> 0
+    end
+  end
+
+  defp configured_dir do
+    Enum.find_value(config_files(), &savefile_directory/1)
+  end
+
+  # Least specific first, so `find_value` has to look at them in reverse:
+  # RetroArch merges each appended file over the main config, so the last one
+  # to set the value is the one that decides it.
+  defp config_files do
+    [Cores.retroarch_config(), bundle_config(), Cores.append_config()]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reverse()
+  end
+
+  # The config inside the installed RetroArch bundle, which the launcher
+  # appends on every launch. Named here from the same two facts the launch
+  # arguments are built from; nil when no bundle is installed.
+  defp bundle_config do
+    case Bundle.current("retroarch") do
+      nil -> nil
+      current -> Path.join([current, "share", "retroarch", "retroarch.cfg"])
+    end
+  end
+
+  defp savefile_directory(path) do
+    with {:ok, contents} <- File.read(path),
+         value when is_binary(value) <- setting(contents, "savefile_directory"),
+         false <- value in ["", "default"],
+         expanded = Path.expand(value),
+         true <- File.dir?(expanded) do
+      expanded
+    else
+      _ -> nil
+    end
+  end
+
+  defp setting(contents, key) do
+    contents
+    |> String.split("\n")
+    |> Enum.find_value(fn line ->
+      case Regex.run(~r/^\s*#{Regex.escape(key)}\s*=\s*"?(.*?)"?\s*$/, line) do
+        [_, value] -> value
+        nil -> nil
+      end
+    end)
+  end
+end

--- a/test/cores_test.exs
+++ b/test/cores_test.exs
@@ -276,8 +276,29 @@ defmodule MayonnaiOS.CoresTest do
     test "names the directory the symlinks go into", %{core_dir: core_dir} do
       assert :ok = Cores.write_append_config()
 
-      assert File.read!(Cores.append_config()) ==
+      assert File.read!(Cores.append_config()) =~
                ~s(libretro_directory = "#{core_dir}"\n)
+    end
+
+    test "turns SRAM autosave on, because off is what lost a save" do
+      # The device was found with autosave_interval = "0": the .srm is then
+      # written only when content closes cleanly, so every kill and every
+      # pulled power cable discards the session.
+      assert :ok = Cores.write_append_config()
+
+      assert File.read!(Cores.append_config()) =~
+               ~s(autosave_interval = "#{Cores.autosave_interval()}")
+
+      refute Cores.autosave_interval() == 0
+    end
+
+    test "the interval travels rather than being written twice" do
+      Application.put_env(:mayonnaios, :retroarch_autosave_interval, 42)
+      on_exit(fn -> Application.delete_env(:mayonnaios, :retroarch_autosave_interval) end)
+
+      Cores.write_append_config()
+
+      assert File.read!(Cores.append_config()) =~ ~s(autosave_interval = "42")
     end
 
     test "follows core_dir rather than repeating it", %{base: base} do
@@ -316,6 +337,91 @@ defmodule MayonnaiOS.CoresTest do
       Cores.Startup.run()
 
       assert File.read!(Cores.append_config()) =~ core_dir
+    end
+  end
+
+  # The autosave setting is asserted in the appended file and scrubbed out of
+  # the player's own config, and it is the scrub that makes it retractable: a
+  # value RetroArch persisted on exit is indistinguishable from one the player
+  # chose, so without this, `autosave_interval = "0"` would outlive every file
+  # that ever set it -- which is precisely what libretro_directory did.
+  describe "clear_persisted_autosave/0" do
+    setup %{core_dir: core_dir} do
+      cfg = Path.join(Path.dirname(core_dir), "retroarch.cfg")
+      prev = Application.get_env(:mayonnaios, :retroarch_config)
+      Application.put_env(:mayonnaios, :retroarch_config, cfg)
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:mayonnaios, :retroarch_config, prev),
+          else: Application.delete_env(:mayonnaios, :retroarch_config)
+      end)
+
+      %{cfg: cfg}
+    end
+
+    test "removes the value that lost the save, and leaves the rest alone", %{cfg: cfg} do
+      File.write!(cfg, """
+      video_driver = "gl"
+      autosave_interval = "0"
+      menu_driver = "rgui"
+      """)
+
+      assert {:ok, {:cleared, ["0"]}} = Cores.clear_persisted_autosave()
+
+      after_ = File.read!(cfg)
+      refute after_ =~ "autosave_interval"
+      assert after_ =~ ~s(video_driver = "gl")
+      assert after_ =~ ~s(menu_driver = "rgui")
+    end
+
+    test "removes the value this firmware itself asks for", %{cfg: cfg} do
+      # Unconditional on purpose, and this is the case that proves it. The
+      # value that decides a launch is the one in the appended file, merged
+      # last on every launch; the copy in the player's config is a fossil even
+      # when it agrees. Leaving agreeing values would mean a later change of
+      # mind could not take them back.
+      File.write!(cfg, ~s(autosave_interval = "#{Cores.autosave_interval()}"\n))
+
+      assert {:ok, {:cleared, _}} = Cores.clear_persisted_autosave()
+      refute File.read!(cfg) =~ "autosave_interval"
+    end
+
+    test "a key that merely looks similar is left alone", %{cfg: cfg} do
+      contents = """
+      savestate_auto_save = "false"
+      autosave_interval_unrelated = "5"
+      video_driver = "gl"
+      """
+
+      File.write!(cfg, contents)
+      assert {:ok, :unchanged} = Cores.clear_persisted_autosave()
+      assert File.read!(cfg) == contents
+    end
+
+    test "no config at all is not a failure", %{cfg: cfg} do
+      refute File.exists?(cfg)
+      assert {:ok, :no_config} = Cores.clear_persisted_autosave()
+    end
+
+    test "the rewrite leaves no temporary file behind", %{cfg: cfg} do
+      File.write!(cfg, ~s(autosave_interval = "0"\n))
+      assert {:ok, {:cleared, _}} = Cores.clear_persisted_autosave()
+      refute File.exists?(cfg <> ".mayonnaios")
+    end
+
+    test "boot scrubs the fossil and writes the setting again", %{cfg: cfg} do
+      # The pair, in the order the device runs it. Without the scrub half, a
+      # device that has ever run RetroArch keeps whatever it persisted and no
+      # later firmware can withdraw it.
+      File.write!(cfg, ~s(autosave_interval = "0"\n))
+
+      Cores.Startup.run()
+
+      refute File.read!(cfg) =~ "autosave_interval"
+
+      assert File.read!(Cores.append_config()) =~
+               ~s(autosave_interval = "#{Cores.autosave_interval()}")
     end
   end
 end

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -163,4 +163,72 @@ defmodule MayonnaiOS.LauncherTest do
       Launcher.selected()
     end
   end
+
+  # RetroArch hands its SRAM to the kernel and never fsyncs it, and this device
+  # is switched off by pulling the power. So the launcher fsyncs the saves at
+  # the moments it knows nothing is writing to them -- and, just as important,
+  # at no other moment. See MayonnaiOS.Saves.
+  describe "flushing the saves" do
+    setup do
+      test = self()
+      Application.put_env(:mayonnaios, :programs, [%{path: "/a"}])
+      on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
+
+      start_supervised!(
+        {Launcher,
+         device: "/nonexistent/event0",
+         flush_delay: 5,
+         flush_saves: fn -> send(test, :flushed) end}
+      )
+
+      :ok
+    end
+
+    test "when the program exits on its own" do
+      # state.port is nil here and the message names nil, so this drives the
+      # same clause a real exit drives: it is the reap that triggers the flush.
+      send(Launcher, {nil, {:exit_status, 0}})
+      assert Launcher.running?() == false
+      assert_receive :flushed
+    end
+
+    test "shortly after a deliberate stop, because closing the port loses the exit" do
+      # Pressing Menu closes the port, which throws away the exit message the
+      # clause above waits for. Without the timer, the most ordinary way to
+      # leave a game would be the one that never flushes.
+      port = spawn_sleeper()
+      :sys.replace_state(Launcher, &%{&1 | port: port})
+
+      Launcher.stop_program()
+      assert_receive :flushed, 500
+    end
+
+    test "not while something is running" do
+      # A flush underneath a running program could fsync a save mid-write,
+      # which would make a truncation durable -- the one way this mechanism
+      # could destroy the thing it exists to protect.
+      send(Launcher, :flush_saves)
+      Launcher.selected()
+      assert_receive :flushed
+
+      # The guard is on the port, so with one open there must be no flush.
+      port = spawn_sleeper()
+      :sys.replace_state(Launcher, &%{&1 | port: port})
+
+      send(Launcher, :flush_saves)
+      Launcher.selected()
+      refute_received :flushed
+
+      Launcher.stop_program()
+    end
+
+    # A real OS process for the launcher to hold, so the stop path signals
+    # something that exists rather than a port with no process behind it.
+    defp spawn_sleeper do
+      Port.open({:spawn_executable, System.find_executable("sleep")}, [
+        :exit_status,
+        args: ["30"]
+      ])
+    end
+  end
 end

--- a/test/saves_test.exs
+++ b/test/saves_test.exs
@@ -1,0 +1,259 @@
+defmodule MayonnaiOS.SavesTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Saves
+
+  # What cannot be tested from here: whether an fsync reached the card. There
+  # is no way to observe that from Elixir and no way to observe it on the
+  # device either without pulling the power mid-game. So `:sync` is injected
+  # and what these tests assert is the part that can be wrong silently -- that
+  # the right directory is found, and that every file in it gets a handle and a
+  # sync -- because a flush of the wrong directory succeeds, logs a cheerful
+  # zero, and protects nothing.
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "saves-test-#{System.unique_integer([:positive])}")
+    saves = Path.join(base, "saves")
+    File.mkdir_p!(saves)
+
+    keys = [:retroarch_config, :retroarch_append_config, :retroarch_save_dir, :bundle_root]
+    prev = Map.new(keys, &{&1, Application.get_env(:mayonnaios, &1)})
+
+    Application.put_env(:mayonnaios, :retroarch_config, Path.join(base, "retroarch.cfg"))
+    Application.put_env(:mayonnaios, :retroarch_append_config, Path.join(base, "mayonnaios.cfg"))
+    Application.put_env(:mayonnaios, :bundle_root, Path.join(base, "bundles"))
+    Application.delete_env(:mayonnaios, :retroarch_save_dir)
+
+    on_exit(fn ->
+      File.rm_rf(base)
+
+      Enum.each(prev, fn
+        {k, nil} -> Application.delete_env(:mayonnaios, k)
+        {k, v} -> Application.put_env(:mayonnaios, k, v)
+      end)
+    end)
+
+    %{base: base, saves: saves}
+  end
+
+  # A sync that records which file it was handed instead of syncing it, by
+  # reading the handle: every file below writes its own name as its contents,
+  # so a test can assert *which* files were flushed and not merely how many.
+  defp recorder do
+    test = self()
+
+    fn handle ->
+      send(test, {:synced, read(handle)})
+      :ok
+    end
+  end
+
+  defp read(handle) do
+    case :file.read(handle, 100) do
+      {:ok, data} -> data
+      other -> other
+    end
+  end
+
+  defp synced do
+    receive do
+      {:synced, what} -> [what | synced()]
+    after
+      0 -> []
+    end
+  end
+
+  describe "flush/1" do
+    test "fsyncs a save that is one directory down, because that is where it is",
+         %{saves: saves} do
+      # sort_savefiles_enable = "true", so the file is under a per-core
+      # directory: a flat listing of the save directory finds nothing at all.
+      core = Path.join(saves, "Snes9x 2010")
+      File.mkdir_p!(core)
+      File.write!(Path.join(core, "Chrono Trigger (U) [!].srm"), "chrono")
+
+      assert {:ok, 1} = Saves.flush(dir: saves, sync: recorder())
+      assert synced() == ["chrono"]
+    end
+
+    test "fsyncs every file, at any depth", %{saves: saves} do
+      File.write!(Path.join(saves, "top.srm"), "top")
+      File.mkdir_p!(Path.join(saves, "core/deeper"))
+      File.write!(Path.join(saves, "core/mid.srm"), "mid")
+      File.write!(Path.join(saves, "core/deeper/deep.srm"), "deep")
+
+      assert {:ok, 3} = Saves.flush(dir: saves, sync: recorder())
+      assert Enum.sort(synced()) == ["deep", "mid", "top"]
+    end
+
+    test "a directory that is not there yet is not a failure", %{base: base} do
+      # A device where nobody has saved anything. Reporting an error here would
+      # make the launcher log a warning on every exit of every program.
+      assert {:ok, 0} = Saves.flush(dir: Path.join(base, "nothing-here"), sync: recorder())
+      assert synced() == []
+    end
+
+    test "counts only the files it actually synced", %{saves: saves} do
+      # One unsyncable file must not cost the flush of the save that matters,
+      # and must not be counted as flushed either.
+      File.write!(Path.join(saves, "a.srm"), "a")
+      File.write!(Path.join(saves, "b.srm"), "b")
+
+      sync = fn _handle ->
+        if Process.put(:failed_once, true), do: :ok, else: {:error, :eio}
+      end
+
+      assert {:ok, 1} = Saves.flush(dir: saves, sync: sync)
+    end
+
+    test "directories are not opened", %{saves: saves} do
+      # File.open/2 on a directory fails, so a listing that included them would
+      # log a warning per subdirectory on every program exit -- which is how a
+      # log stops being worth reading.
+      File.mkdir_p!(Path.join(saves, "Snes9x 2010"))
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, 0} = Saves.flush(dir: saves, sync: recorder())
+        end)
+
+      refute log =~ "could not open"
+    end
+
+    test "is capped, and it is the most recently written that make the cut", %{saves: saves} do
+      # The cap bounds a flush that runs on the way back to the menu. Ordering
+      # by mtime is what makes it safe rather than arbitrary: a file that could
+      # still be dirty is one that was written recently, and the ones past the
+      # cap were written in an earlier session and are long since on the card.
+      for i <- 1..70 do
+        path = Path.join(saves, "game#{i}.srm")
+        File.write!(path, "game#{i}")
+        File.touch!(path, {{2020, 1, 1}, {0, 0, 0}} |> shift(i))
+      end
+
+      assert {:ok, 64} = Saves.flush(dir: saves, sync: recorder())
+
+      flushed = synced()
+      assert "game70" in flushed
+      assert "game7" in flushed
+      refute "game6" in flushed
+      refute "game1" in flushed
+    end
+
+    defp shift(datetime, seconds) do
+      datetime
+      |> NaiveDateTime.from_erl!()
+      |> NaiveDateTime.add(seconds)
+      |> NaiveDateTime.to_erl()
+    end
+
+    test "the handle it syncs cannot write to the save", %{saves: saves} do
+      # An fsync needs a descriptor, not write access, and a mechanism that
+      # exists to protect save files must not be able to damage one. The handle
+      # is opened read-only, so a write through it is refused by the kernel.
+      path = Path.join(saves, "a.srm")
+      File.write!(path, "a")
+
+      test = self()
+
+      # Attempted while the handle is open, which is the only moment the
+      # question means anything.
+      sync = fn handle ->
+        send(test, {:write, :file.write(handle, "clobbered")})
+        :ok
+      end
+
+      Saves.flush(dir: saves, sync: sync)
+
+      assert_received {:write, {:error, :ebadf}}
+      assert File.read!(path) == "a"
+    end
+  end
+
+  describe "dir/0" do
+    test "defaults to saves beside RetroArch's own config" do
+      assert Saves.dir() == Saves.default_dir()
+      assert Path.basename(Saves.dir()) == "saves"
+    end
+
+    test "an explicit configuration wins over everything", %{base: base} do
+      elsewhere = Path.join(base, "elsewhere")
+      File.mkdir_p!(elsewhere)
+      Application.put_env(:mayonnaios, :retroarch_save_dir, elsewhere)
+      on_exit(fn -> Application.delete_env(:mayonnaios, :retroarch_save_dir) end)
+
+      assert Saves.dir() == elsewhere
+    end
+
+    test "follows savefile_directory out of the player's config", %{base: base} do
+      elsewhere = Path.join(base, "player-said-here")
+      File.mkdir_p!(elsewhere)
+      File.write!(config(), ~s(savefile_directory = "#{elsewhere}"\n))
+
+      assert Saves.dir() == elsewhere
+    end
+
+    test "an appended file wins over the player's config, as RetroArch merges them",
+         %{base: base} do
+      # --appendconfig is merged over the main config, so the last file to set
+      # the value is the one that decides where the saves actually go.
+      player = Path.join(base, "player")
+      appended = Path.join(base, "appended")
+      File.mkdir_p!(player)
+      File.mkdir_p!(appended)
+
+      File.write!(config(), ~s(savefile_directory = "#{player}"\n))
+      File.write!(MayonnaiOS.Cores.append_config(), ~s(savefile_directory = "#{appended}"\n))
+
+      assert Saves.dir() == appended
+    end
+
+    test "the bundle's config is read too", %{base: base} do
+      # The launcher appends it on every launch, and it is a separately
+      # versioned artifact that has already been wrong about a directory once.
+      elsewhere = Path.join(base, "bundle-said-here")
+      File.mkdir_p!(elsewhere)
+
+      cfg = Path.join([base, "bundles", "retroarch", "1.0.0", "share", "retroarch"])
+      File.mkdir_p!(cfg)
+      File.write!(Path.join(cfg, "retroarch.cfg"), ~s(savefile_directory = "#{elsewhere}"\n))
+
+      File.ln_s!(
+        Path.join([base, "bundles", "retroarch", "1.0.0"]),
+        Path.join([base, "bundles", "retroarch", "current"])
+      )
+
+      assert Saves.dir() == elsewhere
+    end
+
+    test ~s(a value of "default" means RetroArch has no opinion) do
+      File.write!(config(), ~s(savefile_directory = "default"\n))
+
+      assert Saves.dir() == Saves.default_dir()
+    end
+
+    test "an empty value does not resolve to the working directory" do
+      # This is the one that needs the name check rather than the directory
+      # check: Path.expand("") is the cwd, which exists, so an empty setting
+      # would otherwise be accepted and every flush would fsync whatever the
+      # VM happens to be sitting in.
+      File.write!(config(), ~s(savefile_directory = ""\n))
+
+      assert Saves.dir() == Saves.default_dir()
+    end
+
+    test "a directory that does not exist is one RetroArch would drop too", %{base: base} do
+      File.write!(config(), ~s(savefile_directory = "#{Path.join(base, "gone")}"\n))
+
+      assert Saves.dir() == Saves.default_dir()
+    end
+
+    test "a config that says nothing about saves falls through" do
+      File.write!(config(), ~s(video_driver = "gl"\nsavestate_directory = "/root/states"\n))
+
+      assert Saves.dir() == Saves.default_dir()
+    end
+
+    defp config, do: MayonnaiOS.Cores.retroarch_config()
+  end
+end


### PR DESCRIPTION
## Summary

`/root/.config/retroarch/retroarch.cfg` on the device has `autosave_interval = "0"`, so RetroArch writes the SRAM `.srm` only when content closes cleanly. Every kill, hang and power pull therefore discards all in-game progress since the ROM was loaded — which is what happened repeatedly to a Chrono Trigger save while a hung RetroArch was being SIGKILLed to diagnose the audio fault #9 fixes. This turns autosave on, and then makes the autosaved bytes actually reach the card.

## The interval: ten seconds

The tradeoff looked like "loss window vs. writes to a card that times out on erase", and it mostly is not one: RetroArch's autosave thread compares the SRAM against its last copy and writes only when it differs, so the interval decides how *soon* a save reaches the card, not how often 8 KB is written. Ten rather than sixty for that reason; ten rather than one so a game that rewrites a checksum region repeatedly coalesces into one write. The change-gating is read from RetroArch's autosave thread, not measured — if it writes unconditionally, `@autosave_interval` is the only thing to move.

Worth being exact about what ten seconds buys, because it is narrower than it sounds: SRAM holds what the *game* wrote, so this makes an in-game save durable shortly after the player makes it. It does not save the walk between save points, and nothing can.

## Where it lives, and how it is retracted

In `Cores.write_append_config/0` — the file appended last on every launch — paired with an unconditional boot-time scrub of `autosave_interval` from the player's own config. That is the `--appendconfig` trap: RetroArch merges the appended value into its main config before reading anything and persists it as though the player had chosen it, so without the scrub, `autosave_interval = "0"` (or `"10"`) would outlive every file that set it and no later firmware could withdraw it. With the scrub, changing the interval is editing one line and no device needs repairing afterwards. Deliberately the same shape as #9's `audio_sync`, and after the merge the two share `strip/3`, `value_of/2` and one boot pass. The price: this firmware now owns the setting, so a value chosen in RetroArch's Saving menu will not survive a reboot.

## Why the fsync is worth building

Autosaving alone would have been the durability theatre this project warns about. RetroArch writes through libretro-common's `filestream`, which flushes and does not fsync, so an autosaved `.srm` sits in the page cache until f2fs writes it back — on a device with no `sync` binary and no clean shutdown. The launcher can't fsync RetroArch's handle, but `fsync(2)` takes any descriptor for the file and flushes the inode's dirty pages whoever dirtied them, so opening the saves read-only once the program is gone is enough, and it is the case that matters most: kill, then power pull.

It must not happen at any other time. An autosave is a truncate plus one 8 KB write; fsyncing between the two would make the truncation durable and the contents not, which is the one way this could destroy what it protects.

## What the merge with trunk changed

The original branch flushed on reap and, for a deliberate stop, a second later on a timer — because the old stop path signalled and hoped, so "the program is gone" was not knowable there. #9's stop path escalates to SIGKILL and *confirms* death before `finish_stop/1` runs, so the flush moved there and the timer, its deferred message and its port guard are all deleted. The guard is now structural rather than a heuristic: a stop that reports `{:error, {:still_running, pid}}` never reaches a flush. The tests moved into #9's harness too — real `/bin/sh` processes and the `Unkillable` fake — so "does not flush when the program survived SIGKILL" is now tested against an actual survivor instead of a stand-in.

Rejected on the way past: `savestate_auto_save`. It writes on a clean close — the path that already works and never the one that failed — so it would add megabyte writes to every ordinary exit and tie a resume state to the core version that wrote it, in exchange for nothing where the loss happens.

## Follow-ups for reviewer

- The save directory is resolved by parsing `savefile_directory` out of the three configs that can set it, in RetroArch's precedence order, because fsyncing the wrong directory succeeds and protects nothing. Is that worth the parsing, or would you rather pin it to `~/.config/retroarch/saves` and let it break loudly?
- Savestates are not flushed (megabyte files, no loss reported yet). Say if you want them in.
- Both flush sites sit after `Panel.release()` and the repaint, so the screen comes back before an fsync that can stall on this card. Nothing can launch before either clause returns, so it costs no safety — but if you would rather the fsync completed before the panel is handed back, it is a two-line move.
- Noticed while resolving the merge and fixed here: the reap clause was repainting twice. The host suite cannot see it (no viewport), so nothing tests it. Worth a `set_root` seam, separately?
- Two things can only be settled on the device, which has been unreachable (`nerves.local:22` refused) throughout: that fsync on a read-only descriptor flushes another process's dirty pages on this kernel (`:ok` on the host; `do_fsync` has no write-mode check), and that a game actually keeps its save across a pulled cable.
