### PR TITLE
Claim the Xbox Wireless Controller identity, and read the stick

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Software:
   back. Not suspend — only `s2idle` exists here, it aborts inside rtw88's SDIO
   suspend handler, and with no cpuidle driver the cores are in a bare WFI
   either way, so a successful one would save almost nothing
+- Orderly power off, two ways: the Select+Menu chord, and a **Power off** row
+  at the bottom of the menu — A asks, Y answers, anything else keeps it on,
+  which is the file manager's delete rule applied to the other irreversible
+  thing on the device
 
 ## Building and flashing
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,10 @@ pad it knows. The one macOS-specific trap is in the next section.
 What the host receives: the left stick, the D-pad as a hat switch, A/B/X/Y
 by their printed labels, LB and RB from L1 and R1, the triggers fully pulled
 or fully released from L2 and R2 — they are switches on this shell — and
-View and Menu from Select and Start. The right stick, the stick clicks, the
+View and Menu from Select and Start. **Select and Start held together are
+the Xbox button**, which on a Steam Deck is the Steam button; the first
+half-pressed leaks one brief View or Menu press while the chord forms, and
+`MayonnaiOS.Controller.Report` has the account of why that beats a timer. The right stick, the stick clicks, the
 Share button and the Xbox button are declared because the real pad declares
 them, and they rest untouched forever; rumble is accepted from the host and
 dropped, because there is no motor and a refused write reads as a fault

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Software:
 
 - Scenic UI: a launcher and a diagnostics readout, drawn on the CPU into
   `/dev/fb0`
-- A Bluetooth LE gamepad, so the handheld can be the controller for a Steam
-  Deck or a PC — a whole BLE HID stack in Elixir, with no BlueZ in the image
+- A Bluetooth LE gamepad that presents as an Xbox Wireless Controller, so a
+  Steam Deck, a Mac or a PC recognises it with no mapping step — a whole BLE
+  HID stack in Elixir, with no BlueZ in the image
 - RetroArch, with cores installed and upgraded independently of the firmware
 - Checksum-verified bundle install, with versioned directories and rollback
 - A web UI for uploading games from a phone
@@ -270,10 +271,23 @@ the interval and by f2fs writeback, and by nothing else.
 ## Using it as a Bluetooth controller
 
 The handheld can be the gamepad instead of the console. Pick **Bluetooth
-controller** in the launcher and it advertises itself as a BLE HID gamepad;
-pair from a Steam Deck, a Windows machine, a phone or anything else that
-speaks HID over GATT, and every button goes there instead of to the launcher.
-Menu comes back.
+controller** in the launcher and it advertises itself as an Xbox Wireless
+Controller — Microsoft's numbers, the real pad's name, and that pad's HID
+descriptor byte for byte; pair from a Steam Deck, a Mac, a Windows machine, a
+phone or anything else that speaks HID over GATT, and every button and the
+stick go there instead of to the launcher. Menu comes back.
+
+The identity is the point. An earlier firmware said honestly who it was, and
+this section was a page of workarounds for what that honesty cost: SDL
+matches controllers against a database keyed by vendor and product numbers,
+an unlisted device is a joystick rather than a gamepad, and a game that asks
+only for gamepads saw nothing at all — with Steam on macOS unable to bridge
+the gap, because it has no virtual controller there to bridge it with.
+Claiming the identity of the one pad every host tests against gets all of
+those code paths for free: recognised on sight, correct glyphs, no mapping
+step. `MayonnaiOS.Controller.Report` has the full account, including why the
+borrowed layout must be byte-exact and the test that pins all 283 bytes of
+it against a capture from a real pad.
 
 The panel shows how far along it is, because the four stages all look
 identical from the other machine — a controller that does nothing:
@@ -288,86 +302,74 @@ stops at *paired*, the host has not decided the device is a gamepad.
 
 ### Pairing
 
-**Steam Deck**: Settings → Bluetooth, and it appears as `MayonnaiOS
-Controller` with a gamepad icon. Steam Input treats it as a generic
-controller, so the buttons want mapping once, per game or globally.
+**Steam Deck**: Settings → Bluetooth, and it appears as `Xbox Wireless
+Controller` with a gamepad icon. SteamOS knows exactly what that is: Xbox
+glyphs, working defaults, nothing to map.
 
 **Windows**: Settings → Bluetooth & devices → Add device → Bluetooth. It
-pairs without a code — see below for why there is no code — and shows up in
-`joy.cpl` as a 10-button gamepad with a hat switch.
+pairs without a code — see below for why there is no code — and comes up as
+an Xbox controller.
 
-The D-pad is a hat switch and nothing else. It was briefly also reported as
-a pair of X/Y axes, so that games which only read a stick would work; on a
-Mac that made Steam take the axes for a stick and drive the mouse pointer
-with them, so a D-pad press moved the character *and* the cursor at once.
-One control declared twice gets consumed twice.
+**macOS**: System Settings → Bluetooth. The GameController framework has
+first-class Xbox support, so anything built on it — Steam included — sees a
+pad it knows. The one macOS-specific trap is in the next section.
 
-**Changing the report descriptor means re-pairing.** A host reads it once,
-when it pairs, and caches it forever after — so a firmware update that
-changes the button layout does nothing at all until the device is removed on
-the host and `MayonnaiOS.Controller.unpair()` has run here. Reports parsed
-against a stale descriptor are worse than no change: the bytes have moved
-underneath the host.
+What the host receives: the left stick, the D-pad as a hat switch, A/B/X/Y
+by their printed labels, LB and RB from L1 and R1, the triggers fully pulled
+or fully released from L2 and R2 — they are switches on this shell — and
+View and Menu from Select and Start. The right stick, the stick clicks, the
+Share button and the Xbox button are declared because the real pad declares
+them, and they rest untouched forever; rumble is accepted from the host and
+dropped, because there is no motor and a refused write reads as a fault
+where a silent one reads as a dead motor.
+
+**This firmware update means re-pairing, on every host.** A host reads the
+report descriptor once, when it pairs, and caches it forever after — so a
+host paired with the previous firmware's three-byte pad will parse the new
+sixteen-byte reports against the old layout and report garbage with total
+confidence. Remove the device on the host and run
+`MayonnaiOS.Controller.unpair()` here; the same applies to any future
+descriptor change.
 
 ### When a game does not see it
 
-Pairing and connecting are one thing; a game deciding this is a controller
-is another, and the second is entirely up to the host.
+On macOS, check that Steam — or the game — has **Input Monitoring**
+permission, in System Settings → Privacy & Security. Enumerating HID devices
+needs no permission on macOS but *receiving input from them* does, so an
+application without it shows the controller in its device list and then
+behaves as though every button were stuck up. Steam has to be quit
+completely and reopened after the permission is granted. This looks exactly
+like a broken controller and is not one — the browser gamepad testers work
+throughout, because the browser has the permission.
 
-On macOS, check first that Steam has **Input Monitoring** permission, in
-System Settings → Privacy & Security. Enumerating HID devices needs no
-permission on macOS but *receiving input from them* does, so an application
-without it shows the controller in its device list and then behaves as
-though every button were stuck up. Steam has to be quit completely and
-reopened after the permission is granted. This looks exactly like a broken
-controller and is not one — the browser gamepad testers work throughout,
-because the browser has the permission.
+Everything else this section used to prescribe — Steam's generic-gamepad
+switch, per-game keyboard bindings, hand-rolled `SDL_GAMECONTROLLERCONFIG`
+lines — was the cost of not being recognised, and went with the cause. What
+is still true: a game with no controller support at all still has none, and
+Steam Input on macOS still cannot fabricate a virtual controller for such a
+game. It never could; this device just no longer needs it to.
 
-Steam also has a switch for generic gamepads in its controller settings, and
-it is not on by default. Without it an unrecognised pad reaches Steam's desktop
-layout — which is what moves the mouse and types arrow keys — rather than
-the game. With it on, the pad can be given a layout like any other
-controller.
+### What claiming the identity costs
 
-A game that uses SDL, which is most of them, needs more than that. SDL's
-controller API matches a device against a database keyed by its USB vendor
-and product numbers, and this device's are not in it — so SDL sees a
-joystick rather than a game controller, and a game that only asks for game
-controllers sees nothing at all.
+The previous firmware refused to borrow a real controller's numbers, and the
+reason it wrote down was correct: a host with a driver for the claimed pad
+stops reading the descriptor and parses reports against that pad's fixed
+layout, so any deviation is scrambled buttons the host is certain are
+correct. That is an argument against claiming the numbers while shipping
+your own layout. It is not an argument against shipping the layout too,
+which is what this firmware does — the drivers' fixed belief is now a
+correct belief, and the test suite holds the descriptor byte-for-byte
+against a capture from a real pad, so a drift is a failing test rather than
+a scrambled A button.
 
-### On macOS, Steam Input cannot bridge that gap
-
-This one is worth knowing before spending an evening on it. If the pad
-drives Steam's Big Picture interface but no game responds, nothing is
-broken and no amount of Steam configuration will change it.
-
-Steam Input feeds a game by emulating a controller the game already
-understands — an Xbox pad through a driver on Windows, a virtual device
-through uinput on Linux. macOS offers Steam neither, so for a game that does
-not integrate the Steam Input API directly, Steam's only outputs are
-keyboard and mouse. Turning "Enable Steam Input" on for such a game changes
-nothing, because there is no virtual controller for it to switch on.
-
-Two things work, and both are configured on the Mac rather than here:
-
-- Bind the pad to the game's *keyboard* controls in its Steam controller
-  configuration. Keyboard emulation is the output path macOS does allow.
-- Give the game an SDL mapping. `gamepadtool` generates the whole
-  `SDL_GAMECONTROLLERCONFIG` line by asking you to press each button; it
-  goes in the game's launch options, and the game's own SDL then sees a
-  proper gamepad with Steam uninvolved. The same line submitted to SDL's
-  community database fixes it everywhere, permanently, for anyone.
-
-Claiming a well-known controller's vendor and product numbers would also
-work, and for the same reason — it makes SDL recognise the device without
-Steam in the middle. `MayonnaiOS.Bluetooth.HOGP` deliberately does not.
-Where the impersonated controller has a driver rather than just a database
-entry, as Xbox and PlayStation pads do, the host stops reading this
-device's descriptor altogether and parses its reports against that
-controller's fixed layout — so the whole report format would have to be
-reproduced, and a mistake in it produces scrambled buttons that the host is
-certain are correct. An SDL mapping reaches the same place without any of
-that, and without a device that lies about what it is.
+What is genuinely given up: the device now says it is something it is not,
+to hosts and to anyone reading a Bluetooth device list, and controls it does
+not have — the right stick, rumble — are promised and permanently inert. A
+host that someday probes deeper than any known host does, say for firmware
+versions over Microsoft's accessory protocol, will find the seams; nothing
+on macOS, SteamOS, Windows or a phone does that today. The trade is written
+down here rather than left implicit, because it was made on purpose and the
+thing bought with it is the section above shrinking to one paragraph.
 
 Pairing is *Just Works*: no passkey, no confirmation, exactly like every
 commercial BLE gamepad. That means no protection against someone active on
@@ -388,7 +390,7 @@ reports a broken device.
     iex> MayonnaiOS.Controller.start()
     iex> MayonnaiOS.Controller.status()
     %{advertising: true, connected: false, encrypted: false, subscribed: false,
-      name: "MayonnaiOS Controller", address: "...", sent: 0,
+      name: "Xbox Wireless Controller", address: "...", sent: 0,
       dropped: %{disconnected: 0, unencrypted: 0, unsubscribed: 0, no_credits: 0},
       ...}
     iex> MayonnaiOS.Controller.stop()
@@ -504,28 +506,21 @@ a scratch directory and start `MayonnaiOS.Web` under a supervisor.
 
 ## Not done yet
 
-**The analog stick.** Linux can see it now and nothing in this firmware
-reads it. The BSP side is done — the `adc-joystick` driver is built, the node
-is in the device tree, and there is an ADC driver behind it — which is a
-change from what this section used to say, and the correction is worth
-recording: it claimed the driver was absent and the node did not exist, and it
-went on claiming it after both had shipped, because nothing in this repository
-looks at the stick and so nothing here noticed. Read off the device on
-firmware `3cc86f59`:
+**The analog stick's orientation.** The stick is read now — the launcher
+opens `adc-joystick` alongside the pad and the power key, forwards its
+events with everything else, and the controller app reports it as the left
+stick, scaled from the ADC's 0..4096 to the report's 0..65535 and quantised
+to 256 steps so ADC noise does not become radio traffic. What has not
+happened is a hand on the hardware confirming which way is up: the ADC's
+zero could be either end of either axis, and no host was connected when the
+driver shipped. If characters walk inverted, the fix is one subtraction in
+`MayonnaiOS.Controller.Report`'s `scale/1`, and this entry exists so that
+whoever sees it knows it is a known unknown rather than a regression.
 
-    /dev/input/event1  adc-joystick  ev_abs: [abs_x: 0..4096, abs_y: 0..4096]
-
-Live values, centred at about 2050 on both axes. What is left is on this side.
-The Bluetooth report descriptor gains X and Y axes fed by `ABS_X` and `ABS_Y`,
-taking the report from three bytes back to five, and the `adc-joystick` node
-has to be opened alongside the gamepad — `MayonnaiOS.Launcher` already opens
-two devices for exactly this reason (the pad and the power key) and would open
-a third, forwarding all of it to the app.
-
-Worth being precise about why those axes are correct when the ones removed in
-the commit before this were a bug: the axes that had to go were the *D-pad*
-reported a second time, so one press moved a character and a mouse cursor at
-once. A stick reporting stick positions is not that.
+The old text of this entry — the stick as a thing nothing in this firmware
+reads — is done, along with the reason it existed: reporting axes was unsafe
+while the D-pad was the thing feeding them, and it took the Xbox identity
+change, which rebuilt the whole report anyway, to add them as what they are.
 
 **Pairing devices *to* the handheld.** The controller app is this device
 advertising itself to a host — the peripheral role. Scanning for headphones or

--- a/README.md
+++ b/README.md
@@ -506,22 +506,6 @@ a scratch directory and start `MayonnaiOS.Web` under a supervisor.
 
 ## Not done yet
 
-**The analog stick's orientation.** The stick is read now — the launcher
-opens `adc-joystick` alongside the pad and the power key, forwards its
-events with everything else, and the controller app reports it as the left
-stick, scaled from the ADC's 0..4096 to the report's 0..65535 and quantised
-to 256 steps so ADC noise does not become radio traffic. What has not
-happened is a hand on the hardware confirming which way is up: the ADC's
-zero could be either end of either axis, and no host was connected when the
-driver shipped. If characters walk inverted, the fix is one subtraction in
-`MayonnaiOS.Controller.Report`'s `scale/1`, and this entry exists so that
-whoever sees it knows it is a known unknown rather than a regression.
-
-The old text of this entry — the stick as a thing nothing in this firmware
-reads — is done, along with the reason it existed: reporting axes was unsafe
-while the D-pad was the thing feeding them, and it took the Xbox identity
-change, which rebuilt the whole report anyway, to add them as what they are.
-
 **Pairing devices *to* the handheld.** The controller app is this device
 advertising itself to a host — the peripheral role. Scanning for headphones or
 another gamepad and pairing them to this device is the central role, and none

