### PR TITLE
Move sleep onto the power button

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Software:
 - RetroArch, with cores installed and upgraded independently of the firmware
 - Checksum-verified bundle install, with versioned directories and rollback
 - A web UI for uploading games from a phone
-- Sleep on Select+Start: the backlight goes off and any button brings it back.
-  Not the power button, which Linux cannot see on this board, and not suspend —
-  no button on the front of the device is wakeup-capable, so a real suspend
-  would look like a brick
+- Sleep on the power button: the backlight goes off and any button brings it
+  back. Not suspend — only `s2idle` exists here, it aborts inside rtw88's SDIO
+  suspend handler, and with no cpuidle driver the cores are in a bare WFI
+  either way, so a successful one would save almost nothing
 
 ## Building and flashing
 
@@ -466,12 +466,14 @@ host-only path:
 | `c` | X — the diagnostics screen |
 | enter | Menu — back to the home screen |
 | backspace | Select |
-| `s` | Start — with backspace held, the sleep chord |
+| `p` | the power button — sleep, and any key wakes it |
 | escape | Select+Menu, the power-off chord |
 
-`x` and `v` are sent too, as B and Y, and do nothing — the launcher binds
-neither. None of this is conditional on the target, so a USB keyboard plugged
-into the handheld gets the same bindings.
+`x`, `v` and `s` are sent too, as B, Y and Start, and do nothing — the launcher
+binds none of them. None of this is conditional on the target, so a USB
+keyboard plugged into the handheld gets the same bindings. `p` is the one key
+that is not a pad button: it sends `KEY_POWER`, which on the device arrives
+from `axp20x-pek` rather than from the gamepad.
 
 Rendering on the host goes through `scenic_driver_local`'s cairo-gtk backend,
 which wants `gtk+3`, `cairo`, `pkgconf` and, on macOS, XQuartz. On the device
@@ -483,27 +485,23 @@ a scratch directory and start `MayonnaiOS.Web` under a supervisor.
 
 ## Not done yet
 
-**The analog stick.** The shell has one and nothing in this firmware can see
-it. Linux is not being told it exists: the `adc-joystick` driver is not built
-(`CONFIG_JOYSTICK_ADC`), there is no joystick node in the device tree, and no
-ADC driver for the H700 for such a node to read. Confirmed on the device
-rather than inferred: `InputEvent.enumerate/0` shows three input devices —
-fifteen gamepad keys, two volume keys, the headphone switch — and no `ev_abs`
-anywhere. No amount of work in this repository changes that; it is a device
-tree node and two kernel options in
-[`nerves_system_rg40xxv`](https://github.com/kek/nerves_system_rg40xxv).
+**The analog stick.** Linux can see it now and nothing in this firmware
+reads it. The BSP side is done — the `adc-joystick` driver is built, the node
+is in the device tree, and there is an ADC driver behind it — which is a
+change from what this section used to say, and the correction is worth
+recording: it claimed the driver was absent and the node did not exist, and it
+went on claiming it after both had shipped, because nothing in this repository
+looks at the stick and so nothing here noticed. Read off the device on
+firmware `3cc86f59`:
 
-The reason it was missed is legible in the device tree itself. This board's
-DTS extends mainline's `sun50i-h700-anbernic-rg35xx-plus.dts`, and the RG35XX
-Plus has no stick — so the inherited description is complete and correct for
-a device that is not quite this one. Everything the two boards share came
-across; the one control they do not share is the one that is missing.
+    /dev/input/event1  adc-joystick  ev_abs: [abs_x: 0..4096, abs_y: 0..4096]
 
-Once it is there, the work on this side is small and known. The Bluetooth
-report descriptor gains X and Y axes fed by `ABS_X` and `ABS_Y`, taking the
-report from three bytes back to five, and whichever input device the driver
-creates has to be read alongside `event0` — `MayonnaiOS.Launcher` owns that
-one today and would own the stick's too, forwarding both to the app.
+Live values, centred at about 2050 on both axes. What is left is on this side.
+The Bluetooth report descriptor gains X and Y axes fed by `ABS_X` and `ABS_Y`,
+taking the report from three bytes back to five, and the `adc-joystick` node
+has to be opened alongside the gamepad — `MayonnaiOS.Launcher` already opens
+two devices for exactly this reason (the pad and the power key) and would open
+a third, forwarding all of it to the app.
 
 Worth being precise about why those axes are correct when the ones removed in
 the commit before this were a bug: the axes that had to go were the *D-pad*

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -151,7 +151,7 @@ defmodule MayonnaiOS.Application do
         MayonnaiOS.Web,
 
         # A launches the selected program, Menu goes back to the home screen,
-        # X opens the diagnostics readout, Select+Start turns the backlight
+        # X opens the diagnostics readout, the power button turns the backlight
         # off until any button is pressed, and Select+Menu powers off.
         MayonnaiOS.Launcher
       ] ++ boot_diagnostics()

--- a/lib/mayonnaios/controller/pad.ex
+++ b/lib/mayonnaios/controller/pad.ex
@@ -2,10 +2,10 @@ defmodule MayonnaiOS.Controller.Pad do
   @moduledoc """
   Holds what is currently pressed, and tells the host when that changes.
 
-  The gamepad is read by `MayonnaiOS.Launcher`, which owns `event0` and always
-  has. This process does not open the device: the launcher forwards whole
-  evdev reports here while controller mode is on. One reader, one owner, and
-  the buttons keep working exactly as they did -- which also means the
+  The gamepad is read by `MayonnaiOS.Launcher`, which owns `gpio-keys-gamepad`
+  and always has. This process does not open the device: the launcher forwards
+  whole evdev reports here while controller mode is on. One reader, one owner,
+  and the buttons keep working exactly as they did -- which also means the
   keyboard bridge in `MayonnaiOS.Keyboard` drives the controller too, so the
   whole path can be exercised from a laptop with no handheld attached.
 

--- a/lib/mayonnaios/controller/report.ex
+++ b/lib/mayonnaios/controller/report.ex
@@ -33,12 +33,14 @@ defmodule MayonnaiOS.Controller.Report do
 
   No axes are declared, and that is a statement about the kernel rather than
   about the hardware. This shell *does* have an analog stick -- unlike the
-  RG35XX Plus whose device tree this board's was extended from -- but nothing
-  in this firmware can see it: no `adc-joystick` driver, no joystick node, so
-  no `ev_abs` on any input device. `InputEvent.enumerate/0` on the device
-  shows `event0` offering fifteen keys and nothing else. Declaring axes that
-  no input can ever move would put a dead stick in front of every host. The
-  README's roadmap has what enabling it would take.
+  RG35XX Plus whose device tree this board's was extended from -- and Linux
+  can now see it: `adc-joystick` is built, the node is in the device tree, and
+  `InputEvent.enumerate/0` on firmware `3cc86f59` shows it with `abs_x` and
+  `abs_y` over 0..4096. This descriptor still declares no axes because
+  *nothing in this firmware reads that device*, and axes fed by nothing would
+  put a dead stick in front of every host just as surely as axes with no
+  driver behind them. What is missing is now on this side; the README's
+  roadmap has it.
 
   ## The D-pad used to be declared twice, and that was the bug
 
@@ -119,8 +121,8 @@ defmodule MayonnaiOS.Controller.Report do
 
   ## What is verified and what is not
 
-  The kernel's own capability list settles most of it. `event0` declares
-  exactly fifteen keys:
+  The kernel's own capability list settles most of it. `gpio-keys-gamepad`
+  declares exactly fifteen keys:
 
       btn_a btn_b btn_x btn_y btn_tl btn_tr btn_tl2 btn_tr2
       btn_select btn_start btn_mode

--- a/lib/mayonnaios/dev.ex
+++ b/lib/mayonnaios/dev.ex
@@ -2,7 +2,7 @@ defmodule MayonnaiOS.Dev do
   @moduledoc """
   Buttons for a laptop, so scenes can be driven without the handheld.
 
-  The host has no `/dev/input/event0`, so `MayonnaiOS.Launcher` starts with no
+  The host has no `/dev/input` at all, so `MayonnaiOS.Launcher` starts with no
   device and simply never receives anything. It still handles the messages the
   real driver would send, though, which is all this needs: each function here
   sends one synthetic evdev press and lets the Launcher do exactly what it
