### PR TITLE
Offer Moonlight on the menu, and teach Bundle to install it

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,34 @@ autosave between its truncate and its write, which is the one way this could
 destroy the file it exists to protect. A cable pulled mid-game is covered by
 the interval and by f2fs writeback, and by nothing else.
 
+## Game streaming (Moonlight)
+
+Moonlight Embedded streams a Sunshine or GeForce host to the handheld —
+decoded in software on the A53s and drawn through SDL on the same KMS stack
+RetroArch uses. It installs the same way RetroArch does, as a bundle:
+
+    iex> MayonnaiOS.Bundle.install(MayonnaiOS.Bundle.spec(:moonlight))
+
+The menu row exists before the bundle does; until the install it renders as
+not installed.
+
+First run is a one-time SSH session, because two things exist only on the
+player's side of the fence. Pairing prints a PIN that must be typed into the
+host, and the stream cannot start without the host's address — which no
+bundle can know, so the launcher passes a config file the player creates:
+
+    /root/bundles/moonlight/current/bin/moonlight pair <host>
+    mkdir -p /root/.config/moonlight
+    cp /root/bundles/moonlight/current/share/moonlight/moonlight.conf \
+       /root/.config/moonlight/moonlight.conf
+    echo 'address = <host>' >> /root/.config/moonlight/moonlight.conf
+
+The template carries the hardware-dictated defaults — 720p30, h264, modest
+bitrate — and says what to lower first if decode cannot keep up. None of this
+has been run on the handheld yet; the
+[`mayonnaios_apps`](https://github.com/kek/mayonnaios_apps) README lists what
+only hardware can answer, the gamepad mapping under SDL first among them.
+
 ## Using it as a Bluetooth controller
 
 The handheld can be the gamepad instead of the console. Pick **Bluetooth

--- a/config/target.exs
+++ b/config/target.exs
@@ -224,6 +224,30 @@ config :mayonnaios, :programs, [
     ],
     needs_udev: true
   },
+  # Game streaming from a Sunshine or GeForce host, decoded in software on
+  # the A53s and drawn through SDL on the same KMS stack RetroArch uses.
+  # Until the bundle is installed this is a visible, unlaunchable row --
+  # `MayonnaiOS.Programs` stats the path on every render.
+  #
+  # -config names the player's own file rather than the bundle's, because the
+  # one thing a stream cannot start without is the host's address, and no
+  # bundle can know it. The file does not exist until the player creates it
+  # over SSH -- the same session in which they pair, since pairing prints a
+  # PIN that must be typed into the host:
+  #
+  #     /root/bundles/moonlight/current/bin/moonlight pair <host>
+  #     cp /root/bundles/moonlight/current/share/moonlight/moonlight.conf \
+  #        /root/.config/moonlight/moonlight.conf
+  #     echo 'address = <host>' >> /root/.config/moonlight/moonlight.conf
+  #
+  # The bundle's template carries the hardware-dictated defaults (720p30,
+  # h264, SDL) and comments on what to lower first if decode cannot keep up.
+  %{
+    name: "Moonlight",
+    path: "/root/bundles/moonlight/current/bin/moonlight",
+    args: ["stream", "-config", "/root/.config/moonlight/moonlight.conf"],
+    needs_udev: true
+  },
   %{name: "Spinning cube (kmscube)", path: "/usr/bin/kmscube"},
   %{name: "Spinning cube (smooth)", path: "/usr/bin/kmscube", args: ["-M", "smooth"]},
   # An app rather than a program: a module in this firmware, started in this
@@ -320,6 +344,16 @@ config :mayonnaios, :bundles, %{
     url:
       "https://github.com/kek/mayonnaios_apps/releases/download/v1.22.2-7/retroarch-1.22.2-aarch64.tar.gz",
     sha256: "fcfeafdf307afac56666a3c9f5004880bee3b9326401a720fe269338ce80824c"
+  },
+  # The sha256 is the one CI printed for the tarball it attached to the
+  # moonlight-v2.7.1-1 release -- the release asset, not a local build, since
+  # two builds of the same sources are not byte-identical across machines.
+  moonlight: %{
+    name: "moonlight",
+    version: "2.7.1-1",
+    url:
+      "https://github.com/kek/mayonnaios_apps/releases/download/moonlight-v2.7.1-1/moonlight-2.7.1-aarch64.tar.gz",
+    sha256: "9208fc553210f82cb07828cd13e7d16609ec0734d540a36ceb33e17af44147db"
   }
 }
 


### PR DESCRIPTION
## Summary
Wires the [moonlight-v2.7.1-1 release](https://github.com/kek/mayonnaios_apps/releases/tag/moonlight-v2.7.1-1) into the firmware: a `:bundles` spec with the CI-built tarball's sha256 (verified against an independent download), a launcher entry, and a README section on the one-time SSH setup.

## Approach
The launcher passes the player's config file rather than the bundle's, because the stream cannot start without the host's address and no bundle can know it — the bundle's `moonlight.conf` becomes a template the player copies and appends `address = <host>` to, in the same SSH session where pairing types its PIN into the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)