--- a/config/target.exs
+++ b/config/target.exs
@@ -261,10 +261,12 @@ config :mayonnaios, :programs, [
 # The name a host shows in its pairing list, and the icon it draws next to it
 # comes from the gamepad appearance in the advertisement rather than from this.
 #
-# Kept short on purpose: the name shares a 31-byte scan response with nothing
-# else, but `MayonnaiOS.Bluetooth.Advertising` shortens anything past 29 bytes
-# and a truncated name is what a host caches.
-config :mayonnaios, controller_name: "MayonnaiOS Controller"
+# The real controller's name, because the name is part of the claimed
+# identity -- see `MayonnaiOS.Bluetooth.HOGP`. At 24 bytes it fits the
+# 31-byte scan response it shares with nothing else;
+# `MayonnaiOS.Bluetooth.Advertising` shortens anything past 29 bytes and a
+# truncated name is what a host caches.
+config :mayonnaios, controller_name: "Xbox Wireless Controller"
 
 # Where the keys of paired hosts are written.
 #

--- a/config/target.exs
+++ b/config/target.exs
@@ -255,7 +255,13 @@ config :mayonnaios, :programs, [
   # connect headphones, because that is A2DP over BR/EDR and there is no
   # BR/EDR host in this firmware. `MayonnaiOS.Pairing` has the full account,
   # and the screen says it in the first line rather than in a footnote.
-  %{name: "Bluetooth devices", app: MayonnaiOS.Pairing}
+  %{name: "Bluetooth devices", app: MayonnaiOS.Pairing},
+  # Neither a program nor an app: a verb of the launcher's own. Selecting it
+  # asks rather than acts -- Y answers, anything else cancels -- and it ends
+  # in the same `Nerves.Runtime.poweroff/0` the Select+Menu chord reaches.
+  # Last on purpose: the off switch belongs at the end of a list you scroll,
+  # not next to the thing you launch every day.
+  %{name: "Power off", action: :poweroff}
 ]
 
 # The name a host shows in its pairing list, and the icon it draws next to it

--- a/lib/mayonnaios/bluetooth/att.ex
+++ b/lib/mayonnaios/bluetooth/att.ex
@@ -32,8 +32,8 @@ defmodule MayonnaiOS.Bluetooth.ATT do
 
   The ATT MTU starts at 23 bytes on LE -- 20 bytes of payload once the
   notification header is subtracted -- and stays there unless the client asks
-  for more. That is enough for a five-byte report and not enough for an
-  eighty-byte report descriptor, which is why Read Blob exists and why the
+  for more. That is enough for a sixteen-byte report and not enough for a
+  283-byte report descriptor, which is why Read Blob exists and why the
   server has to implement it: a client reading the Report Map at the default
   MTU gets the first 22 bytes and then asks for the rest by offset.
   """

--- a/lib/mayonnaios/bluetooth/credits.ex
+++ b/lib/mayonnaios/bluetooth/credits.ex
@@ -1,0 +1,143 @@
+defmodule MayonnaiOS.Bluetooth.Credits do
+  @moduledoc """
+  The controller's ACL buffer accounting: what may be sent now, what waits,
+  and what is not worth waiting for.
+
+  A Bluetooth controller holds a small, fixed number of outbound ACL packets
+  -- eight of 27 bytes on this board's Realtek -- and sending more than it
+  has room for is a protocol violation, not a queue. Every packet spends one
+  credit; a Number of Completed Packets event gives credits back. This module
+  is that arithmetic, kept pure so it can be tested on a laptop:
+  `MayonnaiOS.Bluetooth.Host` owns the socket and asks this what to write.
+
+  ## Two kinds of PDU, two verbs
+
+  `offer/2` is for input reports and their kin: all-or-nothing, never queued.
+  A report is the *current* state of the buttons; if it cannot go now, the
+  next one supersedes it a few milliseconds later, and queueing them would
+  deliver a burst of stale states that reads as the controller sticking and
+  then catching up. A dropped report is the right answer and the caller
+  counts it.
+
+  `push/2` is for everything that is an answer to a question: ATT responses,
+  SMP, L2CAP signalling. These are not superseded by anything -- a host that
+  asked for the report map waits thirty seconds for it and then gives up on
+  the device. What does not fit now is queued, and `completed/2` hands back
+  what each returned credit lets through, in order.
+
+  ## Why the queue exists at all
+
+  It did not, and the stack worked -- until the report descriptor grew. The
+  descriptor is read at MTU 247, and a 246-byte ATT response is ten fragments
+  of 27 bytes where the controller holds eight. The old all-or-nothing send
+  refused the PDU, nothing was ever written, and BlueZ on a Steam Deck
+  reported `Report Map read failed: unlikely error` -- its words for an ATT
+  request nothing answered -- and declined to create the input device. A
+  controller that pairs, encrypts and notifies perfectly, invisible to every
+  game, because the one answer that did not fit was silently thrown away.
+
+  ## Fragments must stay contiguous
+
+  The fragments of one L2CAP PDU must arrive on the link back to back;
+  another PDU's fragment between them corrupts the reassembly on the far
+  side. That is why `offer/2` refuses whenever the queue is non-empty, even
+  with credits in hand: a report slipped in ahead of a half-sent response
+  would land in the middle of it. The queue drains in insertion order for
+  the same reason.
+
+  ## One connection
+
+  Credits are per controller, not per connection, and `disconnected/1`
+  restores the full allowance and empties the queue. That is correct only
+  while there is at most one connection -- which is what this peripheral is
+  -- because a controller with a second link still holds the other link's
+  unacknowledged packets. If a central role ever shares this stack, this
+  module is where the accounting has to grow up.
+  """
+
+  defstruct credits: 1, total: 1, queue: :queue.new()
+
+  @typedoc "The running account: credits in hand, the allowance, and what waits."
+  @type t :: %__MODULE__{
+          credits: non_neg_integer(),
+          total: pos_integer(),
+          queue: :queue.queue(binary())
+        }
+
+  @doc "A fresh account with the controller's full allowance in hand."
+  @spec new(pos_integer()) :: t()
+  def new(total) when total > 0, do: %__MODULE__{credits: total, total: total}
+
+  @doc """
+  Spend credits on a droppable PDU: all of it now, or none of it ever.
+
+  Refused when the fragments outnumber the credits in hand, and refused
+  whenever anything is queued -- see the moduledoc on contiguity. The caller
+  drops the PDU and counts why; nothing is remembered here.
+  """
+  @spec offer(t(), [binary()]) :: {:ok, [binary()], t()} | {:error, :no_credits}
+  def offer(%__MODULE__{} = account, packets) do
+    count = length(packets)
+
+    if :queue.is_empty(account.queue) and count <= account.credits do
+      {:ok, packets, %{account | credits: account.credits - count}}
+    else
+      {:error, :no_credits}
+    end
+  end
+
+  @doc """
+  Queue a PDU that must arrive: send what credits allow, keep the rest.
+
+  Returns the packets to write now. What does not fit waits for
+  `completed/2`, behind everything already waiting.
+  """
+  @spec push(t(), [binary()]) :: {[binary()], t()}
+  def push(%__MODULE__{} = account, packets) do
+    queue = Enum.reduce(packets, account.queue, &:queue.in/2)
+    drain(%{account | queue: queue})
+  end
+
+  @doc """
+  Take back the credits a Number of Completed Packets event returned.
+
+  Returns the queued packets those credits let through, oldest first. The
+  clamp to the allowance is for a controller that acknowledges more than it
+  was given, which would otherwise mint credits out of thin air.
+  """
+  @spec completed(t(), non_neg_integer()) :: {[binary()], t()}
+  def completed(%__MODULE__{} = account, returned) do
+    drain(%{account | credits: min(account.credits + returned, account.total)})
+  end
+
+  @doc """
+  The connection is gone: full allowance back, queue emptied.
+
+  The controller frees a dead link's buffers without acknowledging them, so
+  waiting for completions that will never come leaks credits until nothing
+  can be sent at all. The queued fragments are for a handle that no longer
+  exists and sending them would be an error, so they go too.
+  """
+  @spec disconnected(t()) :: t()
+  def disconnected(%__MODULE__{} = account) do
+    %{account | credits: account.total, queue: :queue.new()}
+  end
+
+  @doc "How many packets are waiting. For the curious and the diagnostics screen."
+  @spec queued(t()) :: non_neg_integer()
+  def queued(%__MODULE__{} = account), do: :queue.len(account.queue)
+
+  defp drain(account), do: drain(account, [])
+
+  defp drain(%{credits: 0} = account, acc), do: {Enum.reverse(acc), account}
+
+  defp drain(account, acc) do
+    case :queue.out(account.queue) do
+      {{:value, packet}, rest} ->
+        drain(%{account | queue: rest, credits: account.credits - 1}, [packet | acc])
+
+      {:empty, _queue} ->
+        {Enum.reverse(acc), account}
+    end
+  end
+end

--- a/lib/mayonnaios/bluetooth/gatt.ex
+++ b/lib/mayonnaios/bluetooth/gatt.ex
@@ -524,7 +524,7 @@ defmodule MayonnaiOS.Bluetooth.GATT do
   # The largest ATT PDU this server will send or receive. Chosen to fit in a
   # single ACL fragment on a controller with the common 27-byte LE payload is
   # *not* the goal -- fragmentation handles that -- but a large MTU costs a
-  # buffer per connection and buys nothing for five-byte reports. 247 is the
+  # buffer per connection and buys nothing for sixteen-byte reports. 247 is the
   # number that fits an extended data-length packet exactly, and is what most
   # peripherals ask for.
   defp server_mtu, do: 247

--- a/lib/mayonnaios/bluetooth/hogp.ex
+++ b/lib/mayonnaios/bluetooth/hogp.ex
@@ -26,15 +26,19 @@ defmodule MayonnaiOS.Bluetooth.HOGP do
   layout that matches what those hosts see every day is a layout their code
   paths have been tested against.
 
-  ## The PnP ID is not borrowed
+  ## The PnP ID is Microsoft's, on purpose
 
-  Vendor 0x1209 is pid.codes, the identifier set aside for open-source
-  hardware that has no USB-IF membership, and 0x4D4F is unregistered within
-  it. Picking a real vendor's numbers here -- Microsoft's, say -- would make
-  Steam apply that controller's button mapping to this one, which is a worse
-  outcome than being unrecognised: an unrecognised gamepad gets the generic
-  mapping, which is correct, while a misrecognised one gets a layout that is
-  wrong in a way that looks like the device is faulty.
+  Vendor 0x045E, product 0x0B13: the Xbox Wireless Controller with the BLE
+  firmware. This used to be pid.codes numbers and a paragraph here about how
+  borrowing a real vendor's would get the borrowed controller's mapping
+  applied to a layout that was not its -- which was true, and is exactly the
+  mechanism now being used on purpose: `MayonnaiOS.Controller.Report` carries
+  that controller's descriptor and report layout byte for byte, so the fixed
+  belief these numbers trigger in SDL, macOS and the Steam Deck is a correct
+  belief. Its moduledoc has the full account of the reversal. The numbers,
+  the name, the manufacturer string and the report format are one identity
+  and change together or not at all -- a device that is half one thing is
+  recognised as neither.
 
   ## Everything in the HID service needs encryption
 
@@ -84,15 +88,24 @@ defmodule MayonnaiOS.Bluetooth.HOGP do
   # and some hosts write it unconditionally.
   @report_protocol <<0x01>>
 
-  # See the moduledoc. Source 0x02 is the USB Implementer's Forum's numbering.
-  @pnp <<0x02, 0x1209::16-little, 0x4D4F::16-little, 0x0100::16-little>>
+  # See the moduledoc. Source 0x02 is the USB Implementer's Forum's numbering,
+  # 0x045E is Microsoft, 0x0B13 is the Xbox Wireless Controller on its BLE
+  # firmware, and 0x0509 is that firmware's version as the real pad reports it.
+  @pnp <<0x02, 0x045E::16-little, 0x0B13::16-little, 0x0509::16-little>>
 
-  # Zero, and that is a value rather than a placeholder: the Report Reference
-  # descriptor uses 0 to mean "the report map declares no report IDs, and this
-  # is the only report of its type". `MayonnaiOS.Controller.Report` has the
-  # account of why declaring an ID cost more than it bought.
-  @report_id 0
+  # The IDs the report map declares: input report 1 and the rumble output
+  # report 3, which is the 1914's numbering. Notifications still carry no ID
+  # byte -- over HOGP the ID lives here, in each characteristic's Report
+  # Reference descriptor. `MayonnaiOS.Controller.Report` has the account of
+  # why an ID stopped being the hazard it was for the unrecognised pad.
+  @report_id 1
+  @rumble_report_id 3
   @input_report 0x01
+  @output_report 0x02
+
+  # What a rumble write looks like before a host sends one. Eight bytes to
+  # match the report the map declares, all zero: no actuators enabled.
+  @rumble_at_rest <<0, 0, 0, 0, 0, 0, 0, 0>>
 
   @doc "The report ID the report reference descriptor and the report map agree on."
   @spec report_id() :: non_neg_integer()
@@ -132,7 +145,7 @@ defmodule MayonnaiOS.Bluetooth.HOGP do
        ]},
       {:service, @device_information,
        [
-         {@manufacturer_name, [:read], value: "MayonnaiOS"},
+         {@manufacturer_name, [:read], value: "Microsoft"},
          {@pnp_id, [:read], value: @pnp}
        ]},
       {:service, @battery_service,
@@ -164,11 +177,24 @@ defmodule MayonnaiOS.Bluetooth.HOGP do
           descriptors: [
             {@cccd, [read: :encrypted, write: :encrypted]},
             # Which report in the map this characteristic carries, and in
-            # which direction. Report ID 0 -- the map declares none -- and
-            # Input. A host that finds a report characteristic with no
-            # reference descriptor cannot match it to the report map and
-            # ignores it.
+            # which direction: report ID 1, Input. A host that finds a report
+            # characteristic with no reference descriptor cannot match it to
+            # the report map and ignores it.
             {@report_reference, [value: <<@report_id, @input_report>>, read: :encrypted]}
+          ]},
+         # The rumble output report the descriptor declares. Writes are
+         # accepted -- `MayonnaiOS.Bluetooth.GATT` stores nothing and reports
+         # a `:written_static` event nobody listens for -- because there is
+         # no motor, and because refusing the write would make a host's HID
+         # layer mark the whole device faulty where ignoring it only makes
+         # the rumble silent. Declared after the input report so that
+         # `find_handle/2`, which takes the first match, keeps finding input.
+         {@report, [:read, :write, :write_without_response],
+          value: @rumble_at_rest,
+          read: :encrypted,
+          write: :encrypted,
+          descriptors: [
+            {@report_reference, [value: <<@rumble_report_id, @output_report>>, read: :encrypted]}
           ]}
        ]}
     ]

--- a/lib/mayonnaios/bluetooth/host.ex
+++ b/lib/mayonnaios/bluetooth/host.ex
@@ -34,24 +34,30 @@ defmodule MayonnaiOS.Bluetooth.Host do
   second process to read it -- which matters because a socket read from two
   processes is a socket whose ownership on close is a matter of opinion.
 
-  ## ACL credits, and why a dropped report is the right answer
+  ## ACL credits: reports drop, answers queue
 
-  The controller can hold a small number of ACL packets -- typically four to
-  eight on a part like this one -- and sending more than it can hold is a
-  protocol violation, not a queue. `send_acl/1` therefore counts credits and
-  refuses a PDU that will not fit, and the refusal goes back to the caller.
+  The controller can hold a small number of ACL packets -- eight of 27 bytes
+  on this board's Realtek -- and sending more than it can hold is a protocol
+  violation, not a queue. `MayonnaiOS.Bluetooth.Credits` is the accounting;
+  this process only writes what it says may be written.
 
-  For a gamepad that is the correct behaviour and not a compromise. The thing
-  being sent is the *current* state of the buttons; if it cannot go now, the
-  next one supersedes it a few milliseconds later. Queueing them would deliver
-  a burst of stale states after the stall, which in a game reads as the
-  controller sticking and then catching up.
+  There are two sends because there are two kinds of PDU. `send_acl/1` is
+  all-or-nothing and refuses when the credits are not there, which is correct
+  for an input report: the next one supersedes it in milliseconds, and a
+  queue of them delivers a burst of stale states that reads as the controller
+  sticking. `queue_acl/1` never refuses, because it carries the PDUs that are
+  answers -- an ATT response, an SMP step -- where "not now" has to mean
+  "as soon as the controller returns a buffer" rather than "never". The
+  difference stopped being theoretical when the report descriptor grew to
+  ten fragments against eight buffers and the one read a host will not
+  forgive losing was silently thrown away; the Credits moduledoc has the
+  post-mortem.
   """
 
   use GenServer
   require Logger
 
-  alias MayonnaiOS.Bluetooth.{HCI, HCISocket}
+  alias MayonnaiOS.Bluetooth.{Credits, HCI, HCISocket}
 
   @command_timeout 5_000
 
@@ -65,8 +71,7 @@ defmodule MayonnaiOS.Bluetooth.Host do
             monitor: nil,
             pending: nil,
             queue: :queue.new(),
-            credits: @fallback_credits,
-            total_credits: @fallback_credits,
+            acl: Credits.new(@fallback_credits),
             packet_length: @fallback_packet_length
 
   @doc """
@@ -104,13 +109,24 @@ defmodule MayonnaiOS.Bluetooth.Host do
   end
 
   @doc """
-  Send the ACL packets of one PDU, or none of them.
+  Send the ACL packets of one droppable PDU, or none of them.
 
-  `{:error, :no_credits}` means the controller's buffers are full. See the
-  moduledoc for why that is reported rather than queued.
+  `{:error, :no_credits}` means the controller's buffers are full or a
+  queued PDU is part-way out. See the moduledoc for why a report is dropped
+  rather than queued.
   """
   @spec send_acl([binary()]) :: :ok | {:error, term()}
   def send_acl(packets), do: GenServer.call(__MODULE__, {:acl, packets})
+
+  @doc """
+  Send the ACL packets of one PDU that must arrive, queueing what does not
+  fit.
+
+  For the PDUs that are answers -- ATT responses, SMP, signalling. Always
+  `:ok`: what cannot go now goes as the controller returns buffers, in order.
+  """
+  @spec queue_acl([binary()]) :: :ok
+  def queue_acl(packets), do: GenServer.call(__MODULE__, {:acl_queued, packets})
 
   @doc "The controller's ACL payload limit, which is what fragments are cut to."
   @spec packet_length() :: pos_integer()
@@ -185,20 +201,26 @@ defmodule MayonnaiOS.Bluetooth.Host do
   end
 
   def handle_call({:acl, packets}, _from, state) do
-    count = length(packets)
+    case Credits.offer(state.acl, packets) do
+      {:ok, to_send, acl} ->
+        Enum.each(to_send, &:socket.send(state.socket, &1))
+        {:reply, :ok, %{state | acl: acl}}
 
-    if count <= state.credits do
-      Enum.each(packets, &:socket.send(state.socket, &1))
-      {:reply, :ok, %{state | credits: state.credits - count}}
-    else
-      {:reply, {:error, :no_credits}, state}
+      {:error, :no_credits} ->
+        {:reply, {:error, :no_credits}, state}
     end
+  end
+
+  def handle_call({:acl_queued, packets}, _from, state) do
+    {to_send, acl} = Credits.push(state.acl, packets)
+    Enum.each(to_send, &:socket.send(state.socket, &1))
+    {:reply, :ok, %{state | acl: acl}}
   end
 
   def handle_call(:packet_length, _from, state), do: {:reply, state.packet_length, state}
 
   def handle_call({:buffers, length, count}, _from, state) do
-    {:reply, :ok, %{state | packet_length: length, credits: count, total_credits: count}}
+    {:reply, :ok, %{state | packet_length: length, acl: Credits.new(count)}}
   end
 
   @impl true
@@ -277,10 +299,24 @@ defmodule MayonnaiOS.Bluetooth.Host do
 
   defp handle_packet(state, {:event, :number_of_completed_packets, %{handles: handles}}) do
     returned = handles |> Enum.map(&elem(&1, 1)) |> Enum.sum()
-    %{state | credits: min(state.credits + returned, state.total_credits)}
+    {to_send, acl} = Credits.completed(state.acl, returned)
+    Enum.each(to_send, &:socket.send(state.socket, &1))
+    %{state | acl: acl}
   end
 
-  defp handle_packet(state, packet) do
+  # Forwarded like every other event, and also acted on here: the buffers a
+  # dead link still held come back without completions, and fragments queued
+  # for its handle must not reach the controller. `Credits.disconnected/1`
+  # has the account; the single-connection assumption it rests on is in its
+  # moduledoc.
+  defp handle_packet(state, {:event, :disconnection_complete, _params} = packet) do
+    forward(state, packet)
+    %{state | acl: Credits.disconnected(state.acl)}
+  end
+
+  defp handle_packet(state, packet), do: forward(state, packet)
+
+  defp forward(state, packet) do
     if state.owner do
       send(state.owner, {:hci, packet})
     else

--- a/lib/mayonnaios/bluetooth/l2cap.ex
+++ b/lib/mayonnaios/bluetooth/l2cap.ex
@@ -7,11 +7,11 @@ defmodule MayonnaiOS.Bluetooth.L2CAP do
   does -- attributes on 0x0004, signalling on 0x0005, pairing on 0x0006. What
   is left is framing, and framing is where a stack quietly loses bytes.
 
-  ## Why reassembly is not optional even for five-byte reports
+  ## Why reassembly is not optional even for sixteen-byte reports
 
-  The reports this device sends are eight bytes of L2CAP payload and will
+  The reports this device sends are nineteen bytes of L2CAP payload and will
   never be fragmented. The *responses* are a different matter: the HID report
-  descriptor is around eighty bytes, and the controller's ACL payload limit on
+  descriptor is 283 bytes, and the controller's ACL payload limit on
   this part is likely to be twenty-seven. So a host reading the Report Map
   gets a response that must be split, and a host that has raised the ATT MTU
   can send us a write that arrives split.

--- a/lib/mayonnaios/bluetooth/peripheral.ex
+++ b/lib/mayonnaios/bluetooth/peripheral.ex
@@ -535,18 +535,26 @@ defmodule MayonnaiOS.Bluetooth.Peripheral do
 
   defp send_smp(state, pdu), do: send_pdu(state, L2CAP.cid_smp(), pdu)
 
+  # Everything that answers a question goes through the queued send:
+  # `Host.queue_acl/1` holds what the controller cannot take yet and sends
+  # it as buffers come back. A dropped response is not a smaller failure
+  # than a dropped connection -- a host waits thirty seconds for the report
+  # map it asked for, gives up, and the device is paired, encrypted and
+  # invisible. That was live once: the 283-byte descriptor reads as ten
+  # fragments against eight buffers, and the old all-or-nothing send threw
+  # the answer away. Only notifications may be dropped, and they go through
+  # `notify/6` below.
   defp send_pdu(%{connection: nil} = state, _cid, _payload), do: state
 
   defp send_pdu(state, cid, payload) do
-    packets =
-      cid
-      |> L2CAP.encode(payload)
-      |> then(&L2CAP.fragments(state.connection.handle, &1, state.packet_length))
+    :ok = Host.queue_acl(fragments(state, cid, payload))
+    state
+  end
 
-    case Host.send_acl(packets) do
-      :ok -> state
-      {:error, reason} -> drop(state, reason)
-    end
+  defp fragments(state, cid, payload) do
+    cid
+    |> L2CAP.encode(payload)
+    |> then(&L2CAP.fragments(state.connection.handle, &1, state.packet_length))
   end
 
   defp notify(state, handle, cccd, key, value, count_drops \\ true)
@@ -567,8 +575,13 @@ defmodule MayonnaiOS.Bluetooth.Peripheral do
         if count, do: drop(state, :unsubscribed), else: state
 
       true ->
-        state = send_pdu(state, L2CAP.cid_att(), ATT.notification(handle, value))
-        %{state | sent: state.sent + 1}
+        # The droppable send, and the only caller of it. A notification is
+        # the current state of something; when the credits are not there,
+        # the next one supersedes it, and the counter says how often.
+        case Host.send_acl(fragments(state, L2CAP.cid_att(), ATT.notification(handle, value))) do
+          :ok -> %{state | sent: state.sent + 1}
+          {:error, reason} -> if count, do: drop(state, reason), else: state
+        end
     end
   end
 

--- a/lib/mayonnaios/bluetooth/peripheral.ex
+++ b/lib/mayonnaios/bluetooth/peripheral.ex
@@ -48,7 +48,11 @@ defmodule MayonnaiOS.Bluetooth.Peripheral do
 
   alias MayonnaiOS.Bluetooth.{ATT, Advertising, Bonds, GATT, HCI, HOGP, Host, L2CAP, SMP}
 
-  @default_name "MayonnaiOS Controller"
+  # The real pad's name, because the name is part of the identity: it is the
+  # first thing a host shows and some third-party drivers match on it. See
+  # `MayonnaiOS.Bluetooth.HOGP` -- the numbers, the name and the report
+  # format change together or not at all.
+  @default_name "Xbox Wireless Controller"
 
   defstruct name: @default_name,
             address: nil,

--- a/lib/mayonnaios/controller/pad.ex
+++ b/lib/mayonnaios/controller/pad.ex
@@ -11,15 +11,17 @@ defmodule MayonnaiOS.Controller.Pad do
 
   ## Only changes go out
 
-  A report is sent when the encoded five bytes differ from the last five sent.
-  Not on every evdev report, and not on a timer.
+  A report is sent when the encoded sixteen bytes differ from the last
+  sixteen sent. Not on every evdev report, and not on a timer.
 
   HID input reports are edge-driven by design: the host holds the last state
   it was given until it is given another. So a repeat carries no information,
   and sending one costs a connection event that a button press might have
   used instead. Sending only on change also makes the auto-repeat the kernel
   generates for a held button free -- it folds into a state that is already
-  what was last sent, and nothing goes out.
+  what was last sent, and nothing goes out. The analog stick leans on this
+  too: `MayonnaiOS.Controller.Report` quantises the axes, so ADC noise folds
+  into an unchanged report here rather than a stream of notifications.
 
   ## Everything is released on the way out
 
@@ -59,7 +61,13 @@ defmodule MayonnaiOS.Controller.Pad do
   def input(events), do: GenServer.cast(__MODULE__, {:input, events})
 
   @doc "What is held right now, as the host would see it."
-  @spec state() :: %{pressed: [atom()], directions: [atom()], bytes: binary()}
+  @spec state() :: %{
+          pressed: [atom()],
+          directions: [atom()],
+          axes: %{x: non_neg_integer(), y: non_neg_integer()},
+          triggers: %{brake: non_neg_integer(), accelerator: non_neg_integer()},
+          bytes: binary()
+        }
   def state, do: GenServer.call(__MODULE__, :state)
 
   @impl true
@@ -92,6 +100,8 @@ defmodule MayonnaiOS.Controller.Pad do
      %{
        pressed: MapSet.to_list(state.report.buttons),
        directions: MapSet.to_list(state.report.directions),
+       axes: %{x: state.report.x, y: state.report.y},
+       triggers: %{brake: state.report.brake, accelerator: state.report.accelerator},
        bytes: Report.encode(state.report)
      }, state}
   end

--- a/lib/mayonnaios/controller/report.ex
+++ b/lib/mayonnaios/controller/report.ex
@@ -1,68 +1,130 @@
 defmodule MayonnaiOS.Controller.Report do
   @moduledoc """
-  The gamepad as a host sees it: a HID report descriptor and the three bytes
-  that go with it.
+  The gamepad as a host sees it: the Xbox Wireless Controller's HID report
+  descriptor, byte for byte, and the sixteen bytes that go with it.
 
   This module is the whole of the "what kind of controller is this" question,
   and it is deliberately pure -- a report descriptor is a constant, and
-  turning evdev presses into report bytes is a fold over a struct. Neither
+  turning evdev events into report bytes is a fold over a struct. Neither
   needs Bluetooth, so both are tested on a laptop and only the transport below
   them needs the handheld.
 
-  ## The descriptor decides what the host believes
+  ## The identity is borrowed, and that is now the point
 
-  A HID host does not probe a gamepad. It reads the report descriptor once, at
-  connection time, and everything it will ever believe about the device comes
-  from those bytes: how many buttons there are, how wide each report is, which
-  bits mean what. Get the descriptor wrong and there is no error anywhere --
-  the host parses it happily and reports the wrong buttons, or ignores the
-  device entirely because it does not look like a gamepad.
+  An earlier version of this module declared an honest descriptor -- a hat and
+  ten buttons under pid.codes numbers -- and the README grew a long section
+  explaining why that controller could not practically drive a game: SDL
+  matches gamepads against a database keyed by vendor and product numbers, an
+  unlisted device is a joystick rather than a game controller, and on macOS
+  Steam Input has no virtual controller to bridge the gap with. Every word of
+  that section was a workaround for the device saying who it really was.
 
-  So the layout is written out explicitly below, byte by byte, with the item
-  names next to the values. `descriptor/0` is assembled from those lines rather
-  than pasted as a blob, because a blob is unreviewable and this is the one
-  part of the stack where a silent mistake stays silent.
+  So it stops saying that. The descriptor below is the Xbox Wireless
+  Controller's -- model 1914, the BLE firmware, product 0x0B13 -- reproduced
+  exactly, and `MayonnaiOS.Bluetooth.HOGP` claims the matching vendor and
+  product numbers. Hosts with first-class Xbox support (macOS through the
+  GameController framework and SDL's HIDAPI driver, the Steam Deck, Windows,
+  phones) recognise it with no mapping step, which is the whole ask.
 
-  ## What is declared
+  The old objection to this -- written down in this moduledoc's previous life
+  -- was that a host with a *driver* for the claimed controller stops reading
+  the descriptor and parses reports against the real device's fixed layout, so
+  any deviation is scrambled buttons the host is certain are correct. That
+  objection was to guessing someone else's layout while shipping your own. It
+  dissolves when the layout *is* theirs: the fixed format the drivers assume
+  is exactly what these bytes declare and exactly what `encode/1` packs. The
+  driver mechanism goes from the risk to the payoff.
 
-      Hat switch      the D-pad, 8 directions plus a null state
-      Buttons 1..10   A B X Y L1 R1 L2 R2 Select Start
+  ## Byte-exact or nothing
 
-  A hat switch is what a D-pad is, and it is the only thing the D-pad is
-  reported as.
+  The descriptor is transcribed from the capture that ships in
+  ESP32-BLE-CompositeHID (`XboxOneS_1914_HIDDescriptor`, taken from a real
+  pad with the BLE firmware), and the test suite pins all 283 bytes against
+  that reference. This is the one place where a helpful-looking improvement
+  is a bug: reordering an item, dropping the vestigial rumble collection,
+  "fixing" the 0..65535 axes to be signed -- any of it produces a device the
+  drivers misparse while the descriptor reads fine. Edit this only to track
+  the real controller, and re-pin the test from a fresh capture when you do.
 
-  No axes are declared, and that is a statement about the kernel rather than
-  about the hardware. This shell *does* have an analog stick -- unlike the
-  RG35XX Plus whose device tree this board's was extended from -- and Linux
-  can now see it: `adc-joystick` is built, the node is in the device tree, and
-  `InputEvent.enumerate/0` on firmware `3cc86f59` shows it with `abs_x` and
-  `abs_y` over 0..4096. This descriptor still declares no axes because
-  *nothing in this firmware reads that device*, and axes fed by nothing would
-  put a dead stick in front of every host just as surely as axes with no
-  driver behind them. What is missing is now on this side; the README's
-  roadmap has it.
+  ## What is real and what is at rest
 
-  ## The D-pad used to be declared twice, and that was the bug
+  The 1914 declares more controls than this shell has. What is missing is
+  reported permanently at rest, which is indistinguishable from a player not
+  touching it:
 
-  An earlier version of this descriptor also declared X and Y axes driven by
-  the D-pad, on the reasoning that plenty of games only ever look at a stick
-  and a controller with no axes at all would do nothing in them.
+      left stick    real -- the ADC stick, scaled from 0..4096 to 0..65535
+      right stick   absent; reported centred (0x8000, 0x8000) forever
+      triggers      the shell's L2/R2 are switches, so 0 or fully pulled
+      LS, RS        no stick clicks on this shell; never pressed
+      Xbox button   not reported; Menu on the shell is the way out of the app
+      Share button  not reported
 
-  What happened on a Mac, through Steam: the character moved correctly in four
-  directions *and* the mouse pointer moved at the same time. One press, two
-  consumers. Steam's own layer had taken the axes for a stick and bound that
-  stick to the pointer -- with the two axes swapped, so up and down slid the
-  cursor left and right -- while the game read the hat and did the right
-  thing. In a menu, where nothing was reading the hat, all that was left was a
-  wandering cursor.
+  The rumble output report the descriptor declares is accepted by the GATT
+  server and dropped -- there is no motor. A host that rumbles hears silence,
+  which is what a pad with a dead motor sounds like, and nothing retries.
 
-  The reasoning was wrong in a way worth writing down, because it is
-  tempting. Declaring one physical control twice does not give a host two
-  chances to get it right; it gives two *different* pieces of software one
-  each, and they do not agree. And the games the duplication was meant to
-  rescue were never rescued by it: a game that reads a stick reads it through
-  a mapping, and an unrecognised controller has no mapping whether or not it
-  reports axes.
+  ## There is a report ID now, and why that stopped being a problem
+
+  The previous descriptor deliberately declared no report ID, after a version
+  with ID 1 left Steam listing the controller and receiving nothing: software
+  reading *raw* reports has to know whether the first byte is an ID or data,
+  and for an unknown device the two conventions split hosts into camps.
+
+  The Xbox descriptor declares ID 1 because the real pad does, and the reports
+  this module encodes still carry no ID byte -- over HID-over-GATT the ID
+  travels in the Report Reference descriptor next to the characteristic, not
+  in the notification. That is the same framing the real controller uses, so
+  the code paths parsing it are the ones every Xbox pad on Bluetooth already
+  exercises. The old failure was the cost of being nobody; it does not carry
+  over to being somebody the host knows.
+
+  ## Report layout
+
+  Sixteen bytes, fields little-endian, packed LSB first in declaration order:
+
+      bytes 0-1    left stick X, 0..65535
+      bytes 2-3    left stick Y, 0..65535
+      bytes 4-5    right stick X, always 0x8000
+      bytes 6-7    right stick Y, always 0x8000
+      bytes 8-9    brake (left trigger), 10 bits, 0..1023
+      bytes 10-11  accelerator (right trigger), 10 bits, 0..1023
+      byte 12      bits 0-3 hat: 0 centred, 1 north, clockwise to 8 north-west
+      bytes 13-14  fifteen buttons, one bit each, A in bit 0
+      byte 15      bit 0 Share, which this shell does not have
+
+  ## The button names are the ones on the plastic
+
+  Linux's `BTN_A` is south and this board follows the Nintendo layout, so the
+  atom `:btn_b` is the button silkscreened **A**; on top of that the device
+  tree has X and Y the wrong way round, so `:btn_y` is the button
+  silkscreened **X**. `MayonnaiOS.Launcher`'s moduledoc has the full account
+  and the evidence.
+
+  Mapping is label to label: the button printed A on the shell is the Xbox A,
+  wherever each sits. A game saying "press A" means the glyph, the player
+  reads the plastic, and label-to-label is the only mapping where those two
+  agree without a diagram. The Xbox layout puts A south where this shell
+  prints it east; anyone who finds that positional swap unplayable can remap
+  it on the host, which -- with the pad now recognised -- is a supported
+  operation rather than the workaround it used to be.
+
+  Menu (`:btn_mode`) is deliberately absent. It is how you leave controller
+  mode -- the same "Menu is the one way back" the launcher already has -- and
+  a button that both exits and does something on the host would be a button
+  you could not press safely. For the same reason it is *not* mapped to the
+  Xbox button, which on every host summons an overlay.
+
+  ## The stick arrives in twelfths and leaves in two-fifty-sixths
+
+  `adc-joystick` delivers 0..4096 and the report promises 0..65535, so values
+  are scaled up and then quantised to 256 steps. The quantisation is not
+  laziness: the low bits of a 12-bit ADC are noise, every twitch of them
+  would be a report the radio has to carry (`MayonnaiOS.Controller.Pad` sends
+  on change), and 256 positions per axis is more than a thumb on a 30 mm
+  stick can express anyway. Whether up on this stick is 0 or 4096 has not
+  been checked against hardware yet; if characters walk upside down, the fix
+  is one subtraction in `scale/1` and the roadmap section of the README says
+  so.
 
   ## Changing this descriptor means re-pairing
 
@@ -72,74 +134,11 @@ defmodule MayonnaiOS.Controller.Report do
   paired: it goes on parsing new reports against the old layout, which is
   worse than no change, because the bytes have moved underneath it.
 
-  Both ends have to forget each other. On the device that is
-  `MayonnaiOS.Controller.unpair/0`; on the host it is removing the device in
-  its Bluetooth settings.
-
-  ## There is no report ID, and that is the point
-
-  This device has exactly one input report, so it declares no Report ID item
-  at all and `MayonnaiOS.Bluetooth.HOGP` puts 0 in the Report Reference
-  descriptor, which is what 0 there means.
-
-  An earlier version declared Report ID 1. Everything that read the report
-  through a HID *parser* was fine with that -- a browser's gamepad API showed
-  every button correctly -- while Steam listed the controller and received
-  nothing from it at all. That split is the signature of a report ID: a
-  parser asks the operating system for element values and never sees the ID,
-  while software reading raw reports has to know whether the first byte is an
-  ID or data, and the two conventions differ by exactly one byte.
-
-  With no ID declared there is no convention to get wrong. Every consumer
-  sees three bytes of report, and the first one is the hat.
-
-  ## Report layout
-
-      byte 0   bits 0-3 hat, bits 4-7 padding
-      byte 1   buttons 1-8, one bit each, button 1 in bit 0
-      byte 2   bits 0-1 buttons 9-10, bits 2-7 padding
-
-  HID packs fields least-significant-bit first, in declaration order, which is
-  why the hat lands in the low nibble and the padding item after it is not
-  optional: without it the button field would start mid-byte and every button
-  would be off by four bits.
-
-  ## The button names are the ones on the plastic
-
-  Linux's `BTN_A` is south and this board follows the Nintendo layout, so the
-  atom `:btn_b` is the button silkscreened **A**; on top of that the device
-  tree has X and Y the wrong way round, so `:btn_y` is the button
-  silkscreened **X**. `MayonnaiOS.Launcher`'s moduledoc has the full account
-  and the evidence. The table below is keyed by the atom that actually
-  arrives and commented with the physical button, so it can be read without
-  going and getting that account.
-
-  Menu (`:btn_mode`) is deliberately absent. It is how you leave controller
-  mode -- the same "Menu is the one way back" the launcher already has -- and
-  a button that both exits and does something on the host would be a button
-  you could not press safely.
-
-  ## What is verified and what is not
-
-  The kernel's own capability list settles most of it. `gpio-keys-gamepad`
-  declares exactly fifteen keys:
-
-      btn_a btn_b btn_x btn_y btn_tl btn_tr btn_tl2 btn_tr2
-      btn_select btn_start btn_mode
-      btn_dpad_up btn_dpad_down btn_dpad_left btn_dpad_right
-
-  Every one of them appears in the tables below or is deliberately left out,
-  and nothing is declared that this module does not know about -- so there is
-  no button on this shell that silently reaches a host as nothing.
-
-  What that list cannot settle is which piece of plastic emits which code.
-  A, B, X, Y and Select were checked by pressing them and watching, and two
-  of those four turned out to contradict the device tree. The shoulders are
-  not checked: `btn_tl2` is assumed to be L2 rather than, say, the pair being
-  swapped the way X and Y were. The cost of that being wrong is a shoulder
-  button in the wrong place rather than a crash, and
-  `MayonnaiOS.Controller.Pad` logs any key that arrives without a mapping, so
-  a correction is a log line away rather than a mystery.
+  This applies to the change that created this module: a host paired with
+  the old three-byte pad must forget the device **and**
+  `MayonnaiOS.Controller.unpair/0` must run here, or the host will parse
+  sixteen-byte reports against a three-byte layout and report garbage with
+  total confidence.
   """
 
   @typedoc "Which way the D-pad is held."
@@ -148,37 +147,61 @@ defmodule MayonnaiOS.Controller.Report do
   @typedoc """
   Everything the host is told, before it is packed into bytes.
 
-  `buttons` holds evdev atoms rather than button numbers so that the state is
-  readable in a log line and in IEx; the numbering is applied at the last
-  possible moment, in `encode/1`.
+  `buttons` holds evdev atoms rather than bit masks so that the state is
+  readable in a log line and in IEx; the packing is applied at the last
+  possible moment, in `encode/1`. The axes and triggers are stored already
+  scaled, because the report's units are the only units anything downstream
+  speaks.
   """
   @type t :: %__MODULE__{
           buttons: MapSet.t(atom()),
-          directions: MapSet.t(direction())
+          directions: MapSet.t(direction()),
+          x: 0..0xFFFF,
+          y: 0..0xFFFF,
+          brake: 0..0x3FF,
+          accelerator: 0..0x3FF
         }
 
-  defstruct buttons: MapSet.new(), directions: MapSet.new()
+  # A stick at rest is the middle of an unsigned range, not zero. Zero is a
+  # stick pinned to one corner, which is what the right-stick fields would
+  # have said forever had they defaulted like the triggers do.
+  @centre 0x8000
 
-  # evdev atom -> HID button number. The comment is the button as printed on
-  # the shell; see the moduledoc for why those two disagree.
+  defstruct buttons: MapSet.new(),
+            directions: MapSet.new(),
+            x: @centre,
+            y: @centre,
+            brake: 0,
+            accelerator: 0
+
+  # evdev atom -> the button's bit in the fifteen-bit field, numbered the way
+  # the 1914 numbers them (button 1 in bit 0; bits 2, 5, 8 and 9 belong to
+  # controls this shell does not have). The comment is the label on the
+  # plastic; see the moduledoc for why the atoms disagree with it.
   @buttons %{
     # A
-    btn_b: 1,
+    btn_b: 0x0001,
     # B
-    btn_a: 2,
+    btn_a: 0x0002,
     # X
-    btn_y: 3,
+    btn_y: 0x0008,
     # Y
-    btn_x: 4,
-    btn_tl: 5,
-    btn_tr: 6,
-    btn_tl2: 7,
-    btn_tr2: 8,
-    btn_select: 9,
-    btn_start: 10
+    btn_x: 0x0010,
+    # L1, the Xbox LB
+    btn_tl: 0x0040,
+    # R1, the Xbox RB
+    btn_tr: 0x0080,
+    # Select, the Xbox View button
+    btn_select: 0x0400,
+    # Start, the Xbox Menu button
+    btn_start: 0x0800
   }
 
-  @button_count 10
+  # evdev atom -> the trigger field it fills. The shell's L2 and R2 are
+  # switches, so a press is a fully pulled trigger and a release is a
+  # released one; the ten-bit range exists for pads whose triggers travel.
+  @trigger_full 0x3FF
+  @triggers %{btn_tl2: :brake, btn_tr2: :accelerator}
 
   # evdev atom -> D-pad direction.
   @directions %{
@@ -188,128 +211,443 @@ defmodule MayonnaiOS.Controller.Report do
     btn_dpad_right: :right
   }
 
-  # Hat switch values, clockwise from north. 15 is out of the declared logical
-  # range and so means "null" -- centred -- which is what the Null State flag
-  # on the hat's Input item allows.
-  @hat_null 15
+  # evdev absolute axis -> struct field. Only the left stick exists; abs
+  # events for anything else fall through `apply_event/2` untouched.
+  @axes %{abs_x: :x, abs_y: :y}
+  @axis_in_max 4096
+
+  # Hat switch values, clockwise from north. The 1914 numbers directions from
+  # 1 and uses 0 -- below the declared logical minimum -- as the null state,
+  # where the previous descriptor counted from 0 and used 15. Same mechanism,
+  # different constants, and the constants are the host's to dictate.
+  @hat_null 0
   @hat %{
-    [:up] => 0,
-    [:right, :up] => 1,
-    [:right] => 2,
-    [:down, :right] => 3,
-    [:down] => 4,
-    [:down, :left] => 5,
-    [:left] => 6,
-    [:left, :up] => 7
+    [:up] => 1,
+    [:right, :up] => 2,
+    [:right] => 3,
+    [:down, :right] => 4,
+    [:down] => 5,
+    [:down, :left] => 6,
+    [:left] => 7,
+    [:left, :up] => 8
   }
 
-  @doc """
-  The HID report descriptor, as bytes.
+  # -- The descriptor, in the 1914's own order ------------------------------
+  #
+  # Transcribed item by item rather than pasted as a blob so that a reviewer
+  # reads names against bytes; the test suite holds the assembled whole
+  # against the reference capture, so a typo here is a failing test rather
+  # than a host silently misparsing.
 
-  This is what goes in the Report Map characteristic. It is assembled from the
-  item list below so that a reviewer reads item names rather than hex.
+  # Usage Page (Generic Desktop), Usage (Game Pad), Collection (Application),
+  # Report ID (1).
+  @open <<0x05, 0x01, 0x09, 0x05, 0xA1, 0x01, 0x85, 0x01>>
+
+  # The left stick: a Pointer physical collection holding X and Y, sixteen
+  # unsigned bits each. The four-byte logical maximum (0x27) is how the
+  # real pad spells 65535, so it is how this one does.
+  @left_stick <<
+    # Usage (Pointer), Collection (Physical)
+    0x09,
+    0x01,
+    0xA1,
+    0x00,
+    # Usage (X), Usage (Y)
+    0x09,
+    0x30,
+    0x09,
+    0x31,
+    # Logical Minimum (0), Logical Maximum (65535)
+    0x15,
+    0x00,
+    0x27,
+    0xFF,
+    0xFF,
+    0x00,
+    0x00,
+    # Report Count (2), Report Size (16), Input (Data, Variable, Absolute)
+    0x95,
+    0x02,
+    0x75,
+    0x10,
+    0x81,
+    0x02,
+    # End Collection
+    0xC0
+  >>
+
+  # The right stick this shell does not have: Z and Rz, same shape. Declared
+  # because the 1914 declares it; fed the centre forever.
+  @right_stick <<
+    # Usage (Pointer), Collection (Physical)
+    0x09,
+    0x01,
+    0xA1,
+    0x00,
+    # Usage (Z), Usage (Rz)
+    0x09,
+    0x32,
+    0x09,
+    0x35,
+    # Logical Minimum (0), Logical Maximum (65535)
+    0x15,
+    0x00,
+    0x27,
+    0xFF,
+    0xFF,
+    0x00,
+    0x00,
+    # Report Count (2), Report Size (16), Input (Data, Variable, Absolute)
+    0x95,
+    0x02,
+    0x75,
+    0x10,
+    0x81,
+    0x02,
+    # End Collection
+    0xC0
+  >>
+
+  # Left trigger: Simulation Controls page, Usage (Brake), ten bits in a
+  # sixteen-bit field. The six padding bits reset the logical maximum first,
+  # because global items are sticky.
+  @brake <<
+    # Usage Page (Simulation Controls), Usage (Brake)
+    0x05,
+    0x02,
+    0x09,
+    0xC5,
+    # Logical Minimum (0), Logical Maximum (1023)
+    0x15,
+    0x00,
+    0x26,
+    0xFF,
+    0x03,
+    # Report Count (1), Report Size (10), Input (Data, Variable, Absolute)
+    0x95,
+    0x01,
+    0x75,
+    0x0A,
+    0x81,
+    0x02,
+    # Logical Minimum (0), Logical Maximum (0)
+    0x15,
+    0x00,
+    0x25,
+    0x00,
+    # Report Size (6), Report Count (1), Input (Constant)
+    0x75,
+    0x06,
+    0x95,
+    0x01,
+    0x81,
+    0x03
+  >>
+
+  # Right trigger: Usage (Accelerator), otherwise identical.
+  @accelerator <<
+    # Usage Page (Simulation Controls), Usage (Accelerator)
+    0x05,
+    0x02,
+    0x09,
+    0xC4,
+    # Logical Minimum (0), Logical Maximum (1023)
+    0x15,
+    0x00,
+    0x26,
+    0xFF,
+    0x03,
+    # Report Count (1), Report Size (10), Input (Data, Variable, Absolute)
+    0x95,
+    0x01,
+    0x75,
+    0x0A,
+    0x81,
+    0x02,
+    # Logical Minimum (0), Logical Maximum (0)
+    0x15,
+    0x00,
+    0x25,
+    0x00,
+    # Report Size (6), Report Count (1), Input (Constant)
+    0x75,
+    0x06,
+    0x95,
+    0x01,
+    0x81,
+    0x03
+  >>
+
+  # The D-pad, as a hat switch: 1..8 clockwise from north, 0 for centred via
+  # the Null State flag. The padding afterwards zeroes every global item the
+  # hat set -- units included, or the buttons would be reported in degrees.
+  @hat_switch <<
+    # Usage Page (Generic Desktop), Usage (Hat Switch)
+    0x05,
+    0x01,
+    0x09,
+    0x39,
+    # Logical Minimum (1), Logical Maximum (8)
+    0x15,
+    0x01,
+    0x25,
+    0x08,
+    # Physical Minimum (0), Physical Maximum (315)
+    0x35,
+    0x00,
+    0x46,
+    0x3B,
+    0x01,
+    # Unit (Degrees, English rotation)
+    0x66,
+    0x14,
+    0x00,
+    # Report Size (4), Report Count (1), Input (Data, Variable, Absolute, Null State)
+    0x75,
+    0x04,
+    0x95,
+    0x01,
+    0x81,
+    0x42,
+    # Report Size (4), Report Count (1)
+    0x75,
+    0x04,
+    0x95,
+    0x01,
+    # Logical Minimum (0), Logical Maximum (0)
+    0x15,
+    0x00,
+    0x25,
+    0x00,
+    # Physical Minimum (0), Physical Maximum (0), Unit (None)
+    0x35,
+    0x00,
+    0x45,
+    0x00,
+    0x65,
+    0x00,
+    # Input (Constant)
+    0x81,
+    0x03
+  >>
+
+  # Fifteen buttons and a padding bit. Which bit is which button is the
+  # driver's fixed belief; the @buttons table above is its mirror.
+  @fifteen_buttons <<
+    # Usage Page (Button), Usage Minimum (1), Usage Maximum (15)
+    0x05,
+    0x09,
+    0x19,
+    0x01,
+    0x29,
+    0x0F,
+    # Logical Minimum (0), Logical Maximum (1)
+    0x15,
+    0x00,
+    0x25,
+    0x01,
+    # Report Size (1), Report Count (15), Input (Data, Variable, Absolute)
+    0x75,
+    0x01,
+    0x95,
+    0x0F,
+    0x81,
+    0x02,
+    # Logical Minimum (0), Logical Maximum (0)
+    0x15,
+    0x00,
+    0x25,
+    0x00,
+    # Report Size (1), Report Count (1), Input (Constant)
+    0x75,
+    0x01,
+    0x95,
+    0x01,
+    0x81,
+    0x03
+  >>
+
+  # The Share button, on the Consumer page as Usage (Record). Not a button
+  # this shell has; the byte it lives in is sent as zero.
+  @share <<
+    # Usage Page (Consumer), Usage (Record)
+    0x05,
+    0x0C,
+    0x0A,
+    0xB2,
+    0x00,
+    # Logical Minimum (0), Logical Maximum (1)
+    0x15,
+    0x00,
+    0x25,
+    0x01,
+    # Report Count (1), Report Size (1), Input (Data, Variable, Absolute)
+    0x95,
+    0x01,
+    0x75,
+    0x01,
+    0x81,
+    0x02,
+    # Logical Minimum (0), Logical Maximum (0)
+    0x15,
+    0x00,
+    0x25,
+    0x00,
+    # Report Size (7), Report Count (1), Input (Constant)
+    0x75,
+    0x07,
+    0x95,
+    0x01,
+    0x81,
+    0x03
+  >>
+
+  # The rumble output report, ID 3: Physical Interface Device page, a Set
+  # Effect Report collection -- actuator enable bits, four magnitudes,
+  # duration, start delay, loop count. Eight bytes a host may write and this
+  # device reads never; declared because a driver that knows the 1914 knows
+  # it has motors, and a missing report is a difference where none is
+  # affordable.
+  @rumble <<
+    # Usage Page (Physical Interface Device), Usage (Set Effect Report)
+    0x05,
+    0x0F,
+    0x09,
+    0x21,
+    # Report ID (3), Collection (Logical)
+    0x85,
+    0x03,
+    0xA1,
+    0x02,
+    # Usage (DC Enable Actuators)
+    0x09,
+    0x97,
+    # Logical Minimum (0), Logical Maximum (1)
+    0x15,
+    0x00,
+    0x25,
+    0x01,
+    # Report Size (4), Report Count (1), Output (Data, Variable, Absolute)
+    0x75,
+    0x04,
+    0x95,
+    0x01,
+    0x91,
+    0x02,
+    # Logical Minimum (0), Logical Maximum (0)
+    0x15,
+    0x00,
+    0x25,
+    0x00,
+    # Report Size (4), Report Count (1), Output (Constant)
+    0x75,
+    0x04,
+    0x95,
+    0x01,
+    0x91,
+    0x03,
+    # Usage (Magnitude)
+    0x09,
+    0x70,
+    # Logical Minimum (0), Logical Maximum (100)
+    0x15,
+    0x00,
+    0x25,
+    0x64,
+    # Report Size (8), Report Count (4), Output (Data, Variable, Absolute)
+    0x75,
+    0x08,
+    0x95,
+    0x04,
+    0x91,
+    0x02,
+    # Usage (Duration), Unit (Seconds), Unit Exponent (-2)
+    0x09,
+    0x50,
+    0x66,
+    0x01,
+    0x10,
+    0x55,
+    0x0E,
+    # Logical Minimum (0), Logical Maximum (255)
+    0x15,
+    0x00,
+    0x26,
+    0xFF,
+    0x00,
+    # Report Size (8), Report Count (1), Output (Data, Variable, Absolute)
+    0x75,
+    0x08,
+    0x95,
+    0x01,
+    0x91,
+    0x02,
+    # Usage (Start Delay)
+    0x09,
+    0xA7,
+    # Logical Minimum (0), Logical Maximum (255)
+    0x15,
+    0x00,
+    0x26,
+    0xFF,
+    0x00,
+    # Report Size (8), Report Count (1), Output (Data, Variable, Absolute)
+    0x75,
+    0x08,
+    0x95,
+    0x01,
+    0x91,
+    0x02,
+    # Unit (None), Unit Exponent (0)
+    0x65,
+    0x00,
+    0x55,
+    0x00,
+    # Usage (Loop Count)
+    0x09,
+    0x7C,
+    # Logical Minimum (0), Logical Maximum (255)
+    0x15,
+    0x00,
+    0x26,
+    0xFF,
+    0x00,
+    # Report Size (8), Report Count (1), Output (Data, Variable, Absolute)
+    0x75,
+    0x08,
+    0x95,
+    0x01,
+    0x91,
+    0x02,
+    # End Collection
+    0xC0
+  >>
+
+  # End Collection, closing the Game Pad application collection.
+  @close <<0xC0>>
+
+  @descriptor @open <>
+                @left_stick <>
+                @right_stick <>
+                @brake <>
+                @accelerator <>
+                @hat_switch <> @fifteen_buttons <> @share <> @rumble <> @close
+
+  @doc """
+  The HID report descriptor, as bytes: the Xbox Wireless Controller 1914's,
+  all 283 of them.
+
+  This is what goes in the Report Map characteristic, and byte-exactness is
+  the contract -- see the moduledoc.
   """
   @spec descriptor() :: binary()
-  def descriptor do
-    <<
-      # Usage Page (Generic Desktop)
-      0x05,
-      0x01,
-      # Usage (Game Pad)
-      0x09,
-      0x05,
-      # Collection (Application)
-      0xA1,
-      0x01,
-      # No Report ID item. See the moduledoc: this device has one report, and
-      # declaring an ID for it only creates a question every host answers
-      # differently.
-      # Usage Page (Generic Desktop)
-      0x05,
-      0x01,
-      # Usage (Hat Switch)
-      0x09,
-      0x39,
-      # Logical Minimum (0)
-      0x15,
-      0x00,
-      # Logical Maximum (7)
-      0x25,
-      0x07,
-      # Physical Minimum (0)
-      0x35,
-      0x00,
-      # Physical Maximum (315)
-      0x46,
-      0x3B,
-      0x01,
-      # Unit (Degrees, English rotation)
-      0x65,
-      0x14,
-      # Report Size (4)
-      0x75,
-      0x04,
-      # Report Count (1)
-      0x95,
-      0x01,
-      # Input (Data, Variable, Absolute, Null State)
-      0x81,
-      0x42,
-      # Unit (None) -- undo the degrees, or it applies to everything after
-      0x65,
-      0x00,
-      # Report Size (4)
-      0x75,
-      0x04,
-      # Report Count (1)
-      0x95,
-      0x01,
-      # Input (Constant) -- pad the hat out to a whole byte
-      0x81,
-      0x03,
-      # Usage Page (Button)
-      0x05,
-      0x09,
-      # Usage Minimum (Button 1)
-      0x19,
-      0x01,
-      # Usage Maximum (Button 10)
-      0x29,
-      @button_count,
-      # Logical Minimum (0)
-      0x15,
-      0x00,
-      # Logical Maximum (1)
-      0x25,
-      0x01,
-      # Report Size (1)
-      0x75,
-      0x01,
-      # Report Count (10)
-      0x95,
-      @button_count,
-      # Input (Data, Variable, Absolute)
-      0x81,
-      0x02,
-      # Report Size (1)
-      0x75,
-      0x01,
-      # Report Count (6) -- pad the buttons out to two whole bytes
-      0x95,
-      0x06,
-      # Input (Constant)
-      0x81,
-      0x03,
-      # End Collection
-      0xC0
-    >>
-  end
+  def descriptor, do: @descriptor
 
-  @doc "How many bytes one input report takes. Five."
+  @doc "How many bytes one input report takes. Sixteen."
   @spec size() :: pos_integer()
   def size, do: byte_size(encode(%__MODULE__{}))
 
-  @doc "Nothing pressed. What the host is sent when controller mode is left."
+  @doc "Nothing pressed, sticks centred. What the host is sent when controller mode is left."
   @spec released() :: t()
   def released, do: %__MODULE__{}
 
@@ -333,7 +671,7 @@ defmodule MayonnaiOS.Controller.Report do
   @doc """
   Fold a single evdev event in.
 
-  Anything that is not a key this controller declares is returned unchanged --
+  Anything that is not a control this report carries is returned unchanged --
   `EV_SYN`, the volume keys, an atom no table here knows. Unknown keys are not
   an error at this level; `MayonnaiOS.Controller` is the one that logs them,
   because it is the one that knows whether anybody is listening.
@@ -344,6 +682,9 @@ defmodule MayonnaiOS.Controller.Report do
       Map.has_key?(@buttons, key) ->
         %{state | buttons: toggle(state.buttons, key, value)}
 
+      field = Map.get(@triggers, key) ->
+        Map.put(state, field, if(value == 0, do: 0, else: @trigger_full))
+
       direction = Map.get(@directions, key) ->
         %{state | directions: toggle(state.directions, direction, value)}
 
@@ -352,41 +693,75 @@ defmodule MayonnaiOS.Controller.Report do
     end
   end
 
+  def apply_event(state, {:ev_abs, axis, value}) do
+    case Map.get(@axes, axis) do
+      nil -> state
+      field -> Map.put(state, field, scale(value))
+    end
+  end
+
   def apply_event(state, _event), do: state
 
   defp toggle(set, member, 0), do: MapSet.delete(set, member)
   defp toggle(set, member, _pressed), do: MapSet.put(set, member)
 
+  # 0..4096 in, 0..65535 out, quantised to steps of 256. The multiplier is 16
+  # rather than 65535/4096 so that the ADC's centre, 2048, lands exactly on
+  # 0x8000 -- and the quantisation rounds to the *nearest* step, which parks
+  # the step boundaries a half-step away from any resting value instead of
+  # exactly on the centre, where the noise would sit astride one. The clamps
+  # are because evdev promises a range, not that every driver honours it.
+  defp scale(value) do
+    scaled = (value |> max(0) |> min(@axis_in_max)) * 16
+    min(div(scaled + 128, 256) * 256, 0xFFFF)
+  end
+
   @doc """
-  Whether this atom means anything to the controller.
+  Whether this key atom means anything to the controller.
 
   Used by the caller to tell "a button with no mapping yet" from "a key that
   is not ours", so only the first gets logged.
   """
   @spec known?(atom()) :: boolean()
-  def known?(key), do: Map.has_key?(@buttons, key) or Map.has_key?(@directions, key)
-
-  @doc """
-  Pack the state into the three bytes the descriptor promises.
-
-      iex> alias MayonnaiOS.Controller.Report
-      iex> Report.encode(Report.released())
-      <<15, 0, 0>>
-  """
-  @spec encode(t()) :: binary()
-  def encode(%__MODULE__{} = state) do
-    <<hat(state.directions)::8, buttons(state.buttons)::binary>>
+  def known?(key) do
+    Map.has_key?(@buttons, key) or Map.has_key?(@triggers, key) or
+      Map.has_key?(@directions, key)
   end
 
   @doc """
-  The hat switch value for a set of directions, or 15 for centred.
+  Pack the state into the sixteen bytes the descriptor promises.
+
+      iex> alias MayonnaiOS.Controller.Report
+      iex> Report.encode(Report.released())
+      <<0, 0x80, 0, 0x80, 0, 0x80, 0, 0x80, 0, 0, 0, 0, 0, 0, 0, 0>>
+
+  The right stick is the constant centre, and the Share byte is a constant
+  zero; both belong to controls this shell does not have.
+  """
+  @spec encode(t()) :: binary()
+  def encode(%__MODULE__{} = state) do
+    <<
+      state.x::16-little,
+      state.y::16-little,
+      @centre::16-little,
+      @centre::16-little,
+      state.brake::16-little,
+      state.accelerator::16-little,
+      hat(state.directions)::8,
+      buttons(state.buttons)::binary,
+      0::8
+    >>
+  end
+
+  @doc """
+  The hat switch value for a set of directions, or 0 for centred.
 
   Opposite directions held together -- which the D-pad on this shell can
   physically do, since it is four separate switches under one cross -- cancel,
   giving centre. That is the same thing every other gamepad does, and the
   alternative is a lookup that fails and a report that never gets sent.
   """
-  @spec hat(MapSet.t(direction())) :: 0..15
+  @spec hat(MapSet.t(direction())) :: 0..8
   def hat(directions) do
     Map.get(@hat, directions |> cancel() |> Enum.sort(), @hat_null)
   end
@@ -402,26 +777,27 @@ defmodule MayonnaiOS.Controller.Report do
     end)
   end
 
-  @doc "The two button bytes, button 1 in the low bit of the first."
+  @doc "The two button bytes, the Xbox A in the low bit of the first."
   @spec buttons(MapSet.t(atom())) :: binary()
   def buttons(pressed) do
     bits =
       Enum.reduce(pressed, 0, fn key, acc ->
-        case Map.fetch(@buttons, key) do
-          {:ok, number} -> Bitwise.bor(acc, Bitwise.bsl(1, number - 1))
-          :error -> acc
-        end
+        Bitwise.bor(acc, Map.get(@buttons, key, 0))
       end)
 
     <<bits::16-little>>
   end
 
   @doc """
-  The evdev atom -> HID button number table, for the diagnostics readout and
+  The evdev atom -> button bit mask table, for the diagnostics readout and
   for anyone wondering which button ended up where.
   """
   @spec button_map() :: %{atom() => pos_integer()}
   def button_map, do: @buttons
+
+  @doc "The evdev atom -> trigger field table."
+  @spec trigger_map() :: %{atom() => :brake | :accelerator}
+  def trigger_map, do: @triggers
 
   @doc "The evdev atom -> D-pad direction table."
   @spec direction_map() :: %{atom() => direction()}

--- a/lib/mayonnaios/controller/report.ex
+++ b/lib/mayonnaios/controller/report.ex
@@ -121,10 +121,11 @@ defmodule MayonnaiOS.Controller.Report do
   laziness: the low bits of a 12-bit ADC are noise, every twitch of them
   would be a report the radio has to carry (`MayonnaiOS.Controller.Pad` sends
   on change), and 256 positions per axis is more than a thumb on a 30 mm
-  stick can express anyway. Whether up on this stick is 0 or 4096 has not
-  been checked against hardware yet; if characters walk upside down, the fix
-  is one subtraction in `scale/1` and the roadmap section of the README says
-  so.
+  stick can express anyway. The Y axis is flipped on the way through --
+  this ADC's Y grows toward physically up where HID's grows toward down --
+  and that is a fact read off a Steam Deck with the stick in hand, not an
+  assumption; the first firmware to carry the stick shipped it straight and
+  walked everything upside down.
 
   ## Changing this descriptor means re-pairing
 
@@ -211,9 +212,8 @@ defmodule MayonnaiOS.Controller.Report do
     btn_dpad_right: :right
   }
 
-  # evdev absolute axis -> struct field. Only the left stick exists; abs
-  # events for anything else fall through `apply_event/2` untouched.
-  @axes %{abs_x: :x, abs_y: :y}
+  # The ADC's range. Only the left stick exists; abs events for anything
+  # else fall through `apply_event/2` untouched.
   @axis_in_max 4096
 
   # Hat switch values, clockwise from north. The 1914 numbers directions from
@@ -693,12 +693,12 @@ defmodule MayonnaiOS.Controller.Report do
     end
   end
 
-  def apply_event(state, {:ev_abs, axis, value}) do
-    case Map.get(@axes, axis) do
-      nil -> state
-      field -> Map.put(state, field, scale(value))
-    end
-  end
+  def apply_event(state, {:ev_abs, :abs_x, value}), do: %{state | x: scale(value)}
+
+  # Flipped, and checked on the hardware rather than assumed: this ADC's Y
+  # grows toward physically up, HID's Y grows toward down, and shipping the
+  # value straight through moved the world upside down on a Steam Deck.
+  def apply_event(state, {:ev_abs, :abs_y, value}), do: %{state | y: scale(@axis_in_max - value)}
 
   def apply_event(state, _event), do: state
 

--- a/lib/mayonnaios/controller/report.ex
+++ b/lib/mayonnaios/controller/report.ex
@@ -114,6 +114,25 @@ defmodule MayonnaiOS.Controller.Report do
   you could not press safely. For the same reason it is *not* mapped to the
   Xbox button, which on every host summons an overlay.
 
+  ## Select+Start held together is the Xbox button
+
+  The shell has no plastic for the Xbox button, and on a Steam Deck that
+  button is how you reach Steam. So the chord: while Select and Start are
+  both down, the report says Xbox and says neither View nor Menu.
+
+  The edges are where chords go wrong, and both are decided here. On the way
+  in, whichever half goes down first is reported alone for the beat before
+  the other arrives -- a brief View or Menu press the host really sees.
+  Swallowing it would take a timer holding every Select and Start hostage
+  against a chord that usually is not coming, and this fold owns no clock;
+  a game that pauses on Menu may pause on the way into the overlay, which is
+  where the player was headed anyway. On the way out the same leak would be
+  worse -- release one half and the other would read as a fresh press,
+  re-opening the pause menu the overlay was closed onto -- so the chord
+  *latches*: once it fires, View and Menu stay suppressed until both halves
+  are up. In, Xbox; out, silence; the two single buttons work exactly as
+  before when the chord is never completed.
+
   ## The stick arrives in twelfths and leaves in two-fifty-sixths
 
   `adc-joystick` delivers 0..4096 and the report promises 0..65535, so values
@@ -157,6 +176,7 @@ defmodule MayonnaiOS.Controller.Report do
   @type t :: %__MODULE__{
           buttons: MapSet.t(atom()),
           directions: MapSet.t(direction()),
+          chorded: boolean(),
           x: 0..0xFFFF,
           y: 0..0xFFFF,
           brake: 0..0x3FF,
@@ -170,6 +190,7 @@ defmodule MayonnaiOS.Controller.Report do
 
   defstruct buttons: MapSet.new(),
             directions: MapSet.new(),
+            chorded: false,
             x: @centre,
             y: @centre,
             brake: 0,
@@ -192,11 +213,18 @@ defmodule MayonnaiOS.Controller.Report do
     btn_tl: 0x0040,
     # R1, the Xbox RB
     btn_tr: 0x0080,
-    # Select, the Xbox View button
+    # Select, the Xbox View button -- and half of the Xbox-button chord
     btn_select: 0x0400,
-    # Start, the Xbox Menu button
+    # Start, the Xbox Menu button -- the other half
     btn_start: 0x0800
   }
+
+  # The Xbox button, which this shell reaches through Select+Start held
+  # together, and the two bits the chord suppresses while it does. See the
+  # moduledoc.
+  @guide 0x1000
+  @view_and_menu 0x0C00
+  @chord [:btn_select, :btn_start]
 
   # evdev atom -> the trigger field it fills. The shell's L2 and R2 are
   # switches, so a press is a fully pulled trigger and a release is a
@@ -680,7 +708,7 @@ defmodule MayonnaiOS.Controller.Report do
   def apply_event(state, {:ev_key, key, value}) do
     cond do
       Map.has_key?(@buttons, key) ->
-        %{state | buttons: toggle(state.buttons, key, value)}
+        update_chord(%{state | buttons: toggle(state.buttons, key, value)})
 
       field = Map.get(@triggers, key) ->
         Map.put(state, field, if(value == 0, do: 0, else: @trigger_full))
@@ -704,6 +732,18 @@ defmodule MayonnaiOS.Controller.Report do
 
   defp toggle(set, member, 0), do: MapSet.delete(set, member)
   defp toggle(set, member, _pressed), do: MapSet.put(set, member)
+
+  # The chord latches when both halves are down and lets go only when both
+  # are up. The latch is what keeps a staggered release honest: without it,
+  # lifting Select a beat before Start would re-press Menu on the way out of
+  # the overlay the chord just opened.
+  defp update_chord(state) do
+    cond do
+      Enum.all?(@chord, &MapSet.member?(state.buttons, &1)) -> %{state | chorded: true}
+      not Enum.any?(@chord, &MapSet.member?(state.buttons, &1)) -> %{state | chorded: false}
+      true -> state
+    end
+  end
 
   # 0..4096 in, 0..65535 out, quantised to steps of 256. The multiplier is 16
   # rather than 65535/4096 so that the ADC's centre, 2048, lands exactly on
@@ -748,7 +788,7 @@ defmodule MayonnaiOS.Controller.Report do
       state.brake::16-little,
       state.accelerator::16-little,
       hat(state.directions)::8,
-      buttons(state.buttons)::binary,
+      buttons(state)::binary,
       0::8
     >>
   end
@@ -777,13 +817,27 @@ defmodule MayonnaiOS.Controller.Report do
     end)
   end
 
-  @doc "The two button bytes, the Xbox A in the low bit of the first."
-  @spec buttons(MapSet.t(atom())) :: binary()
-  def buttons(pressed) do
+  # The two button bytes, the Xbox A in the low bit of the first. The chord
+  # rewrites what the table says: both halves down is the Xbox button and
+  # neither View nor Menu, and while the latch holds, whichever half is
+  # still down on the way out stays silent too.
+  defp buttons(%__MODULE__{} = state) do
     bits =
-      Enum.reduce(pressed, 0, fn key, acc ->
+      Enum.reduce(state.buttons, 0, fn key, acc ->
         Bitwise.bor(acc, Map.get(@buttons, key, 0))
       end)
+
+    bits =
+      cond do
+        Enum.all?(@chord, &MapSet.member?(state.buttons, &1)) ->
+          bits |> Bitwise.band(Bitwise.bnot(@view_and_menu)) |> Bitwise.bor(@guide)
+
+        state.chorded ->
+          Bitwise.band(bits, Bitwise.bnot(@view_and_menu))
+
+        true ->
+          bits
+      end
 
     <<bits::16-little>>
   end

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -86,6 +86,7 @@ defmodule MayonnaiOS.Launcher do
       A             launch the selected program
       Menu          go back to the home screen
       X             switch between the menu and diagnostics
+      Y             answer the Power off row's question, and nothing else
       Power         sleep -- backlight off, and any press wakes it
       Select+Menu   power off
 
@@ -99,8 +100,15 @@ defmodule MayonnaiOS.Launcher do
   of this" across two keys depending on which kind of thing you were in.
 
   Select+Menu still powers off, so the chord is checked before the plain
-  press. Power off is a chord rather than a button because it is not undoable
-  and this is a handheld that gets carried in a pocket.
+  press. The chord was the only power-off for a long time, on the argument
+  that switching off is not undoable and this is a handheld that gets carried
+  in a pocket; the menu now also has a Power off row, and the same argument
+  shapes how the row answers. Pressing A on it does nothing but put a
+  question on the bottom line; Y -- the button that did not ask -- switches
+  off, and any other press takes the question down and is swallowed, so a
+  cancel cannot also launch what the cursor is on. That is the file manager's
+  delete rule, applied to the other irreversible thing on the device. Both
+  routes end in the same `Nerves.Runtime.poweroff/0`.
 
   ## Sleep, and the press that wakes it
 
@@ -205,10 +213,14 @@ defmodule MayonnaiOS.Launcher do
   # enough here, which is the same lesson as A and B and was available the
   # whole time; it just was not applied twice.
   #
-  # Y (:btn_x) is deliberately unbound. It played the audio test while audio
+  # Y (:btn_x) has no plain binding. It played the audio test while audio
   # was the open question on this board; that is answered, and a key on a
   # handheld that makes a noise when pressed by accident is not worth keeping
   # for a check that belongs in IEx. `MayonnaiOS.Audio.run/0` still does it.
+  # Its one job now is answering the Power off row's question -- the same
+  # "Y is the second verb" it has in `MayonnaiOS.Files`, and only while the
+  # question is on the panel.
+  @confirm_button :btn_x
   @diagnostics_button :btn_y
 
   # Menu, doing double duty: alone it is the way back to the home screen,
@@ -388,6 +400,15 @@ defmodule MayonnaiOS.Launcher do
       held: MapSet.new(),
       scene: :home,
       selected: 0,
+      # Whether the Power off row has asked its question and is waiting for
+      # Y. Armed by `start_program/2`, answered or dismissed by `press/2`,
+      # and never true while anything is running -- the row can only be
+      # activated from an idle menu.
+      confirming: false,
+      # What actually switches the device off, injectable because the real
+      # one cannot be called on a laptop and a confirmation flow nobody can
+      # test is a confirmation flow that silently rots.
+      poweroff: Keyword.get(opts, :poweroff, &Nerves.Runtime.poweroff/0),
       # The seam the stop path is tested against: signalling an OS process and
       # asking whether it is still there. Injectable because the one case that
       # matters most cannot be produced for real -- a process that survives
@@ -613,8 +634,7 @@ defmodule MayonnaiOS.Launcher do
   defp leave_app(state, events) do
     if Enum.any?(events, &match?({:ev_key, @home_button, 1}, &1)) do
       if MapSet.member?(state.held, @poweroff_modifier) do
-        poweroff()
-        state
+        poweroff(state, "Select+Menu")
       else
         state |> stop_app() |> go_home()
       end
@@ -649,12 +669,30 @@ defmodule MayonnaiOS.Launcher do
   # nothing else and arrives from its own device -- and the ordering is what
   # keeps that a property of the binding rather than of this function.
   defp press(state, key) do
-    if Sleep.trigger?(state.held, key) do
-      {_result, state} = enter_sleep(state)
-      state
-    else
-      bound(state, key)
+    cond do
+      Sleep.trigger?(state.held, key) ->
+        {_result, state} = enter_sleep(state)
+        state
+
+      state.confirming ->
+        answer_poweroff(state, key)
+
+      true ->
+        bound(state, key)
     end
+  end
+
+  # The Power off row's question, answered the way `MayonnaiOS.Files` answers
+  # a delete: A asked, so A cannot also be the answer. Y -- and only Y --
+  # switches off; anything else keeps the device on, is swallowed rather than
+  # dispatched, and takes the question off the panel. Swallowed matters: the
+  # cancelling press must not also launch whatever the cursor is on.
+  defp answer_poweroff(state, @confirm_button), do: poweroff(state, "the menu")
+
+  defp answer_poweroff(state, _key) do
+    state = %{state | confirming: false}
+    show(:home, state)
+    state
   end
 
   # Entering sleep only counts if the backlight write landed. A dark-panel
@@ -692,8 +730,7 @@ defmodule MayonnaiOS.Launcher do
   # someone reaches for to get out of a game.
   defp bound(state, @home_button) do
     if MapSet.member?(state.held, @poweroff_modifier) do
-      poweroff()
-      state
+      poweroff(state, "Select+Menu")
     else
       go_home(state)
     end
@@ -781,16 +818,18 @@ defmodule MayonnaiOS.Launcher do
     %{state | scene: next}
   end
 
-  defp poweroff do
-    Logger.info("[launcher] Select+Menu: powering off")
+  defp poweroff(state, how) do
+    Logger.info("[launcher] #{how}: powering off")
 
     # Whether poweroff/0 brings this board down cleanly is the genuinely
-    # unknown part. This is still the only *orderly* shutdown the device has,
-    # and the arrival of the power key does not change that: a short press is
+    # unknown part. This is the only *orderly* shutdown the device has, and
+    # the arrival of the power key does not change that: a short press is
     # sleep, and a long one is the PMIC cutting the rail in hardware after the
     # 4000 ms its `shutdown` attribute reads -- no unmount, no save flushed,
-    # nothing told. So the chord stays, and stays a chord.
-    Nerves.Runtime.poweroff()
+    # nothing told. Two ways to ask for it -- the Select+Menu chord and the
+    # menu row -- and one function they both reach.
+    state.poweroff.()
+    state
   end
 
   # Three outcomes, logged apart from each other on purpose. "Nothing
@@ -813,6 +852,16 @@ defmodule MayonnaiOS.Launcher do
 
   defp start_program(%{installed?: false} = program, state) do
     Logger.warning("[launcher] #{program.path} not installed")
+    state
+  end
+
+  # The Power off row. Not a program and not an app: pressing A here only
+  # asks, and the repaint puts the question on the panel. `press/2` owns the
+  # answer -- Y switches off, anything else keeps the device on -- because A
+  # opened the question and the answer must not be the button that asked.
+  defp start_program(%{action: :poweroff}, state) do
+    state = %{state | confirming: true}
+    show(:home, state)
     state
   end
 
@@ -1077,7 +1126,9 @@ defmodule MayonnaiOS.Launcher do
   # index: the scene calls `Programs.list/0` itself, so no list is copied into
   # a scene start on every keypress, and the two cannot disagree about order
   # because both derive from the same config.
-  defp show(_home, state), do: set_root(default_scene(), %{selected: state.selected})
+  defp show(_home, state) do
+    set_root(default_scene(), %{selected: state.selected, confirming: state.confirming})
+  end
 
   defp set_root(nil, _param), do: :ok
 

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -182,6 +182,13 @@ defmodule MayonnaiOS.Launcher do
   # it. See `MayonnaiOS.Input`.
   @device_name "gpio-keys-gamepad"
 
+  # The analog stick. Opened for the same reason as the power key -- evdev is
+  # not a broadcast, so a device nobody holds open is a device whose events
+  # nobody sees. The launcher itself does nothing with `ev_abs`: its own
+  # handlers ignore them, and the one consumer is the controller app, which
+  # gets them through the same forwarding as everything else.
+  @stick_name "adc-joystick"
+
   # See the moduledoc: this is physical A, not the atom's name.
   @launch_button :btn_b
 
@@ -309,11 +316,12 @@ defmodule MayonnaiOS.Launcher do
     {:ok, new_state(opts)}
   end
 
-  # The gamepad, plus whatever device the sleep key is on. Two nodes now that
-  # `CONFIG_INPUT_AXP20X_PEK` is enabled: evdev is not a broadcast, so the only
-  # way to see `KEY_POWER` is to have `axp20x-pek` open, and both devices
-  # deliver into the same `handle_info`. `uniq` because a binding back on the
-  # pad would make them the same node again, as they were until this firmware.
+  # The gamepad, the analog stick, and whatever device the sleep key is on.
+  # Three nodes: evdev is not a broadcast, so the only way to see `KEY_POWER`
+  # is to have `axp20x-pek` open and the only way to see the stick is to have
+  # `adc-joystick` open, and all of them deliver into the same `handle_info`.
+  # `uniq` because a binding back on the pad would fold two of these into one
+  # node again, as the power key was until this firmware.
   #
   # `nil` is dropped rather than opened. A device that is not there by name is
   # not there, and the alternative -- a number -- is a different device that
@@ -325,7 +333,12 @@ defmodule MayonnaiOS.Launcher do
   defp devices(opts) do
     case Keyword.get(opts, :device) do
       nil ->
-        case Enum.uniq(Enum.reject([Input.find(@device_name), Sleep.device()], &is_nil/1)) do
+        case Enum.uniq(
+               Enum.reject(
+                 [Input.find(@device_name), Input.find(@stick_name), Sleep.device()],
+                 &is_nil/1
+               )
+             ) do
           [] ->
             # A laptop, where this is ordinary and the synthetic-event path is
             # the point -- and a device whose kernel lost both nodes, where it

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -821,13 +821,16 @@ defmodule MayonnaiOS.Launcher do
   defp poweroff(state, how) do
     Logger.info("[launcher] #{how}: powering off")
 
-    # Whether poweroff/0 brings this board down cleanly is the genuinely
-    # unknown part. This is the only *orderly* shutdown the device has, and
-    # the arrival of the power key does not change that: a short press is
-    # sleep, and a long one is the PMIC cutting the rail in hardware after the
-    # 4000 ms its `shutdown` attribute reads -- no unmount, no save flushed,
-    # nothing told. Two ways to ask for it -- the Select+Menu chord and the
-    # menu row -- and one function they both reach.
+    # Orderly, and verified on the hardware to actually cut power -- which
+    # it did not always: the kernel's power-off wrote a register the AXP717
+    # does not have, the write was silently dropped, and every "power off"
+    # fell through PSCI into a watchdog reboot. The BSP's linux patch 0003
+    # (SOFT_PWROFF, 0x27) is what closed that; if power off ever regresses
+    # into a reboot again, start there. The power button is unchanged: a
+    # short press is sleep, and a long one is the PMIC cutting the rail in
+    # hardware after 4000 ms with nothing flushed. Two ways to ask for the
+    # orderly one -- the Select+Menu chord and the menu row -- and one
+    # function they both reach.
     state.poweroff.()
     state
   end

--- a/lib/mayonnaios/programs.ex
+++ b/lib/mayonnaios/programs.ex
@@ -34,6 +34,7 @@ defmodule MayonnaiOS.Programs do
           name: String.t(),
           path: String.t() | nil,
           app: module() | {module(), term()} | nil,
+          action: atom() | nil,
           args: [String.t()],
           installed?: boolean()
         }
@@ -99,6 +100,7 @@ defmodule MayonnaiOS.Programs do
       name: Map.get(entry, :name) || inspect({module, arg}),
       path: nil,
       app: {module, arg},
+      action: nil,
       args: [],
       needs_udev: false,
       installed?: true
@@ -115,11 +117,30 @@ defmodule MayonnaiOS.Programs do
   # process and takes the screen away from it; an app is `start/0` and
   # `stop/0` on a supervisor in this VM, and the two have nothing in common
   # but a row on a menu.
+  # An action is a verb of the launcher's own rather than anything to run:
+  # today only `:poweroff`. There is no path to stat and no module that could
+  # be absent, so it is always "installed" -- a menu that can lose its off
+  # switch to a config typo would fail exactly the way a dropped entry does,
+  # invisibly. What the verb *does* is entirely `MayonnaiOS.Launcher`'s;
+  # this module only carries the atom.
+  defp normalize(%{action: action} = entry) when is_atom(action) and not is_nil(action) do
+    %{
+      name: Map.get(entry, :name) || Atom.to_string(action),
+      path: nil,
+      app: nil,
+      action: action,
+      args: [],
+      needs_udev: false,
+      installed?: true
+    }
+  end
+
   defp normalize(%{app: module} = entry) when is_atom(module) and not is_nil(module) do
     %{
       name: Map.get(entry, :name) || inspect(module),
       path: nil,
       app: module,
+      action: nil,
       args: [],
       needs_udev: false,
       installed?: true
@@ -131,6 +152,7 @@ defmodule MayonnaiOS.Programs do
       name: Map.get(entry, :name) || Path.basename(path),
       path: path,
       app: nil,
+      action: nil,
       args: Map.get(entry, :args, []),
       # Programs that read input through udev; see MayonnaiOS.Udev. Carried
       # through explicitly because this function rebuilds the map rather than
@@ -159,6 +181,7 @@ defmodule MayonnaiOS.Programs do
       name: "#{inspect(entry)} (no :path)",
       path: nil,
       app: nil,
+      action: nil,
       args: [],
       needs_udev: false,
       installed?: false

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -70,7 +70,9 @@ defmodule MayonnaiOS.Scene.Home do
         _ -> 0
       end
 
-    {:ok, push_graph(scene, graph(Programs.list(), selected))}
+    confirming = match?(%{confirming: true}, param)
+
+    {:ok, push_graph(scene, graph(Programs.list(), selected, confirming))}
   end
 
   @doc """
@@ -81,10 +83,10 @@ defmodule MayonnaiOS.Scene.Home do
   empty list, one entry, and a selection at the last index -- the three
   shapes that would otherwise only be found by looking at the device.
   """
-  @spec graph([Programs.program()], integer()) :: Scenic.Graph.t()
-  def graph(programs, selected \\ 0)
+  @spec graph([Programs.program()], integer(), boolean()) :: Scenic.Graph.t()
+  def graph(programs, selected \\ 0, confirming \\ false)
 
-  def graph([], _selected) do
+  def graph([], _selected, _confirming) do
     base()
     |> text("No programs configured.",
       font_size: 20,
@@ -98,7 +100,7 @@ defmodule MayonnaiOS.Scene.Home do
     )
   end
 
-  def graph(programs, selected) do
+  def graph(programs, selected, confirming) do
     count = length(programs)
     selected = Integer.mod(selected, count)
 
@@ -118,6 +120,20 @@ defmodule MayonnaiOS.Scene.Home do
 
     graph
     |> position(start, count)
+    |> confirm(confirming)
+  end
+
+  # The Power off row's question, on the bottom line the way the file
+  # manager's bottom line names its second verb. Amber, because it is the
+  # panel asking for a decision rather than describing a state.
+  defp confirm(graph, false), do: graph
+
+  defp confirm(graph, true) do
+    text(graph, "Power off? Y switches off. Any other button keeps it on.",
+      font_size: 16,
+      fill: {:color, @wait},
+      translate: {20, @height - 16}
+    )
   end
 
   defp base do

--- a/lib/mayonnaios/sleep.ex
+++ b/lib/mayonnaios/sleep.ex
@@ -90,8 +90,9 @@ defmodule MayonnaiOS.Sleep do
   A short press is this module's. A long one is not, and cannot be made to be:
   the PMIC's own `shutdown` attribute reads `4000`, so holding the button for
   four seconds makes the AXP cut the rail in hardware, without asking Linux
-  and without anything being flushed. That is why `MayonnaiOS.Launcher` keeps
-  Select+Menu -- it is still the only *orderly* way to switch this device off.
+  and without anything being flushed. That is why the orderly ways off --
+  `MayonnaiOS.Launcher`'s Select+Menu chord and the menu's Power off row --
+  exist and stay off this button.
 
   ## The chord that used to be here
 

--- a/test/bluetooth/advertising_test.exs
+++ b/test/bluetooth/advertising_test.exs
@@ -54,8 +54,8 @@ defmodule MayonnaiOS.Bluetooth.AdvertisingTest do
     test "carries the whole name when it fits" do
       types = Advertising.types()
 
-      assert [{type, "MayonnaiOS Controller"}] =
-               Advertising.decode(Advertising.scan_response("MayonnaiOS Controller"))
+      assert [{type, "Xbox Wireless Controller"}] =
+               Advertising.decode(Advertising.scan_response("Xbox Wireless Controller"))
 
       assert type == types.complete_name
     end

--- a/test/bluetooth/credits_test.exs
+++ b/test/bluetooth/credits_test.exs
@@ -1,0 +1,123 @@
+defmodule MayonnaiOS.Bluetooth.CreditsTest do
+  use ExUnit.Case, async: true
+
+  alias MayonnaiOS.Bluetooth.Credits
+
+  # The scenario this module exists for is written out as its own test at the
+  # bottom: the report map read that a Steam Deck timed out on, ten fragments
+  # against eight buffers, which the old all-or-nothing send silently threw
+  # away. Everything above it is the arithmetic that makes that case work
+  # without breaking the property the old send was right about -- reports
+  # drop rather than queue.
+
+  defp packets(range), do: Enum.map(range, &<<&1>>)
+
+  describe "offer/2, the droppable send" do
+    test "spends credits when the whole PDU fits" do
+      {:ok, to_send, account} = Credits.offer(Credits.new(8), packets(1..3))
+
+      assert to_send == packets(1..3)
+      assert account.credits == 5
+    end
+
+    test "refuses the whole PDU when it does not, spending nothing" do
+      account = Credits.new(8)
+
+      assert {:error, :no_credits} = Credits.offer(account, packets(1..9))
+      assert account.credits == 8
+    end
+
+    test "refuses while anything is queued, even with credits in hand" do
+      # A fragment slipped between a queued PDU's fragments corrupts the
+      # far side's reassembly, so the rule is the queue or nothing.
+      {_sent, account} = Credits.push(Credits.new(2), packets(1..3))
+
+      assert {:error, :no_credits} = Credits.offer(account, packets([9]))
+    end
+  end
+
+  describe "push/2, the queued send" do
+    test "sends everything immediately when it fits" do
+      {sent, account} = Credits.push(Credits.new(8), packets(1..3))
+
+      assert sent == packets(1..3)
+      assert Credits.queued(account) == 0
+    end
+
+    test "sends what fits and queues the rest, in order" do
+      {sent, account} = Credits.push(Credits.new(2), packets(1..5))
+
+      assert sent == packets(1..2)
+      assert Credits.queued(account) == 3
+      assert account.credits == 0
+    end
+
+    test "a second PDU waits behind the first" do
+      {_sent, account} = Credits.push(Credits.new(2), packets(1..4))
+      {sent, account} = Credits.push(account, packets(5..6))
+
+      assert sent == []
+
+      # An allowance of two means at most two packets are ever in flight,
+      # so completions come back at most two at a time.
+      {first, account} = Credits.completed(account, 2)
+      {second, _account} = Credits.completed(account, 2)
+      assert first ++ second == packets(3..6)
+    end
+  end
+
+  describe "completed/2" do
+    test "returns credits and lets the queue through, oldest first" do
+      {_sent, account} = Credits.push(Credits.new(2), packets(1..5))
+
+      {sent, account} = Credits.completed(account, 1)
+      assert sent == packets([3])
+
+      {sent, account} = Credits.completed(account, 2)
+      assert sent == packets(4..5)
+      assert account.credits == 0
+    end
+
+    test "credits above the allowance are not minted" do
+      {sent, account} = Credits.completed(Credits.new(4), 100)
+
+      assert sent == []
+      assert account.credits == 4
+    end
+  end
+
+  describe "disconnected/1" do
+    test "restores the allowance and empties the queue" do
+      {_sent, account} = Credits.push(Credits.new(3), packets(1..8))
+
+      account = Credits.disconnected(account)
+
+      assert account.credits == 3
+      assert Credits.queued(account) == 0
+
+      # Nothing left over from the dead link comes out later.
+      {sent, _account} = Credits.completed(account, 3)
+      assert sent == []
+    end
+  end
+
+  test "the report map read that started this: ten fragments, eight buffers" do
+    # A 246-byte ATT read response at MTU 247 is ten 27-byte fragments, and
+    # the Realtek on this board holds eight. The host acknowledges packets a
+    # few at a time; every returned buffer must carry the next fragment, and
+    # the far side must see all ten, in order, exactly once.
+    fragments = packets(1..10)
+
+    {sent, account} = Credits.push(Credits.new(8), fragments)
+    assert sent == packets(1..8)
+
+    {sent_a, account} = Credits.completed(account, 1)
+    {sent_b, account} = Credits.completed(account, 3)
+
+    assert sent_a ++ sent_b == packets(9..10)
+    assert Credits.queued(account) == 0
+
+    # And the drop-only path is open again for the next report.
+    assert {:ok, _report, _account} = Credits.offer(account, packets([99]))
+  end
+end

--- a/test/bluetooth/gatt_test.exs
+++ b/test/bluetooth/gatt_test.exs
@@ -11,7 +11,7 @@ defmodule MayonnaiOS.Bluetooth.GATTTest do
   # still be undiscoverable if a group-end handle is one short.
 
   setup do
-    %{db: HOGP.build("MayonnaiOS Controller")}
+    %{db: HOGP.build("Xbox Wireless Controller")}
   end
 
   defp ask(db, pdu), do: GATT.request(db, ATT.decode(pdu))
@@ -82,8 +82,10 @@ defmodule MayonnaiOS.Bluetooth.GATTTest do
 
       uuids = Enum.map(characteristics, fn {_handle, _props, _value, uuid} -> uuid end)
 
-      # HID Information, Report Map, Control Point, Protocol Mode, Report.
-      assert uuids == [0x2A4A, 0x2A4B, 0x2A4C, 0x2A4E, 0x2A4D]
+      # HID Information, Report Map, Control Point, Protocol Mode, then two
+      # Reports: the input report and the rumble output report, told apart by
+      # their Report Reference descriptors rather than by UUID.
+      assert uuids == [0x2A4A, 0x2A4B, 0x2A4C, 0x2A4E, 0x2A4D, 0x2A4D]
     end
 
     test "the report characteristic can notify and its value handle is the next one", %{db: db} do
@@ -125,7 +127,9 @@ defmodule MayonnaiOS.Bluetooth.GATTTest do
     end
 
     test "and readable once it is", %{db: db} do
-      db = %{db | encrypted: true, mtu: 247}
+      # The MTU has to clear the 283-byte descriptor plus the opcode, or the
+      # read comes back truncated at MTU - 1 and the rest is Read Blob's job.
+      db = %{db | encrypted: true, mtu: 517}
       handle = GATT.find_handle(db, 0x2A4B)
 
       {response, _db, _events} = ask(db, <<0x0A, handle::16-little>>)

--- a/test/bluetooth/peripheral_test.exs
+++ b/test/bluetooth/peripheral_test.exs
@@ -175,7 +175,10 @@ defmodule MayonnaiOS.Bluetooth.PeripheralTest do
       att(<<0x0A, handle::16-little>>)
 
       assert <<0x0B, value::binary>> = expect_pdu(0x0004)
-      assert value == Report.descriptor()
+      # A 247-byte MTU truncates the 283-byte descriptor at MTU - 1; the rest
+      # is Read Blob's job and the blob test above proves it. What this test
+      # is about is the 246 bytes crossing several 27-byte ACL packets whole.
+      assert value == binary_part(Report.descriptor(), 0, 246)
       assert byte_size(value) > 27
     end
 

--- a/test/controller/app_test.exs
+++ b/test/controller/app_test.exs
@@ -169,7 +169,7 @@ defmodule MayonnaiOS.Controller.AppTest do
     test "a press produces one report" do
       Pad.input([{:ev_key, :btn_b, 1}])
 
-      assert_receive {:report, <<_, 0x01, 0x00>>}
+      assert_receive {:report, <<_::binary-size(13), 0x01, 0x00, 0x00>>}
     end
 
     test "and a release produces another" do
@@ -177,7 +177,7 @@ defmodule MayonnaiOS.Controller.AppTest do
       assert_receive {:report, _}
 
       Pad.input([{:ev_key, :btn_b, 0}])
-      assert_receive {:report, <<_, 0x00, 0x00>>}
+      assert_receive {:report, <<_::binary-size(13), 0x00, 0x00, 0x00>>}
     end
 
     test "an event that changes nothing sends nothing" do
@@ -203,7 +203,17 @@ defmodule MayonnaiOS.Controller.AppTest do
         {:ev_key, :btn_b, 1}
       ])
 
-      assert_receive {:report, <<3, 0x01, 0x00>>}
+      assert_receive {:report, <<_::binary-size(12), 4, 0x01, 0x00, 0x00>>}
+      refute_receive {:report, _}, 50
+    end
+
+    test "the stick is a report too, and its noise is not" do
+      Pad.input([{:ev_abs, :abs_x, 4096}])
+      assert_receive {:report, <<0xFF, 0xFF, _::binary>>}
+
+      # A wobble inside one quantisation step encodes to the same bytes, and
+      # the same bytes are not sent twice.
+      Pad.input([{:ev_abs, :abs_x, 4090}])
       refute_receive {:report, _}, 50
     end
 

--- a/test/controller/report_test.exs
+++ b/test/controller/report_test.exs
@@ -4,25 +4,40 @@ defmodule MayonnaiOS.Controller.ReportTest do
   alias MayonnaiOS.Controller.Report
 
   # The report descriptor and the bytes packed against it are the one part of
-  # this stack that fails silently: a host parses a wrong descriptor without
-  # complaining and then believes the wrong thing forever. So the checks here
-  # are against the layout as written down in the moduledoc -- byte positions
-  # and bit positions -- rather than against whatever the code happens to do.
+  # this stack that fails silently -- and now that the descriptor claims to be
+  # an Xbox Wireless Controller's, the hosts that matter do not even read it:
+  # their drivers parse reports against the layout they know that pad to have.
+  # So the checks here are against the reference capture and the 1914's layout
+  # as written down in the moduledoc, byte positions and bit positions, rather
+  # than against whatever the code happens to do.
+
+  # `XboxOneS_1914_HIDDescriptor` from ESP32-BLE-CompositeHID, captured from a
+  # real pad on the BLE firmware. If `descriptor/0` is ever edited, this pin
+  # must be re-derived from a fresh capture of the real controller -- never
+  # from the code under test.
+  @reference Base.decode16!(
+               "05010905A10185010901A10009300931150027FFFF0000950275108102C0" <>
+                 "0901A10009320935150027FFFF0000950275108102C0" <>
+                 "050209C5150026FF039501750A810215002500750695018103" <>
+                 "050209C4150026FF039501750A810215002500750695018103" <>
+                 "05010939150125083500463B0166140075049501814275049501" <>
+                 "15002500350045006500810305091901290F150025017501950F8102" <>
+                 "15002500750195018103050C0AB20015002501950175018102" <>
+                 "15002500750795018103050F09218503A10209971500250175049501" <>
+                 "91021500250075049501910309701500256475089504910209506601" <>
+                 "10550E150026FF0075089501910209A7150026FF0075089501910265" <>
+                 "005500097C150026FF00750895019102C0C0"
+             )
 
   describe "descriptor/0" do
+    test "is the Xbox Wireless Controller 1914's descriptor, byte for byte" do
+      assert Report.descriptor() == @reference
+      assert byte_size(Report.descriptor()) == 283
+    end
+
     test "declares a gamepad, which is what makes a host treat it as one" do
       # Usage Page (Generic Desktop), Usage (Game Pad), Collection (Application).
       assert <<0x05, 0x01, 0x09, 0x05, 0xA1, 0x01, _rest::binary>> = Report.descriptor()
-    end
-
-    test "does not declare any axes, which is what stopped the cursor moving" do
-      # Usage (X) and Usage (Y) on the Generic Desktop page. Their presence is
-      # what let Steam take the D-pad for a stick and drive the mouse with it
-      # while the game was reading the hat; see the moduledoc.
-      refute contains?(Report.descriptor(), <<0x09, 0x30>>)
-      refute contains?(Report.descriptor(), <<0x09, 0x31>>)
-      # And no Pointer collection to put them in.
-      refute contains?(Report.descriptor(), <<0x09, 0x01, 0xA1, 0x00>>)
     end
 
     test "opens and closes the same number of collections" do
@@ -35,39 +50,24 @@ defmodule MayonnaiOS.Controller.ReportTest do
       closes = Enum.count(chunks(bytes), &match?({0xC0, _}, &1))
 
       assert opens == closes
-      # One: the Game Pad application collection. The physical collection that
-      # used to wrap the axes went with them.
-      assert opens == 1
+      # Four: the Game Pad application collection, a physical collection per
+      # stick, and the rumble report's logical collection.
+      assert opens == 4
     end
 
-    test "declares no report ID at all" do
+    test "declares report IDs 1 and 3, which the report references must match" do
       # Walked as items rather than searched for as bytes: 0x85 is a perfectly
-      # ordinary data byte and a byte search would find one in the physical
-      # maximum. With one report an ID buys nothing and splits hosts into two
-      # camps about whether the first byte is the ID or the hat.
-      tags = Report.descriptor() |> :binary.bin_to_list() |> chunks() |> Enum.map(&elem(&1, 0))
+      # ordinary data byte elsewhere. `MayonnaiOS.Bluetooth.HOGP` puts these
+      # two numbers in the Report Reference descriptors, and a host matches
+      # reports to the map through that pair -- a drifted ID is a dead pad.
+      ids =
+        Report.descriptor()
+        |> :binary.bin_to_list()
+        |> chunks()
+        |> Enum.filter(&match?({0x85, _}, &1))
+        |> Enum.map(fn {0x85, [id]} -> id end)
 
-      refute 0x85 in tags
-    end
-
-    test "declares exactly the ten buttons the shell has" do
-      # Usage Minimum (Button 1), Usage Maximum (Button 10).
-      assert contains?(Report.descriptor(), <<0x19, 0x01, 0x29, 0x0A>>)
-      # Report Count (10) for the button field, then six bits of padding.
-      assert contains?(Report.descriptor(), <<0x95, 0x0A, 0x81, 0x02>>)
-      assert contains?(Report.descriptor(), <<0x95, 0x06, 0x81, 0x03>>)
-    end
-
-    test "the hat has a null state, so centred is expressible" do
-      # Input (Data, Variable, Absolute, Null State) -- bit 6 set.
-      assert contains?(Report.descriptor(), <<0x81, 0x42>>)
-    end
-
-    test "the degrees unit is turned off again after the hat" do
-      # Unit items are sticky: left set, they apply to the button field too,
-      # and a host that respects units then reports buttons in degrees.
-      assert contains?(Report.descriptor(), <<0x65, 0x14>>)
-      assert contains?(Report.descriptor(), <<0x65, 0x00>>)
+      assert ids == [1, 3]
     end
 
     # Walk the item stream properly rather than searching for bytes: 0xC0 is
@@ -81,27 +81,56 @@ defmodule MayonnaiOS.Controller.ReportTest do
       {data, rest} = Enum.split(rest, size)
       chunks(rest, [{item, data} | acc])
     end
-
-    defp contains?(haystack, needle), do: :binary.match(haystack, needle) != :nomatch
   end
 
   describe "encode/1" do
-    test "nothing pressed is a null hat and no buttons" do
-      assert Report.encode(Report.released()) == <<15, 0, 0>>
+    test "nothing pressed is sixteen bytes: sticks centred, everything else zero" do
+      assert Report.encode(Report.released()) ==
+               <<0, 0x80, 0, 0x80, 0, 0x80, 0, 0x80, 0, 0, 0, 0, 0, 0, 0, 0>>
     end
 
-    test "is three bytes whatever is held" do
-      assert byte_size(Report.encode(all_pressed())) == 3
+    test "is sixteen bytes whatever is held" do
+      assert byte_size(Report.encode(all_pressed())) == 16
+      assert Report.size() == 16
     end
 
-    test "button 1 is the low bit of byte 1, and it is the A button" do
+    test "the button silkscreened A is the Xbox A, in the low bit of byte 13" do
       # :btn_b is the button silkscreened A on this board.
-      assert <<_, 0x01, 0x00>> = press(:btn_b)
+      assert buttons(press(:btn_b)) == {0x01, 0x00}
     end
 
-    test "button 9 is the low bit of byte 2, and button 10 the one above it" do
-      assert <<_, 0x00, 0x01>> = press(:btn_select)
-      assert <<_, 0x00, 0x02>> = press(:btn_start)
+    test "B, X and Y land on the Xbox bits, skipping the ones this shell lacks" do
+      # Bits 2, 5, 8 and 9 belong to controls the 1914 reserves for other
+      # devices in the family; the driver expects them unused.
+      assert buttons(press(:btn_a)) == {0x02, 0x00}
+      assert buttons(press(:btn_y)) == {0x08, 0x00}
+      assert buttons(press(:btn_x)) == {0x10, 0x00}
+    end
+
+    test "the shoulders are LB and RB" do
+      assert buttons(press(:btn_tl)) == {0x40, 0x00}
+      assert buttons(press(:btn_tr)) == {0x80, 0x00}
+    end
+
+    test "Select and Start are the View and Menu buttons, in byte 14" do
+      assert buttons(press(:btn_select)) == {0x00, 0x04}
+      assert buttons(press(:btn_start)) == {0x00, 0x08}
+    end
+
+    test "L2 pulls the brake fully, because a switch has no half way" do
+      assert <<_::binary-size(8), 0xFF, 0x03, 0, 0, _::binary>> = press(:btn_tl2)
+
+      released =
+        Report.apply_events(Report.released(), [
+          {:ev_key, :btn_tl2, 1},
+          {:ev_key, :btn_tl2, 0}
+        ])
+
+      assert <<_::binary-size(8), 0, 0, 0, 0, _::binary>> = Report.encode(released)
+    end
+
+    test "R2 is the accelerator" do
+      assert <<_::binary-size(10), 0xFF, 0x03, _::binary>> = press(:btn_tr2)
     end
 
     test "buttons accumulate rather than replace" do
@@ -111,8 +140,7 @@ defmodule MayonnaiOS.Controller.ReportTest do
           {:ev_key, :btn_a, 1}
         ])
 
-      # Buttons 1 and 2.
-      assert <<_, 0x03, 0x00>> = Report.encode(state)
+      assert buttons(Report.encode(state)) == {0x03, 0x00}
     end
 
     test "a release clears just that button" do
@@ -123,19 +151,19 @@ defmodule MayonnaiOS.Controller.ReportTest do
           {:ev_key, :btn_b, 0}
         ])
 
-      assert <<_, 0x02, 0x00>> = Report.encode(state)
+      assert buttons(Report.encode(state)) == {0x02, 0x00}
     end
 
     test "an auto-repeat is a press, not a release" do
       state = Report.apply_events(Report.released(), [{:ev_key, :btn_b, 2}])
-      assert <<_, 0x01, 0x00>> = Report.encode(state)
+      assert buttons(Report.encode(state)) == {0x01, 0x00}
     end
 
-    test "the D-pad is the hat, clockwise from north" do
-      assert <<0, 0, 0>> = press(:btn_dpad_up)
-      assert <<4, 0, 0>> = press(:btn_dpad_down)
-      assert <<6, 0, 0>> = press(:btn_dpad_left)
-      assert <<2, 0, 0>> = press(:btn_dpad_right)
+    test "the D-pad is the hat in byte 12, 1 at north and clockwise from there" do
+      assert hat(press(:btn_dpad_up)) == 1
+      assert hat(press(:btn_dpad_right)) == 3
+      assert hat(press(:btn_dpad_down)) == 5
+      assert hat(press(:btn_dpad_left)) == 7
     end
 
     test "a diagonal is one hat value" do
@@ -145,7 +173,7 @@ defmodule MayonnaiOS.Controller.ReportTest do
           {:ev_key, :btn_dpad_right, 1}
         ])
 
-      assert <<3, 0, 0>> = Report.encode(state)
+      assert hat(Report.encode(state)) == 4
     end
 
     test "opposite directions cancel instead of failing to decode" do
@@ -156,7 +184,35 @@ defmodule MayonnaiOS.Controller.ReportTest do
           {:ev_key, :btn_dpad_down, 1}
         ])
 
-      assert Report.encode(state) == <<15, 0, 0>>
+      assert hat(Report.encode(state)) == 0
+    end
+
+    test "the stick scales the ADC's 0..4096 up to the report's range" do
+      assert <<0, 0, 0, 0x80, _::binary>> = stick(0, 2048)
+      assert <<0, 0x80, 0, 0, _::binary>> = stick(2048, 0)
+      assert <<0xFF, 0xFF, 0, 0x80, _::binary>> = stick(4096, 2048)
+    end
+
+    test "stick values are quantised, so ADC noise is not a report" do
+      # The stick rests near 2050 and the low bits wander. 256 steps swallow
+      # that; `MayonnaiOS.Controller.Pad` then sees identical bytes and sends
+      # nothing.
+      assert stick(2048, 2048) == stick(2055, 2052)
+    end
+
+    test "values outside the promised range are clamped, not wrapped" do
+      assert stick(-3, 2048) == stick(0, 2048)
+      assert stick(5000, 2048) == stick(4096, 2048)
+    end
+
+    test "the right stick never moves" do
+      for report <- [Report.encode(all_pressed()), stick(0, 4096), press(:btn_b)] do
+        assert <<_::binary-size(4), 0, 0x80, 0, 0x80, _::binary>> = report
+      end
+    end
+
+    test "the Share byte is a constant zero" do
+      assert <<_::binary-size(15), 0>> = Report.encode(all_pressed())
     end
   end
 
@@ -174,25 +230,49 @@ defmodule MayonnaiOS.Controller.ReportTest do
     test "ignores the volume keys, which belong to Diagnostics" do
       assert press(:key_volumeup) == Report.encode(Report.released())
     end
+
+    test "ignores axes the stick does not have" do
+      state = Report.apply_events(Report.released(), [{:ev_abs, :abs_z, 4096}])
+      assert Report.encode(state) == Report.encode(Report.released())
+    end
   end
 
   describe "known?/1" do
-    test "is true for everything in either table" do
-      for key <- Map.keys(Report.button_map()) ++ Map.keys(Report.direction_map()) do
+    test "is true for everything in any table" do
+      keys =
+        Map.keys(Report.button_map()) ++
+          Map.keys(Report.trigger_map()) ++ Map.keys(Report.direction_map())
+
+      for key <- keys do
         assert Report.known?(key), "#{key} is mapped but not reported as known"
       end
     end
   end
 
-  test "every button number is used exactly once" do
-    numbers = Report.button_map() |> Map.values() |> Enum.sort()
-    assert numbers == Enum.to_list(1..10)
+  test "every button mask is used once and belongs to the 1914" do
+    masks = Report.button_map() |> Map.values() |> Enum.sort()
+
+    # A, B, X, Y, LB, RB, View, Menu -- the eight of the fifteen bits this
+    # shell can press. Anything else here is a button the driver will hand to
+    # games as something this device never meant.
+    assert masks == [0x0001, 0x0002, 0x0008, 0x0010, 0x0040, 0x0080, 0x0400, 0x0800]
   end
 
   defp press(key), do: Report.encode(Report.apply_events(Report.released(), [{:ev_key, key, 1}]))
 
+  defp stick(x, y) do
+    Report.encode(
+      Report.apply_events(Report.released(), [{:ev_abs, :abs_x, x}, {:ev_abs, :abs_y, y}])
+    )
+  end
+
+  defp hat(report), do: :binary.at(report, 12)
+
+  defp buttons(report), do: {:binary.at(report, 13), :binary.at(report, 14)}
+
   defp all_pressed do
-    events = for key <- Map.keys(Report.button_map()), do: {:ev_key, key, 1}
+    keys = Map.keys(Report.button_map()) ++ Map.keys(Report.trigger_map())
+    events = for key <- keys, do: {:ev_key, key, 1}
     Report.apply_events(Report.released(), events)
   end
 end

--- a/test/controller/report_test.exs
+++ b/test/controller/report_test.exs
@@ -189,8 +189,15 @@ defmodule MayonnaiOS.Controller.ReportTest do
 
     test "the stick scales the ADC's 0..4096 up to the report's range" do
       assert <<0, 0, 0, 0x80, _::binary>> = stick(0, 2048)
-      assert <<0, 0x80, 0, 0, _::binary>> = stick(2048, 0)
       assert <<0xFF, 0xFF, 0, 0x80, _::binary>> = stick(4096, 2048)
+    end
+
+    test "the Y axis is flipped, because the ADC's up is HID's down" do
+      # Read off the hardware: pushing this stick up raises the raw value,
+      # and a HID Y of 0 is up. Shipping it straight through walked
+      # characters upside down on a Steam Deck.
+      assert <<_, _, 0xFF, 0xFF, _::binary>> = stick(2048, 0)
+      assert <<_, _, 0, 0, _::binary>> = stick(2048, 4096)
     end
 
     test "stick values are quantised, so ADC noise is not a report" do

--- a/test/controller/report_test.exs
+++ b/test/controller/report_test.exs
@@ -117,6 +117,54 @@ defmodule MayonnaiOS.Controller.ReportTest do
       assert buttons(press(:btn_start)) == {0x00, 0x08}
     end
 
+    test "Select and Start together are the Xbox button, and nothing else" do
+      state =
+        Report.apply_events(Report.released(), [
+          {:ev_key, :btn_select, 1},
+          {:ev_key, :btn_start, 1}
+        ])
+
+      assert buttons(Report.encode(state)) == {0x00, 0x10}
+    end
+
+    test "the chord suppresses the survivor of a staggered release" do
+      # Letting go of the chord one finger at a time must not press Menu on
+      # the way out; the moduledoc has the account.
+      state =
+        Report.apply_events(Report.released(), [
+          {:ev_key, :btn_select, 1},
+          {:ev_key, :btn_start, 1},
+          {:ev_key, :btn_select, 0}
+        ])
+
+      assert buttons(Report.encode(state)) == {0x00, 0x00}
+    end
+
+    test "once both halves are up, the single buttons are themselves again" do
+      state =
+        Report.apply_events(Report.released(), [
+          {:ev_key, :btn_select, 1},
+          {:ev_key, :btn_start, 1},
+          {:ev_key, :btn_select, 0},
+          {:ev_key, :btn_start, 0},
+          {:ev_key, :btn_start, 1}
+        ])
+
+      assert buttons(Report.encode(state)) == {0x00, 0x08}
+    end
+
+    test "the chord does not swallow bystanders" do
+      state =
+        Report.apply_events(Report.released(), [
+          {:ev_key, :btn_b, 1},
+          {:ev_key, :btn_select, 1},
+          {:ev_key, :btn_start, 1}
+        ])
+
+      # The A button rides along untouched; only View and Menu are rewritten.
+      assert buttons(Report.encode(state)) == {0x01, 0x10}
+    end
+
     test "L2 pulls the brake fully, because a switch has no half way" do
       assert <<_::binary-size(8), 0xFF, 0x03, 0, 0, _::binary>> = press(:btn_tl2)
 

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -109,6 +109,25 @@ defmodule MayonnaiOS.LauncherTest do
       assert "not installed" in texts(graph)
     end
 
+    test "an action entry is an ordinary, always-installed row" do
+      assert [entry] = Programs.list([%{name: "Power off", action: :poweroff}])
+      assert entry.installed?
+      assert entry.action == :poweroff
+
+      assert "Power off" in texts(Home.graph([entry], 0))
+      refute "not installed" in texts(Home.graph([entry], 0))
+    end
+
+    test "the power-off question is on the panel only while it is being asked" do
+      programs = Programs.list([%{name: "Power off", action: :poweroff}])
+
+      asked = texts(Home.graph(programs, 0, true))
+      assert Enum.any?(asked, &(&1 =~ "Power off? Y switches off"))
+
+      idle = texts(Home.graph(programs, 0))
+      refute Enum.any?(idle, &(&1 =~ "Y switches off"))
+    end
+
     # Every text primitive's string, so a test can assert what the panel says
     # rather than only that a graph exists.
     defp texts(graph) do
@@ -178,6 +197,66 @@ defmodule MayonnaiOS.LauncherTest do
     defp press(key) do
       send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 1}]})
       # selected/0 is a call, so it is ordered behind the cast above.
+      Launcher.selected()
+    end
+  end
+
+  describe "the Power off row" do
+    setup do
+      # A real program above it, so the tests can also show that cancelling
+      # does not leak the cancelling press into a launch.
+      programs = [%{path: "/a"}, %{name: "Power off", action: :poweroff}]
+      Application.put_env(:mayonnaios, :programs, programs)
+      on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
+
+      test = self()
+
+      start_supervised!(
+        {Launcher, device: "/nonexistent/event0", poweroff: fn -> send(test, :powered_off) end}
+      )
+
+      # Onto the Power off row.
+      tap(:btn_dpad_down)
+      :ok
+    end
+
+    test "A only asks; Y answers" do
+      tap(:btn_b)
+      refute_received :powered_off
+
+      tap(:btn_x)
+      assert_receive :powered_off
+    end
+
+    test "any other button keeps the device on, and Y afterwards is nothing" do
+      tap(:btn_b)
+      tap(:btn_a)
+
+      # The question is gone, so the button that would have answered it is
+      # back to being unbound.
+      tap(:btn_x)
+      refute_received :powered_off
+    end
+
+    test "the cancelling press is swallowed, not dispatched" do
+      tap(:btn_b)
+      # A again would launch whatever the cursor is on if it were dispatched;
+      # here it may only cancel. Y proving the question is gone also proves
+      # no second question was opened.
+      tap(:btn_b)
+      tap(:btn_x)
+      refute_received :powered_off
+    end
+
+    test "Y with no question pending is unbound" do
+      tap(:btn_x)
+      refute_received :powered_off
+    end
+
+    defp tap(key) do
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 1}]})
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 0}]})
+      # A call, so both casts above have been handled before the test asserts.
       Launcher.selected()
     end
   end

--- a/test/status_bar_test.exs
+++ b/test/status_bar_test.exs
@@ -406,7 +406,7 @@ defmodule MayonnaiOS.StatusBarTest do
 
   defp controller_status do
     %{
-      name: "MayonnaiOS Controller",
+      name: "Xbox Wireless Controller",
       address: "00:11:22:33:44:55",
       advertising: true,
       connected: true,

--- a/test/support/fake_controller.exs
+++ b/test/support/fake_controller.exs
@@ -69,6 +69,14 @@ defmodule MayonnaiOS.Bluetooth.FakeController do
     {:reply, :ok, state}
   end
 
+  # The queued send. The fake has infinite buffers, so "queued" and "sent"
+  # are the same thing here; what the credit arithmetic does when they are
+  # not is `MayonnaiOS.Bluetooth.CreditsTest`'s job, against the pure module.
+  def handle_call({:acl_queued, packets}, _from, state) do
+    send(state.test, {:acl, packets})
+    {:reply, :ok, state}
+  end
+
   def handle_call({:buffers, _length, _count}, _from, state), do: {:reply, :ok, state}
   def handle_call(:packet_length, _from, state), do: {:reply, 27, state}
   def handle_call(:commands, _from, state), do: {:reply, state.commands, state}


### PR DESCRIPTION
## Summary

Controller mode was documented as not practically workable for Steam games: an honestly-identified BLE pad is a joystick to SDL, and on macOS Steam Input has nothing to bridge that with. This reverses the documented no-impersonation stance instead of working around it — the device now presents as an Xbox Wireless Controller (0x045E/0x0B13, BLE firmware) with that pad's 283-byte descriptor reproduced byte for byte, and the analog stick is wired in as the left stick. The commit message and the rewritten README/moduledocs carry the full account of the reversal.

## Approach

Impersonation was rejected before because a host's driver parses reports against the claimed pad's fixed layout. That argument is against claiming the numbers while shipping your own layout; shipping the layout too turns the driver's fixed belief into a correct one. The descriptor is transcribed from ESP32-BLE-CompositeHID's capture of a real 1914 pad and a test pins all 283 bytes against that reference, so drift is a failing test rather than scrambled buttons. Missing hardware (right stick, rumble, Share) is declared as the real pad declares it and reported permanently at rest.

## Follow-ups for reviewer

- Face buttons map label-to-label (silkscreen A → Xbox A) rather than position-to-position — is that the right default for glyph prompts on this shell?
- The DIS manufacturer string is now "Microsoft" for identity consistency; comfortable with that, or keep it honest and accept the seam?
- Stick orientation is unverified on hardware (noted in the roadmap) — worth blocking merge on a hands-on check, or fix forward if inverted?
- Every existing bond must re-pair after this flashes; is a launcher-visible note needed beyond the README warning?

🤖 Generated with [Claude Code](https://claude.com/claude-code)