@@ -91,7 +91,21 @@ defmodule MayonnaiOS.Dev do
   end
 
   @doc """
+  Press the power button: the backlight goes off, and any press brings it back.
+
+  Not in the table above, because it is not on the pad. On the device this
+  arrives from `axp20x-pek` rather than from the gamepad; the Launcher reads
+  both nodes and does not look at which one a report came from, so one
+  synthetic `:key_power` exercises the same path.
+  """
+  def power, do: press(:key_power)
+
+  @doc """
   Press and hold Select, then Menu: the power-off chord.
+
+  Not the power button. A short press of that is `power/0` above and sleeps; a
+  four-second hold makes the PMIC cut the rail without telling Linux, which is
+  why an orderly shutdown is still a chord. See `MayonnaiOS.Sleep`.
 
   On the device this powers off, so it is spelled out rather than given a
   one-letter name. On the host `Nerves.Runtime.poweroff/0` is a no-op, which
@@ -114,8 +128,8 @@ defmodule MayonnaiOS.Dev do
 
   # One synthetic report, shaped exactly like input_event's. The device string
   # is a lie and deliberately an obvious one: the Launcher ignores it, and a
-  # plausible-looking "/dev/input/event0" in a host session would invite the
-  # reader to believe something is really open.
+  # plausible-looking device node in a host session would invite the reader to
+  # believe something is really open.
   defp send_events(events) do
     send(Launcher, {:input_event, "(MayonnaiOS.Dev)", events})
   end

--- a/lib/mayonnaios/diagnostics.ex
+++ b/lib/mayonnaios/diagnostics.ex
@@ -15,16 +15,21 @@ defmodule MayonnaiOS.Diagnostics do
 
   ## Why it opens two input devices
 
-  The gamepad is `event0` and `MayonnaiOS.Launcher` has it. `InputEvent`
+  `MayonnaiOS.Launcher` has the gamepad and the power key. `InputEvent`
   delivers to whichever process opened the device, so the two devices the
-  Launcher does not read are opened here:
+  Launcher does not read are opened here, by name:
 
-      event1  gpio-keys-volume            KEY_VOLUMEDOWN 114, KEY_VOLUMEUP 115
-      event2  H616 Audio Codec Headphone  SW_HEADPHONE_INSERT
+      gpio-keys-volume                 KEY_VOLUMEDOWN 114, KEY_VOLUMEUP 115
+      H616 Audio Codec Headphone Jack  SW_HEADPHONE_INSERT
 
   Both codes were read from `/sys/firmware/devicetree/base/gpio-keys-volume/`
   on the device rather than assumed. They happen to be the obvious ones this
   time; the gamepad's were not, which is the reason for looking.
+
+  No numbers in that table, because the numbers have moved twice and the
+  numbers this module used to name are now other devices -- `event1` is the
+  analog stick and `event2` is the gamepad. `MayonnaiOS.Input` has the current
+  numbering and the argument for not writing it down here.
 
   `MayonnaiOS.Volume` opens the rocker as well, and acts on it. Both readers
   get every event -- evdev is only exclusive to a reader that asks for
@@ -55,12 +60,13 @@ defmodule MayonnaiOS.Diagnostics do
 
   alias MayonnaiOS.Bluetooth.HCISocket
 
-  # Looked up by name at startup, with these as the fallback; see
-  # `MayonnaiOS.Input` for why the numbering is not something to rely on.
+  # Looked up by name at startup, and by name only. These used to carry a
+  # numbered fallback each -- `event1` and `event2` -- and both numbers had
+  # already moved: they are the analog stick and the gamepad now, so the
+  # fallbacks would have counted volume presses on a device that has no keys
+  # and queried a jack switch on one that has no switch. See `MayonnaiOS.Input`.
   @volume_name "gpio-keys-volume"
-  @volume_device "/dev/input/event1"
   @jack_name "H616 Audio Codec Headphone Jack"
-  @jack_device "/dev/input/event2"
 
   # The blob whose absence stops Bluetooth from initialising. See the long
   # comment against BR2_PACKAGE_LINUX_FIRMWARE_RTL_87XX_BT in nerves_defconfig.
@@ -128,8 +134,8 @@ defmodule MayonnaiOS.Diagnostics do
 
   @impl GenServer
   def init(_opts) do
-    open(MayonnaiOS.Input.find(@volume_name, @volume_device))
-    open(MayonnaiOS.Input.find(@jack_name, @jack_device))
+    open(@volume_name)
+    open(@jack_name)
 
     # Without this the fdinfo engine counters stay at zero, which would look
     # exactly like a GPU doing nothing.
@@ -163,10 +169,10 @@ defmodule MayonnaiOS.Diagnostics do
   # One handler for both devices, matching on what the event *is* rather than
   # on which path it came from.
   #
-  # These used to be two clauses keyed on "/dev/input/event1" and
-  # "/dev/input/event2". That worked while those numbers were stable, and
-  # /dev/input numbering is probe order rather than a promise -- adding one
-  # device to the board is enough to move it. The two kinds of event here are
+  # These used to be two clauses keyed on the two devices' numbered paths. That
+  # worked while those numbers were stable, and /dev/input numbering is probe
+  # order rather than a promise -- adding one device to the board is enough to
+  # move it, which has since happened twice. The two kinds of event here are
   # disjoint, a volume key and a jack switch, so the path was never carrying
   # information in the first place.
   def handle_info({:input_event, _device, events}, state) do
@@ -403,26 +409,42 @@ defmodule MayonnaiOS.Diagnostics do
 
   # -- helpers ---------------------------------------------------------------
 
-  defp open(device) do
-    case InputEvent.start_link(device) do
-      {:ok, _pid} ->
-        :ok
-
-      other ->
+  # Takes the driver name rather than a path, so the "there is no such device"
+  # case is a line naming the thing that is missing instead of a number that
+  # would have been some other device's.
+  defp open(name) do
+    case MayonnaiOS.Input.find(name) do
+      nil ->
         # Losing one of these costs a diagnostic, not the boot.
-        Logger.warning("[diagnostics] #{device} unavailable: #{inspect(other)}")
+        Logger.warning("[diagnostics] no #{name} input device; its readings stay blank")
         :error
+
+      device ->
+        case InputEvent.start_link(device) do
+          {:ok, _pid} ->
+            :ok
+
+          other ->
+            Logger.warning("[diagnostics] #{device} unavailable: #{inspect(other)}")
+            :error
+        end
     end
   end
 
-  # evtest exits 10 when the switch is set, 0 when it is not.
+  # evtest exits 10 when the switch is set, 0 when it is not. No jack device
+  # means nil -- "nobody could ask", which is what nil already means for this
+  # field and is not the same as "nothing is plugged in".
   defp query_jack do
-    jack = MayonnaiOS.Input.find(@jack_name, @jack_device)
+    case MayonnaiOS.Input.find(@jack_name) do
+      nil ->
+        nil
 
-    case cmd_status("evtest", ["--query", jack, "EV_SW", "SW_HEADPHONE_INSERT"]) do
-      {:ok, 10} -> true
-      {:ok, 0} -> false
-      _ -> nil
+      jack ->
+        case cmd_status("evtest", ["--query", jack, "EV_SW", "SW_HEADPHONE_INSERT"]) do
+          {:ok, 10} -> true
+          {:ok, 0} -> false
+          _ -> nil
+        end
     end
   end
 

--- a/lib/mayonnaios/file_manager.ex
+++ b/lib/mayonnaios/file_manager.ex
@@ -116,7 +116,7 @@ defmodule MayonnaiOS.FileManager do
 
   Under a DynamicSupervisor rather than linked to the caller, which is how
   `MayonnaiOS.Controller` starts too. `MayonnaiOS.Launcher` calls this from
-  inside the process that owns `event0`, so a link would mean that a bug in
+  inside the process that owns the gamepad, so a link would mean that a bug in
   here -- a directory that turns into something odd halfway through a listing,
   say -- takes the launcher down with it, and the device then stops answering
   its buttons at all.
@@ -173,7 +173,7 @@ defmodule MayonnaiOS.FileManager do
   @doc """
   Forward an evdev report from the Launcher.
 
-  A cast: this is called from the process holding `event0`, and a directory
+  A cast: this is called from the process holding the gamepad, and a directory
   listing must never be able to make the buttons late. Safe when the app is
   not running, because the launcher's view of that and the actual state can
   differ for as long as it takes to stop.

