### PR TITLE
Take bundle 1.22.2-7, whose autoconfig knows about the stick click

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -308,10 +308,10 @@ config :mayonnaios, pickles_root: "/root/pickles"
 config :mayonnaios, :bundles, %{
   retroarch: %{
     name: "retroarch",
-    version: "1.22.2-6",
+    version: "1.22.2-7",
     url:
-      "https://github.com/kek/retroarch-rg40xxv/releases/download/v1.22.2-6/retroarch-1.22.2-aarch64.tar.gz",
-    sha256: "2f2542dc0f812a5e922aad738d32ea0d53f831ba2dde7083786e96d1fce189b4"
+      "https://github.com/kek/retroarch-rg40xxv/releases/download/v1.22.2-7/retroarch-1.22.2-aarch64.tar.gz",
+    sha256: "fcfeafdf307afac56666a3c9f5004880bee3b9326401a720fe269338ce80824c"
   }
 }
 


### PR DESCRIPTION
## Summary
The D-pad came out rotated in RetroArch after firmware `4fcc0ec` added the analog stick's click to `gpio-keys-gamepad` as `BTN_THUMBL` (317): udev_joypad.c numbers buttons by walking keycodes in ascending order, and 317 sorts between `BTN_MODE` (316) and the D-pad block (544..547), so every D-pad index shifted up by one while the face buttons kept theirs. Up acted as down, and down as left — which RGUI renders as a jump to the top.

Bundle [v1.22.2-7](https://github.com/kek/retroarch-rg40xxv/releases/tag/v1.22.2-7) (kek/retroarch-rg40xxv@ed31f3c) rebinds the D-pad at indices 12–15 and puts the click on L3. This PR points the bundle pin at it; the sha256 matches both the published `.sha256` and a local hash of the downloaded tarball, and the tarball was checked to actually contain the new binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)