--- a/lib/mayonnaios/input.ex
+++ b/lib/mayonnaios/input.ex
@@ -1,32 +1,50 @@
 defmodule MayonnaiOS.Input do
   @moduledoc """
-  Finding an input device by what it is rather than by what it is numbered.
+  Finding an input device by what it is, and saying so when it is not there.
 
   `/dev/input/eventN` is assigned in probe order, and probe order is not a
-  promise. Three devices on this board were reliably `event0`, `event1` and
-  `event2` for as long as there were only three, and every caller wrote those
-  paths down. Adding a fourth -- the analog stick, once the BSP describes it
-  -- changes the number of things racing to register, and the failure that
-  produces is the worst-shaped one available: the launcher opens `event0`,
-  gets the joystick, and the handheld boots with no buttons and no way to
-  leave whatever is on the screen.
+  promise. It has now moved twice. Three devices were reliably `event0`,
+  `event1` and `event2` for as long as there were only three, and every caller
+  wrote those numbers down; then the BSP grew an `adc-joystick` node, and then
+  `CONFIG_INPUT_AXP20X_PEK` added the power key ahead of it. Read off the
+  device on firmware `3cc86f59`:
 
-  So the device is looked up by the name its driver gives it, which comes
-  from the device tree and changes only when someone changes it on purpose:
+      event0  axp20x-pek                       the power button
+      event1  adc-joystick                     the analog stick, read by nothing
+      event2  gpio-keys-gamepad                the buttons and the D-pad
+      event3  gpio-keys-volume                 the volume rocker
+      event4  H616 Audio Codec Headphone Jack  the jack switch
 
-      gpio-keys-gamepad             the buttons and the D-pad
-      gpio-keys-volume              the volume rocker
-      H616 Audio Codec Headphone Jack   the jack switch
+  Every number in that table is different from the one the same device had two
+  firmware revisions ago. It is here to be read, not to be depended on: what
+  callers ask for is the name, which comes from the device tree and changes
+  only when somebody changes it on purpose.
 
-  ## The fallback is the point
+  ## There is no fallback, and that is the point
 
-  `find/2` takes the path to use when the name is not found, and that path is
-  the one the caller used to hard-code. So this is strictly safer than what
-  it replaces: when enumeration works and the name is there, the answer is
-  right even if the numbering moved; when enumeration finds nothing -- on a
-  laptop, where there is no `/dev/input` at all -- the caller gets exactly
-  the behaviour it had before, which is to try the old path and degrade
-  gracefully when it does not open.
+  `find/2` used to take the numbered path to use when the name was not found --
+  the path each caller had hard-coded before this module existed -- and that
+  read as strictly safer than what it replaced. It was not.
+
+  A fallback only ever runs in the state where the name is absent, and a
+  number reached in that state does not name a worse version of the right
+  device. It names a different device. `event1` is the analog stick: opening it
+  and waiting for `KEY_VOLUMEUP` waits for ever, and every symptom of that is
+  an absence -- the button does nothing, the log says nothing, and the code
+  reads as though the case were handled. That is this project's characteristic
+  failure with a helpful-looking name on it, and it was live in four modules
+  the whole time the numbering was wrong, because a fallback behind a working
+  lookup is never exercised and never noticed.
+
+  It also never did the job it was kept for. A laptop has no `/dev/input` at
+  all, so the fallback there was a path that does not exist handed to a caller
+  that checks `File.exists?/1` before opening it. Nothing on the host path
+  needed the string to look like a device node.
+
+  So `find/1` answers `nil`, and says so out loud: a warning naming the device
+  that is missing and every device that is present. What losing a device costs
+  is the caller's own business -- no rocker is not a failed boot -- but no
+  caller can now reach the wrong one.
 
   There is deliberately no caching. This is called once per process at
   startup, the answer is two file reads, and a cache would be a second thing
@@ -36,28 +54,30 @@ defmodule MayonnaiOS.Input do
   require Logger
 
   @doc """
-  The path of the input device called `name`, or `fallback`.
+  The path of the input device called `name`, or `nil` when there is none.
 
-  Enumeration is wrapped because `InputEvent.enumerate/0` reaches for a port
-  binary that is only built on Linux; on a development machine it can raise
-  rather than return an empty list, and a raise here would take down whichever
-  process was merely trying to find its buttons.
+  The success is logged at info because the boot log is then a record of what
+  the numbering actually was on the firmware that booted, which is the one
+  thing nobody can reconstruct afterwards.
+
+  The failure is logged at warning, naming every device that *is* present,
+  because a name that is not there means a device tree or a kernel config
+  changed underneath this code -- and the only thing worse than a button that
+  does nothing is a button that does nothing while the log stays quiet about
+  which devices the kernel does have.
   """
-  @spec find(String.t(), String.t()) :: String.t()
-  def find(name, fallback) do
-    case Enum.find(enumerate(), fn {_path, info} -> info.name == name end) do
-      {path, _info} ->
-        if path != fallback do
-          # Worth an info line rather than a debug one: this is the moment
-          # the numbering turned out not to be what the code assumed, and it
-          # explains why a later log line names a device nobody configured.
-          Logger.info("[input] #{name} is #{path}, not #{fallback}")
-        end
+  @spec find(String.t()) :: String.t() | nil
+  def find(name) do
+    devices = names()
 
+    case Enum.find(devices, fn {_path, device_name} -> device_name == name end) do
+      {path, _name} ->
+        Logger.info("[input] #{name} is #{path}")
         path
 
       nil ->
-        fallback
+        Logger.warning("[input] no input device named #{name}; present: #{inspect(devices)}")
+        nil
     end
   end
 

--- a/lib/mayonnaios/keyboard.ex
+++ b/lib/mayonnaios/keyboard.ex
@@ -3,9 +3,9 @@ defmodule MayonnaiOS.Keyboard do
   Drives the launcher from a keyboard, by pretending to be the gamepad.
 
   The handheld's buttons reach `MayonnaiOS.Launcher` as evdev reports from
-  `/dev/input/event0`. A laptop has no such device, so this process subscribes
-  to Scenic's `:key` and `:codepoint` input and re-sends each keystroke in
-  exactly the shape the real driver uses:
+  `gpio-keys-gamepad`, and its power button as one from `axp20x-pek`. A laptop
+  has neither, so this process subscribes to Scenic's `:key` and `:codepoint`
+  input and re-sends each keystroke in exactly the shape the real driver uses:
 
       {:input_event, device, [{:ev_key, :btn_dpad_down, 1}]}
 
@@ -31,7 +31,7 @@ defmodule MayonnaiOS.Keyboard do
       c                   X -- the diagnostics screen
       enter               Menu -- back to the home screen
       backspace           Select
-      s                   Start -- with backspace held, the sleep chord
+      p                   the power button -- sleep, and any key wakes
       escape              Select+Menu, the power-off chord
 
   Arrows and `jk` both move because the arrows are where a hand goes first and
@@ -39,10 +39,18 @@ defmodule MayonnaiOS.Keyboard do
   rather than the letter printed on the shell, because the physical layout has
   no left-to-right mapping onto a keyboard worth guessing at.
 
-  `x` and `v` are also sent, as B and Y, and deliberately do nothing: the
-  Launcher binds neither. They are here so the mapping is complete and so those
-  presses reach the Launcher's unhandled-key logging rather than being dropped
-  silently -- if B or Y ever gains a binding, the keyboard already has it.
+  `x`, `v` and `s` are also sent, as B, Y and Start, and deliberately do
+  nothing: the Launcher binds none of them. They are here so the mapping is
+  complete and so those presses reach the Launcher's unhandled-key logging
+  rather than being dropped silently -- if one of them ever gains a binding,
+  the keyboard already has it. `s` is in that list rather than being the sleep
+  key because sleep left the pad: it was Select+Start, and it is now the power
+  button, which is `p`.
+
+  `p` is the one key here that is not a pad button. It sends `:key_power`, the
+  only key `axp20x-pek` has, and the Launcher reads that node alongside the
+  pad -- so a keystroke that arrives from neither is still handled by exactly
+  the code the device runs.
   """
 
   use GenServer
@@ -87,12 +95,14 @@ defmodule MayonnaiOS.Keyboard do
     "c" => :btn_y,
     # Y, also unbound in the Launcher
     "v" => :btn_x,
-    # Start, which the Launcher does not bind on its own either -- but held
-    # with backspace it is Select+Start, the sleep chord. A codepoint has no
-    # release, and this is the one key where that is worth saying: the chord
-    # works because *Select* is held through the :key path, and `s` only has
-    # to be the press that completes it.
-    "s" => :btn_start
+    # Start, which the Launcher does not bind. It was half of the sleep chord
+    # until the power key existed; see the moduledoc.
+    "s" => :btn_start,
+    # Not a pad button at all: the power button, which on the device arrives
+    # from `axp20x-pek` rather than `gpio-keys-gamepad`. The Launcher opens
+    # both and does not look at which node a report came from, so one
+    # synthetic report is enough here too.
+    "p" => :key_power
   }
 
   # Escape is the chord rather than a single key, because Select+Menu is

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -86,7 +86,7 @@ defmodule MayonnaiOS.Launcher do
       A             launch the selected program
       Menu          go back to the home screen
       X             switch between the menu and diagnostics
-      Select+Start  sleep -- backlight off, and any press wakes it
+      Power         sleep -- backlight off, and any press wakes it
       Select+Menu   power off
 
   These are the buttons as printed on the shell. Two of the atoms above name
@@ -104,9 +104,10 @@ defmodule MayonnaiOS.Launcher do
 
   ## Sleep, and the press that wakes it
 
-  Select+Start turns the backlight off; `MayonnaiOS.Sleep` owns both the
-  mechanism and the choice of keys, including why it is not the power button
-  (Linux cannot see the power button on this board) and why it is not suspend.
+  The power button turns the backlight off; `MayonnaiOS.Sleep` owns both the
+  mechanism and the choice of key, including why it is that button now that
+  Linux can see it, why the Select+Start chord it replaced is gone rather than
+  kept as well, and why sleep is still not suspend.
 
   What belongs here is the other half: while the panel is dark, **the next
   press is consumed**. Waking is not a binding of its own -- any button wakes,
@@ -118,18 +119,34 @@ defmodule MayonnaiOS.Launcher do
   The held set is cleared at the same time, so a key that was down when the
   device woke cannot become half of a chord it was never meant to complete.
 
-  Three limits, all deliberate. The volume rocker does not wake it, because
+  Two limits, both deliberate. The volume rocker does not wake it, because
   `MayonnaiOS.Diagnostics` owns that input device and the Launcher never sees
-  its events. An app that has the buttons keeps them, sleep chord included,
-  for the same reason it keeps Menu -- see below. And a running *program* has
-  its own file descriptor on the pad: it goes on running with the panel dark,
-  and the press that wakes the device reaches it too. Only the launcher's own
-  bindings can be swallowed, which is the half that would have launched
-  something.
+  its events. And a running *program* has its own file descriptor on the pad:
+  it goes on running with the panel dark, and the press that wakes the device
+  reaches it too. Only the launcher's own bindings can be swallowed, which is
+  the half that would have launched something.
 
-  This process owns `event0`, so everything on the gamepad is bound here even
-  when it belongs to something else. `MayonnaiOS.Diagnostics` owns the
-  other two input devices for the same reason in reverse.
+  An app running in this VM used to be a third limit -- it kept every button,
+  the sleep chord included, for the same reason it keeps Menu. That stops with
+  the move onto the power key, and the sleep binding is now taken out of the
+  report before the app sees it. Three reasons, in the order that decides it.
+  The key is not on the pad at all, so this is not the launcher reaching into
+  a button an app might want. `MayonnaiOS.Controller.Report` describes fifteen
+  gamepad keys and `KEY_POWER` is not one of them, so forwarding it means it
+  is dropped on the floor -- and a power button that does nothing while the
+  controller screen is open is exactly the failure this codebase keeps naming.
+  And it was already asymmetric: the sleeping clause below is tested before
+  the app clause, so *waking* has always been the launcher's whoever has the
+  buttons. Sleeping now matches.
+
+  That is a property of a one-key binding rather than of the mechanism. Move
+  `MayonnaiOS.Sleep`'s `@binding` back onto a pad chord and an app loses those
+  keys, which is a reason to leave it on a key no app wants.
+
+  This process owns the gamepad and the power key's device, so everything on
+  the pad is bound here even when it belongs to something else.
+  `MayonnaiOS.Diagnostics` owns the rocker and the jack for the same reason in
+  reverse.
 
   ## Where the menu lives, and why the cursor is here
 
@@ -139,8 +156,9 @@ defmodule MayonnaiOS.Launcher do
   reasons that are both about how this device is put together.
 
   First, the cairo-fb driver delivers no input. The gamepad reaches Elixir
-  only through `InputEvent` on `event0`, which this process opens, so a
-  Scenic scene on this hardware can never receive a D-pad press at all.
+  only through `InputEvent` on the `gpio-keys-gamepad` node, which this
+  process opens, so a Scenic scene on this hardware can never receive a D-pad
+  press at all.
 
   Second, `Scenic.ViewPort.set_root/3` stops the running scene and starts a
   fresh one. This module calls it after every program exit (that is how the
@@ -157,12 +175,12 @@ defmodule MayonnaiOS.Launcher do
 
   alias MayonnaiOS.{Input, Panel, Programs, Sleep}
 
-  # The name the driver gives the gamepad, and the path it has always had.
-  # `MayonnaiOS.Input` prefers the name and falls back to the path, because
-  # /dev/input numbering is probe order and the analog stick adds a fourth
-  # device to the race.
+  # The name the driver gives the gamepad, which is the only thing this module
+  # knows about which device it is. There is no numbered fallback: this used to
+  # be `/dev/input/event0` and that number is the power key now, so a fallback
+  # would have opened the one device on the board with no gamepad buttons on
+  # it. See `MayonnaiOS.Input`.
   @device_name "gpio-keys-gamepad"
-  @device "/dev/input/event0"
 
   # See the moduledoc: this is physical A, not the atom's name.
   @launch_button :btn_b
@@ -291,21 +309,37 @@ defmodule MayonnaiOS.Launcher do
     {:ok, new_state(opts)}
   end
 
-  # The gamepad, plus whatever device the sleep key is on.
+  # The gamepad, plus whatever device the sleep key is on. Two nodes now that
+  # `CONFIG_INPUT_AXP20X_PEK` is enabled: evdev is not a broadcast, so the only
+  # way to see `KEY_POWER` is to have `axp20x-pek` open, and both devices
+  # deliver into the same `handle_info`. `uniq` because a binding back on the
+  # pad would make them the same node again, as they were until this firmware.
   #
-  # Today those are the same node and `uniq` collapses them to one open, which
-  # is why this is not speculation: it is the same single device it has always
-  # been. The day `CONFIG_INPUT_AXP20X_PEK` is enabled, `Sleep.device/0`
-  # resolves to the `axp20x-pek` node instead and the launcher opens both --
-  # evdev is not a broadcast, so the only way to see `KEY_POWER` is to have
-  # that node open, and both devices deliver into the same `handle_info`.
+  # `nil` is dropped rather than opened. A device that is not there by name is
+  # not there, and the alternative -- a number -- is a different device that
+  # never sends the key being waited for. Which device went missing is already
+  # in the log by the time this runs; see `MayonnaiOS.Input.find/1`.
   #
   # An explicit `:device` overrides the lot, which is how the tests and
   # `MayonnaiOS.Dev` drive this with synthetic events.
   defp devices(opts) do
     case Keyword.get(opts, :device) do
-      nil -> Enum.uniq([Input.find(@device_name, @device), Sleep.device()])
-      device -> [device]
+      nil ->
+        case Enum.uniq(Enum.reject([Input.find(@device_name), Sleep.device()], &is_nil/1)) do
+          [] ->
+            # A laptop, where this is ordinary and the synthetic-event path is
+            # the point -- and a device whose kernel lost both nodes, where it
+            # is a disaster. The log line is the same because this process
+            # cannot tell them apart; `Input.find/1` has named what it did see.
+            Logger.warning("[launcher] no input devices found; no buttons are bound")
+            []
+
+          devices ->
+            devices
+        end
+
+      device ->
+        [device]
     end
   end
 
@@ -436,20 +470,20 @@ defmodule MayonnaiOS.Launcher do
   # difference is only in the plumbing. A program reads evdev for itself
   # through udev, so the launcher has nothing to forward; an app runs in this
   # VM and has to be handed the reports, because this process is the one
-  # holding `event0` open and evdev is not a broadcast.
+  # holding the pad open and evdev is not a broadcast.
+  #
+  # The exception is the sleep key, which is held back: it is not a pad button,
+  # no app has a use for it, and a power button that does nothing while the
+  # controller screen is open is worse than an app missing an event it would
+  # have dropped. The moduledoc has the argument.
   #
   # Whole reports go across rather than single events, so a diagonal or a
   # button and a direction pressed in the same kernel report reach the app as
   # one thing and become one HID report.
   def handle_info({:input_event, _device, events}, %{app: app} = state) when app != nil do
-    state =
-      Enum.reduce(events, state, fn
-        {:ev_key, key, 1}, acc -> hold(acc, key)
-        {:ev_key, key, 0}, acc -> release(acc, key)
-        _, acc -> acc
-      end)
+    {state, slept?} = Enum.reduce(events, {state, false}, &app_event/2)
 
-    app.input(events)
+    if not slept?, do: app.input(events)
 
     {:noreply, leave_app(state, events)}
   end
@@ -536,6 +570,29 @@ defmodule MayonnaiOS.Launcher do
   defp hold(state, key), do: %{state | held: MapSet.put(state.held, key)}
   defp release(state, key), do: %{state | held: MapSet.delete(state.held, key)}
 
+  # The held set is folded one event at a time and the trigger is asked after
+  # each press, exactly as the ordinary path does it, so that a `@binding` with
+  # a modifier in it would still see the set the way the user pressed it rather
+  # than the set the whole report leaves behind.
+  #
+  # The whole report is dropped when the sleep key is in it, not just that one
+  # event. A report cannot span two devices and the sleep device carries one
+  # key, so "the report contains the sleep key" and "the report is the sleep
+  # key" are the same statement on this hardware.
+  defp app_event({:ev_key, key, 1}, {state, slept?}) do
+    state = hold(state, key)
+
+    if Sleep.trigger?(state.held, key) do
+      {_result, state} = enter_sleep(state)
+      {state, true}
+    else
+      {state, slept?}
+    end
+  end
+
+  defp app_event({:ev_key, key, 0}, {state, slept?}), do: {release(state, key), slept?}
+  defp app_event(_event, acc), do: acc
+
   # Menu while an app is running. The power-off chord is checked first, for
   # the same reason it is checked first everywhere else: a bare Menu must
   # never be able to switch the device off, and someone holding Select while
@@ -561,12 +618,13 @@ defmodule MayonnaiOS.Launcher do
     %{state | app: nil, running: nil}
   end
 
-  # The sleep chord is tested before any single-key binding, for the reason
+  # The sleep binding is tested before any single-key binding, for the reason
   # the power-off chord is tested before Menu: a modifier that only works when
-  # the other key happens to be unbound is not a modifier, and the next thing
-  # someone does with `MayonnaiOS.Sleep`'s one-line binding is move it onto a
-  # key that *is* bound (`KEY_POWER` is not, but Select+X would be). Asking
-  # `Sleep` first means that keeps working instead of silently doing nothing.
+  # the other key happens to be unbound is not a modifier, and moving
+  # `MayonnaiOS.Sleep`'s one-line binding onto a key that *is* bound is a
+  # change to one tuple. It does not matter today -- `KEY_POWER` is bound to
+  # nothing else and arrives from its own device -- and the ordering is what
+  # keeps that a property of the binding rather than of this function.
   defp press(state, key) do
     if Sleep.trigger?(state.held, key) do
       {_result, state} = enter_sleep(state)
@@ -704,9 +762,11 @@ defmodule MayonnaiOS.Launcher do
     Logger.info("[launcher] Select+Menu: powering off")
 
     # Whether poweroff/0 brings this board down cleanly is the genuinely
-    # unknown part. The PMIC power key is not wired into Linux here
-    # (CONFIG_INPUT_AXP20X_PEK is unset and there is no power-key node), so
-    # this is the only orderly shutdown the device has.
+    # unknown part. This is still the only *orderly* shutdown the device has,
+    # and the arrival of the power key does not change that: a short press is
+    # sleep, and a long one is the PMIC cutting the rail in hardware after the
+    # 4000 ms its `shutdown` attribute reads -- no unmount, no save flushed,
+    # nothing told. So the chord stays, and stays a chord.
     Nerves.Runtime.poweroff()
   end
 

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -15,7 +15,7 @@ defmodule MayonnaiOS.Scene.Home do
   ## Where the selection comes from
 
   This scene renders the cursor, it does not own it. `MayonnaiOS.Launcher`
-  owns `event0` and therefore the D-pad, and it passes the selected index in
+  owns the gamepad and therefore the D-pad, and it passes the selected index in
   as the scene's start argument. That has to be the direction of travel:
   `Scenic.ViewPort.set_root/3` terminates this process and starts a new one on
   every repaint, so anything this scene remembered would be lost the moment a

--- a/lib/mayonnaios/sleep.ex
+++ b/lib/mayonnaios/sleep.ex
@@ -18,10 +18,20 @@ defmodule MayonnaiOS.Sleep do
   these cores reach is a bare WFI whether "suspended" or not: a successful
   s2idle would save almost nothing.
 
-  And it would be dangerous. **No button on the front of this device is
-  wakeup-capable** -- only `alarmtimer.0.auto`, `musb-hdrc.2.auto` and
-  `7000000.rtc` have a `power/wakeup` at all. A system suspend that worked
-  would look exactly like a brick in someone's hands.
+  It also used to be dangerous, and that is the half of the analysis that has
+  changed. There is now a button that could bring the board back: the power
+  key's platform device is wakeup-capable and enabled --
+  `/sys/bus/platform/devices/axp20x-pek/power/wakeup` reads `enabled` on
+  firmware `3cc86f59` -- where before only `alarmtimer.0.auto`,
+  `musb-hdrc.2.auto` and `7000000.rtc` had a `power/wakeup` at all, and a
+  suspend that worked would have looked exactly like a brick in someone's
+  hands.
+
+  The wake source is recorded here because it was load-bearing and is now
+  wrong, not because it changes the answer. The other three reasons are the
+  ones that decide it, and all three stand: no `deep`, an s2idle that aborts
+  in rtw88, and no cpuidle driver to make a successful one worth anything. So
+  sleep is still the backlight and nothing else.
 
   ## Why the backlight, and why 0 and 1
 
@@ -63,30 +73,45 @@ defmodule MayonnaiOS.Sleep do
   answer: `MayonnaiOS.Launcher` only starts swallowing button presses if the
   panel really was told to go dark.
 
-  ## The binding, and the power button
+  ## The binding
 
-  Karl asked for the power button, and the power button does not exist as far
-  as Linux is concerned. There are exactly four input devices on this board --
-  `adc-joystick`, `gpio-keys-gamepad`, `gpio-keys-volume` and
-  `H616 Audio Codec Headphone Jack` -- and no power key among them. The button
-  is on the PMIC's PWRON pin; mainline has the driver
-  (`drivers/input/misc/axp20x-pek.c`, which would expose `KEY_POWER` on an
-  input device named `axp20x-pek`), but `CONFIG_INPUT_AXP20X_PEK` appears
-  nowhere in the system repo -- not in `linux/nerves.fragment`, not in
-  `linux/linux-6.18.defconfig`. Enabling it is a one-line kernel config change
-  and a 2-3 hour Buildroot rebuild, and no device-tree change at all, since it
-  is an MFD cell rather than a DT node.
+  Karl asked for the power button, and the power button now exists. It is on
+  the PMIC's PWRON pin, `CONFIG_INPUT_AXP20X_PEK` is set in the system repo's
+  `linux/nerves.fragment`, and `drivers/input/misc/axp20x-pek.c` puts
+  `KEY_POWER` on an input device named `axp20x-pek`. Read off the device on
+  firmware `3cc86f59`:
 
-  Until that rebuild happens the trigger is a chord on the pad, and `@binding`
-  below is one line so that the day the key exists, moving sleep onto it is
-  one line:
+      /dev/input/event0  axp20x-pek  report_info: [ev_key: [:key_power]]
 
-      @binding {"axp20x-pek", "/dev/input/event0", {nil, :key_power}}
+  One key and nothing else on that device, which is what makes this a binding
+  with no modifier. There is no neighbouring button to press by accident, and
+  a key that is alone on its own node cannot be half of a chord.
 
-  `MayonnaiOS.Input.find/2` is what makes that safe in both directions: it
-  looks the device up by the name its driver gives it and falls back to a
-  path, so firmware without the option still finds the pad and the chord keeps
-  working.
+  A short press is this module's. A long one is not, and cannot be made to be:
+  the PMIC's own `shutdown` attribute reads `4000`, so holding the button for
+  four seconds makes the AXP cut the rail in hardware, without asking Linux
+  and without anything being flushed. That is why `MayonnaiOS.Launcher` keeps
+  Select+Menu -- it is still the only *orderly* way to switch this device off.
+
+  ## The chord that used to be here
+
+  Sleep was Select+Start until the power key existed, and that chord is gone
+  rather than kept alongside. The case for keeping both is discoverability
+  insurance, and it does not survive contact with what a second trigger
+  costs: it has to be written down in this moduledoc, in the launcher's
+  binding list, in the README, in `MayonnaiOS.Keyboard` and in the
+  application's supervision comment, and `@binding` below is one tuple
+  precisely so that there is one place where any of that is written down.
+  Undiscoverability was the entire complaint about a chord, and answering it
+  with a chord *and* a button leaves the complaint standing while doubling
+  what a reader has to keep in step. Start goes back to being unbound, like B
+  and Y.
+
+  `MayonnaiOS.Input.find/1` is what makes the move safe: it looks the device
+  up by the name its driver gives it, and firmware without the option gets
+  `nil` and a warning naming every device that is present, rather than a
+  numbered guess that opens the analog stick and waits for `KEY_POWER` for
+  ever.
   """
 
   require Logger
@@ -102,30 +127,23 @@ defmodule MayonnaiOS.Sleep do
   @off "0"
   @on "1"
 
-  # `{device name, path to fall back on, {modifier, key}}`.
+  # `{device name, {modifier, key}}`.
   #
-  # Select+Start. Select because it is already the modifier this launcher uses
-  # and a second modifier would be a second thing to remember; Start because
-  # the launcher binds it to nothing at all, so the chord cannot be half of an
-  # existing action the way Select+X would be, and because Select and Start
-  # are the two recessed buttons in the middle of the shell -- nobody's thumb
-  # is resting on them while playing, which is what "cannot be pressed by
-  # accident" has to mean on a handheld.
+  # The power button, on its own. `nil` for the modifier means the key alone
+  # is the trigger; the chord shape is still supported and still resolved at
+  # compile time below, so sleep moving back onto the pad -- or onto whatever
+  # key the next shell puts it on -- stays a change to this one line.
   #
-  # Not Menu: Select+Menu powers off, and the reason that chord is guarded is
-  # that Menu is the key someone mashes to get out of a game. Not Y, which is
-  # deliberately unbound and stays that way.
-  #
-  # A `nil` modifier means the key alone is the trigger, which is what the
-  # real power button will want.
-  @binding {"gpio-keys-gamepad", "/dev/input/event0", {:btn_select, :btn_start}}
+  # There is no path in here any more. A fallback would be a number, and a
+  # number reached because the name was missing is a different device; see
+  # `MayonnaiOS.Input`.
+  @binding {"axp20x-pek", {nil, :key_power}}
 
   # Taken apart at compile time, so the one line above stays the only place
   # any of it is written down.
   @device_name elem(@binding, 0)
-  @device_fallback elem(@binding, 1)
-  @modifier @binding |> elem(2) |> elem(0)
-  @key @binding |> elem(2) |> elem(1)
+  @modifier @binding |> elem(1) |> elem(0)
+  @key @binding |> elem(1) |> elem(1)
 
   @doc """
   The sysfs file that turns the backlight off and on.
@@ -136,13 +154,16 @@ defmodule MayonnaiOS.Sleep do
   def path, do: Application.get_env(:mayonnaios, :backlight_brightness, @default_path)
 
   @doc """
-  The input device the sleep key arrives on.
+  The input device the sleep key arrives on, or `nil` when there is none.
 
-  Looked up by driver name with a path fallback, because `/dev/input/eventN`
-  is probe order and not a promise. See `MayonnaiOS.Input`.
+  Looked up by driver name and by nothing else, because `/dev/input/eventN` is
+  probe order and not a promise, and a numbered guess would open some other
+  device and wait for a key it never sends. `nil` on a laptop, and on any
+  firmware built without `CONFIG_INPUT_AXP20X_PEK`; `MayonnaiOS.Input.find/1`
+  has already logged which devices there were instead. See `MayonnaiOS.Input`.
   """
-  @spec device() :: String.t()
-  def device, do: Input.find(@device_name, @device_fallback)
+  @spec device() :: String.t() | nil
+  def device, do: Input.find(@device_name)
 
   @doc """
   Whether this press is the sleep trigger, given what is currently held.
@@ -153,9 +174,12 @@ defmodule MayonnaiOS.Sleep do
   @spec trigger?(MapSet.t(atom()), atom()) :: boolean()
   def trigger?(held, key), do: triggered?(held, key)
 
-  # Which of the two shapes this is, is decided when the module is compiled:
-  # a nil modifier -- what the real power key will want -- makes the key alone
-  # the trigger, and then nothing looks at the held set at all.
+  # Which of the two shapes this is, is decided when the module is compiled: a
+  # nil modifier -- which is what the power key wants -- makes the key alone
+  # the trigger, and then nothing looks at the held set at all. The chord
+  # clause is compiled only when `@binding` names a modifier, so a `held` set
+  # is still threaded through `trigger?/2` by every caller: that argument is
+  # what keeps moving the binding back onto the pad a one-line change.
   if @modifier do
     defp triggered?(held, key), do: key == @key and MapSet.member?(held, @modifier)
   else
@@ -163,7 +187,9 @@ defmodule MayonnaiOS.Sleep do
   end
 
   @doc """
-  The chord, for a log line or a help screen that wants to name it.
+  The binding, for a log line or a help screen that wants to name it.
+
+  `{nil, key}` when the key is the whole trigger, which is what it is now.
   """
   @spec binding() :: {atom() | nil, atom()}
   def binding, do: {@modifier, @key}

--- a/lib/mayonnaios/volume.ex
+++ b/lib/mayonnaios/volume.ex
@@ -110,10 +110,13 @@ defmodule MayonnaiOS.Volume do
 
   alias MayonnaiOS.Audio
 
-  # The name the driver gives the rocker, and the path it has had. Looked up
-  # by name because /dev/input numbering is probe order; see `MayonnaiOS.Input`.
+  # The name the driver gives the rocker, and the only thing this module knows
+  # about which device it is. There is no numbered fallback: this attribute
+  # used to be `/dev/input/event1`, and by the time the power key shipped that
+  # number was the analog stick -- a fallback that opens the stick and waits
+  # for `KEY_VOLUMEUP` is the rocker doing nothing with nothing in the log.
+  # See `MayonnaiOS.Input`.
   @device_name "gpio-keys-volume"
-  @device "/dev/input/event1"
 
   # Read off the hardware, not the device tree: these are the atoms
   # `InputEvent` decodes KEY_VOLUMEUP (115) and KEY_VOLUMEDOWN (114) to, and
@@ -144,15 +147,23 @@ defmodule MayonnaiOS.Volume do
 
   @impl GenServer
   def init(opts) do
-    device = Keyword.get(opts, :device, MayonnaiOS.Input.find(@device_name, @device))
+    # get_lazy, so an injected device does not also run a lookup whose warning
+    # would then be about a device this process was never going to open.
+    device = Keyword.get_lazy(opts, :device, fn -> MayonnaiOS.Input.find(@device_name) end)
 
     case open_device(device) do
       {:ok, _pid} ->
         Logger.info("[volume] watching #{device}: #{Audio.steps()} levels above silence")
 
+      {:error, :no_device} ->
+        # No rocker is not a reason to fail the boot, and this is the loud
+        # half of not having a fallback: the name is in the line, because the
+        # name is the thing that has to change in a device tree for this to
+        # happen. `MayonnaiOS.Input.find/1` has already logged what was there
+        # instead.
+        Logger.warning("[volume] no #{@device_name} input device; the rocker does nothing")
+
       {:error, reason} ->
-        # No rocker is not a reason to fail the boot. Everything else about
-        # the device still works, and `up/0` from IEx still works.
         Logger.warning("[volume] #{device} unavailable: #{inspect(reason)}")
     end
 
@@ -173,6 +184,8 @@ defmodule MayonnaiOS.Volume do
   # port binary is only built on Linux, so `start_link/1` *raises* on a macOS
   # host rather than returning an error, which inside a linked start would
   # take this process down at boot instead of degrading to "no rocker".
+  defp open_device(nil), do: {:error, :no_device}
+
   defp open_device(device) do
     if File.exists?(device), do: InputEvent.start_link(device), else: {:error, :enoent}
   end

--- a/test/input_test.exs
+++ b/test/input_test.exs
@@ -4,10 +4,9 @@ defmodule MayonnaiOS.InputTest do
   alias MayonnaiOS.Input
 
   # There is no /dev/input on the machine these tests run on, which is the
-  # case worth pinning down: the fallback has to be what a caller gets when
-  # enumeration cannot happen at all, because that is the difference between
-  # "the launcher opens the path it always did" and "the launcher crashes at
-  # boot looking for its buttons".
+  # case worth pinning down: a caller that asks for a device by name and is
+  # not on the device has to get an answer it cannot mistake for a device, and
+  # it must not get one by way of a raise at boot.
 
   describe "enumerate/0" do
     test "is a list even where there is nothing to enumerate" do
@@ -21,16 +20,40 @@ defmodule MayonnaiOS.InputTest do
     end
   end
 
-  describe "find/2" do
-    test "falls back to the given path when the name is not there" do
-      assert Input.find("no-such-device", "/dev/input/event0") == "/dev/input/event0"
+  describe "find/1" do
+    test "is nil when the name is not there, and not a path" do
+      # find/2 used to take the number to fall back on. There is nothing to
+      # fall back to now, on purpose: a fallback runs in exactly the state
+      # where the name is absent, and a number reached in that state is some
+      # other device that never sends the key being waited for.
+      assert Input.find("no-such-device") == nil
     end
 
-    test "the fallback is returned verbatim, not normalised or checked" do
-      # Deliberately not File.exists?/1: the caller's job is to open it and
-      # handle the failure, and a find/2 that returned nil for a missing path
-      # would make every call site handle two kinds of nothing.
-      assert Input.find("no-such-device", "/tmp/not-a-device") == "/tmp/not-a-device"
+    test "a real device name is still nil where there is no input layer" do
+      # A laptop, and a device tree that renamed something, get the same
+      # answer. Neither of them has the device, and neither is improved by
+      # being handed a path to open.
+      assert Input.find("gpio-keys-gamepad") == nil
+    end
+  end
+
+  describe "the paths this app is allowed to know" do
+    test "no module hard-codes a numbered input device path" do
+      # The regression this test exists for. A quoted `/dev/input/eventN` in
+      # `lib/` is a fallback growing back, and a fallback is only ever reached
+      # in the state where it names the wrong device: the numbering has moved
+      # twice, and each time every number written down in this app was wrong
+      # for a firmware or two without anything failing.
+      #
+      # It looks for the string a caller would pass rather than for the word
+      # `event0`, because prose about the numbering is fine and `Input`'s own
+      # moduledoc has the table.
+      offenders =
+        "lib/**/*.ex"
+        |> Path.wildcard()
+        |> Enum.filter(&Regex.match?(~r{"/dev/input/event\d}, File.read!(&1)))
+
+      assert offenders == []
     end
   end
 

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -119,6 +119,24 @@ defmodule MayonnaiOS.LauncherTest do
     end
   end
 
+  describe "the devices it opens" do
+    test "starts on a machine with none, and says so" do
+      # The host path, and the one the `:device` option in every other test
+      # here deliberately steps around. Two lookups happen at boot -- the pad
+      # and whatever device the sleep key is on -- and on a laptop both answer
+      # `nil`. Neither may be opened, and neither may take the boot down:
+      # `File.exists?/1` on a nil raises, which is what a fallback used to
+      # hide by handing over a path that merely did not exist.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          start_supervised!(Launcher)
+          assert Launcher.selected() == 0
+        end)
+
+      assert log =~ "no input devices found"
+    end
+  end
+
   describe "the D-pad binding" do
     setup do
       # The Launcher is not in the host supervision tree, and there is no

--- a/test/sleep_test.exs
+++ b/test/sleep_test.exs
@@ -72,22 +72,53 @@ defmodule MayonnaiOS.SleepTest do
     end
   end
 
-  describe "the chord" do
-    test "is Select plus a key the launcher does not otherwise bind" do
-      assert Sleep.binding() == {:btn_select, :btn_start}
-      assert Sleep.trigger?(MapSet.new([:btn_select, :btn_start]), :btn_start)
+  describe "the binding" do
+    test "is the power key, on its own" do
+      assert Sleep.binding() == {nil, :key_power}
+      assert Sleep.trigger?(MapSet.new(), :key_power)
     end
 
-    test "does not fire on the key alone" do
-      # The point of the modifier: this is a handheld in a pocket, and a bare
-      # Start must not blank the screen.
-      refute Sleep.trigger?(MapSet.new([:btn_start]), :btn_start)
+    test "fires whatever else is held" do
+      # A nil modifier means the held set is not consulted at all. That is the
+      # property the launcher leans on when it asks this from the app path,
+      # where what is held is somebody else's business.
+      assert Sleep.trigger?(MapSet.new([:btn_select, :btn_start, :btn_mode]), :key_power)
     end
 
-    test "does not fire on the modifier alone, or on the power-off chord" do
-      refute Sleep.trigger?(MapSet.new([:btn_select]), :btn_select)
-      refute Sleep.trigger?(MapSet.new([:btn_select, :btn_mode]), :btn_mode)
+    test "the chord it replaced does nothing at all" do
+      # This is the test that fails if Select+Start is kept "just in case".
+      # It is not a spare tyre: it is a second trigger to write down in the
+      # moduledoc, the launcher, the README, the keyboard bridge and the
+      # supervision tree, and `@binding` is one tuple so that there is one
+      # place to read it off. The full argument is in MayonnaiOS.Sleep.
+      refute Sleep.trigger?(MapSet.new([:btn_select]), :btn_start)
+      refute Sleep.trigger?(MapSet.new([:btn_select, :btn_start]), :btn_start)
     end
+
+    test "no button on the pad sleeps the device" do
+      pad = [:btn_a, :btn_b, :btn_x, :btn_y, :btn_select, :btn_start, :btn_mode]
+
+      for key <- pad, held <- [MapSet.new(), MapSet.new(pad)] do
+        refute Sleep.trigger?(held, key)
+      end
+    end
+  end
+
+  describe "the device the key arrives on" do
+    test "is nil here, and never a number" do
+      # The fallback used to be `/dev/input/event0`, which is the power key's
+      # number on this firmware and was the gamepad's on the one before. Both
+      # of those are accidents; the name is the thing that is meant.
+      assert Sleep.device() == nil
+    end
+
+    # What no test here can check is that the *name* is right. Point
+    # `@binding` at "gpio-keys-gamepad" and this suite stays green: on a
+    # laptop both names resolve to nil, and the synthetic reports below carry
+    # a device string the Launcher deliberately ignores. The name is checkable
+    # against one thing only, which is the hardware --
+    # `MayonnaiOS.Input.names/0` over SSH -- and this note is here so that
+    # nobody reads a green run as having confirmed it.
   end
 
   describe "the launcher binding" do
@@ -102,11 +133,8 @@ defmodule MayonnaiOS.SleepTest do
       :ok
     end
 
-    test "Select+Start sleeps, and the next press only wakes", %{path: path} do
-      # A press with no release is a hold, which is all the launcher's held
-      # set records -- so this is Select held down and Start pressed.
-      press(:btn_select)
-      press(:btn_start)
+    test "the power key sleeps, and the next press only wakes", %{path: path} do
+      press(:key_power)
 
       assert Launcher.asleep?()
       assert File.read!(path) == "0"
@@ -124,42 +152,47 @@ defmodule MayonnaiOS.SleepTest do
       assert Launcher.selected() == 1
     end
 
-    test "releasing the chord does not wake it", %{path: path} do
-      press(:btn_select)
-      press(:btn_start)
+    test "releasing the key does not wake it", %{path: path} do
+      press(:key_power)
       assert Launcher.asleep?()
 
-      # Both keys are still down when the device goes to sleep; their
-      # releases arrive a moment later and must not turn the panel straight
-      # back on.
-      release(:btn_start)
-      release(:btn_select)
+      # The key is still down when the panel goes dark; its release arrives a
+      # moment later and must not turn the panel straight back on.
+      release(:key_power)
 
       assert Launcher.asleep?()
       assert File.read!(path) == "0"
     end
 
-    test "the press that wakes cannot be half of a chord" do
-      press(:btn_select)
-      press(:btn_start)
+    test "the power key wakes it too, and does not put it straight back" do
+      press(:key_power)
       assert Launcher.asleep?()
 
-      # Select is still down as far as the kernel is concerned. Waking on it
-      # consumes the press, and the held set goes with it -- otherwise the
-      # very next Start would put the device back to sleep, and the very next
-      # Menu would power it off, from presses nobody meant as chords.
-      press(:btn_select)
+      # The one press that has to be idempotent in the other direction: the
+      # button someone reaches for to bring the screen back is the same button
+      # that darkened it, so waking must consume the press before the binding
+      # gets a look at it.
+      press(:key_power)
       refute Launcher.asleep?()
 
-      press(:btn_start)
-      refute Launcher.asleep?()
+      # And it is an ordinary press again afterwards.
+      press(:key_power)
+      assert Launcher.asleep?()
     end
+
+    # There is no longer a test that the held set is cleared on waking.
+    #
+    # It was worth having and its last observable consequence went away with
+    # the chord: the held set now feeds exactly one thing, the Select+Menu
+    # power-off, and a test that presses that chord calls
+    # `Nerves.Runtime.poweroff/0`, which on the host begins stopping the VM
+    # and takes the whole run down with no summary. `wake_up/1` still clears
+    # it, for that chord's sake; see the comment there.
 
     test "a backlight that cannot be written does not swallow anything" do
       Application.put_env(:mayonnaios, :backlight_brightness, "/nonexistent/dir/brightness")
 
-      press(:btn_select)
-      press(:btn_start)
+      press(:key_power)
 
       # The write failed, so the device is not asleep -- and the next press
       # does its ordinary job instead of being eaten by a sleep that never
@@ -186,6 +219,68 @@ defmodule MayonnaiOS.SleepTest do
       assert Launcher.wake() == :ok
       refute Launcher.asleep?()
       assert File.read!(path) == "1"
+    end
+  end
+
+  # A stand-in for an app that runs in this VM, recording what it was handed.
+  # Small on purpose: the only thing under test here is which reports reach it.
+  defmodule FakeApp do
+    def start(_opts \\ []) do
+      Agent.update(__MODULE__, &%{&1 | started: &1.started + 1})
+      {:ok, self()}
+    end
+
+    def stop, do: :ok
+
+    def input(events) do
+      Agent.update(__MODULE__, &%{&1 | events: &1.events ++ [events]})
+      :ok
+    end
+
+    def scene, do: MayonnaiOS.Scene.Home
+
+    def log, do: Agent.get(__MODULE__, & &1)
+  end
+
+  describe "the power key while an app has the buttons" do
+    # An app running in this VM is handed every report the launcher gets, so
+    # that whatever has the screen has the input. The sleep key is the one
+    # exception, and this is the pair of tests that says so: the panel goes
+    # dark, and the app is not told about a key it has no use for.
+    setup do
+      start_supervised!(%{
+        id: FakeApp,
+        start: {Agent, :start_link, [fn -> %{started: 0, events: []} end, [name: FakeApp]]}
+      })
+
+      Application.put_env(:mayonnaios, :programs, [%{name: "Fake", app: FakeApp}])
+      on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
+
+      start_supervised!({Launcher, device: "/nonexistent/event0"})
+
+      # A starts it. :btn_b is the button silkscreened A; see the Launcher.
+      press(:btn_b)
+      assert FakeApp.log().started == 1
+      :ok
+    end
+
+    test "still sleeps the panel", %{path: path} do
+      press(:key_power)
+
+      assert Launcher.asleep?()
+      assert File.read!(path) == "0"
+    end
+
+    test "is not forwarded to the app, and the pad still is" do
+      # The pad's buttons are the app's and go across untouched.
+      press(:btn_dpad_down)
+      assert FakeApp.log().events == [[{:ev_key, :btn_dpad_down, 1}]]
+
+      # The power key is not on the pad, and the app would only drop it. Note
+      # the order: after this the panel is dark, and the next press of anything
+      # is spent on waking and does not reach the app either.
+      press(:key_power)
+      assert FakeApp.log().events == [[{:ev_key, :btn_dpad_down, 1}]]
     end
   end
 

--- a/test/volume_test.exs
+++ b/test/volume_test.exs
@@ -338,6 +338,28 @@ defmodule MayonnaiOS.VolumeTest do
     end
   end
 
+  describe "the device it opens" do
+    test "is looked up by name, and its absence is a line naming the name" do
+      # The rocker was `/dev/input/event1` in this file until the numbering
+      # moved, and by then `event1` was the analog stick -- a device with no
+      # keys on it at all. A fallback to that number is not a degraded volume
+      # control, it is a process waiting for ever for `KEY_VOLUMEUP` from
+      # something that has never sent one, and the only visible symptom is
+      # that the buttons do nothing.
+      #
+      # So there is no number to fall back to, and what makes that better
+      # rather than merely stricter is this log line: it names the device tree
+      # name, which is the thing that would have to change for this to happen.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          start_supervised!({Volume, mixer: FakeMixer})
+        end)
+
+      assert log =~ "gpio-keys-volume"
+      refute log =~ "/dev/input/event"
+    end
+  end
+
   describe "the rocker" do
     setup do
       # No device: there is no /dev/input here, so Volume degrades to "no


### PR DESCRIPTION
## Summary

`CONFIG_INPUT_AXP20X_PEK` is enabled and firmware `3cc86f59` has the key, so sleep moves onto the power button — the one line `MayonnaiOS.Sleep`'s moduledoc has been promising. Verified on the device rather than taken on trust: `axp20x-pek` is `event0` with `report_info: [ev_key: [:key_power]]`, `power/wakeup` reads `enabled`, and `shutdown` reads `4000`. Suspend stays out of scope; the wake source was the only part of that analysis that had gone wrong.

## The chord does not survive

Select+Start is gone rather than kept as a discoverable-button-plus-insurance pair. It was introduced as a stopgap "until that rebuild happens" and the rebuild happened, but the deciding argument is cost rather than history: a second trigger has to be written down in `Sleep`'s moduledoc, the launcher's binding list, the README, the keyboard bridge and the supervision comment, and `@binding` is one tuple *precisely* so that there is one place to read any of it off. Undiscoverability was the entire complaint about a chord; keeping a chord and a button answers none of it while doubling what has to be kept in step. Start goes back to unbound, like B and Y.

## The fallbacks are removed, not corrected

`Input.find/2` becomes `find/1`, answering `nil` with a warning that names the missing device and every device present. Correcting the numbers was the smaller change and the wrong one.

The evidence is that this already failed silently, twice. Every fallback in the app was wrong before the power key arrived — the stick took `event0` when it landed and shifted all four — and nothing failed, because a fallback behind a working by-name lookup is never exercised. `event1`, which two modules named, has no keys on it at all. And a fallback does not degrade: it opens a different device and blocks for ever on a key that device never sends, which presents as a button doing nothing with an empty log. That is this project's named characteristic failure, wearing a helpful name.

Nothing was lost on the host, which was the fallbacks' stated purpose: there is no `/dev/input` on a laptop, so the fallback was a path that does not exist handed to a caller that checks `File.exists?/1` first. The loud version is strictly better there too — the warning names `gpio-keys-volume`, which is the thing that would have to change in a device tree, instead of a number that means nothing. `MayonnaiOS.Dev` and `Keyboard` are unaffected (they inject synthetic reports), and the launcher's both-lookups-nil boot is now a test.

## Follow-ups for reviewer

- An app running in this VM no longer keeps the sleep key: `KEY_POWER` is not on the pad, not one of the fifteen keys `Controller.Report` declares, and forwarding it means the app drops it and the power button does nothing while the controller screen is open. Waking was already the launcher's whoever has the buttons. Is taking sleeping too the right call, or does "whatever has the screen has the input" outrank a dead button here?
- No host test can catch the device *name* being wrong — point `@binding` at `"gpio-keys-gamepad"` and the suite stays green, because both names resolve to `nil` on a laptop. `test/sleep_test.exs` says so where a reader will look. Worth more than a comment?
- The README and `Controller.Report` both claimed the analog stick cannot be seen; it has been `event1` with live `abs_x`/`abs_y` for at least a firmware. Corrected, but nothing reads that device yet, so the axes stay undeclared for a new reason. Separate issue?
