### PR TITLE
Follow the bundle repository's rename to mayonnaios_bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ file it describes is not evidence of anything.
 RetroArch's own online core updater is compiled out of this build. The libretro
 buildbot's cores are linked against a different glibc and sysroot and will not
 load here; cores for this device are cross-built in
-[`mayonnaios_apps`](https://github.com/kek/mayonnaios_apps) against the same
+[`mayonnaios_bundles`](https://github.com/kek/mayonnaios_bundles) against the same
 sysroot as the rest of the system.
 
 ### Where cores end up
@@ -235,7 +235,7 @@ merges its files in order, last one winning.
 `MayonnaiOS.Cores.write_append_config/0` generates it from `MayonnaiOS.Cores.dir/0`
 at boot, so it always names the directory the symlinks actually go into.
 Fixing the bundle would be tidier and is worth doing in
-[`mayonnaios_apps`](https://github.com/kek/mayonnaios_apps) — but a bundle
+[`mayonnaios_bundles`](https://github.com/kek/mayonnaios_bundles) — but a bundle
 is versioned separately and installed independently, so relying on it to *not*
 set something is the arrangement that already failed once.
 
@@ -297,7 +297,7 @@ bundle can know, so the launcher passes a config file the player creates:
 The template carries the hardware-dictated defaults — 720p30, h264, modest
 bitrate — and says what to lower first if decode cannot keep up. None of this
 has been run on the handheld yet; the
-[`mayonnaios_apps`](https://github.com/kek/mayonnaios_apps) README lists what
+[`mayonnaios_bundles`](https://github.com/kek/mayonnaios_bundles) README lists what
 only hardware can answer, the gamepad mapping under SDL first among them.
 
 ## Using it as a Bluetooth controller
@@ -573,4 +573,4 @@ deciding one at a time whether each is worth having.
 |---|---|
 | [`nerves_system_rg40xxv`](https://github.com/kek/nerves_system_rg40xxv) | The Buildroot BSP: kernel, device tree, U-Boot, fwup layout. |
 | `mayonnaios` | This one: the OTP release and the bundle mechanism. |
-| [`mayonnaios_apps`](https://github.com/kek/mayonnaios_apps) | Cross-builds the native apps — RetroArch and its cores, Moonlight — against the system’s own sysroot; publishes checksummed tarballs. |
+| [`mayonnaios_bundles`](https://github.com/kek/mayonnaios_bundles) | Cross-builds the native apps — RetroArch and its cores, Moonlight — against the system’s own sysroot; publishes checksummed tarballs. |

--- a/config/target.exs
+++ b/config/target.exs
@@ -327,7 +327,7 @@ config :mayonnaios, pickles_root: "/root/pickles"
 #
 #     iex> MayonnaiOS.Bundle.install(MayonnaiOS.Bundle.spec(:retroarch))
 #
-# Built by github.com/kek/mayonnaios_apps against this system's own staging
+# Built by github.com/kek/mayonnaios_bundles against this system's own staging
 # sysroot, so the sonames match what the rootfs ships.
 #
 # `version` must change whenever the tarball does, and it is the *release*
@@ -342,7 +342,7 @@ config :mayonnaios, :bundles, %{
     name: "retroarch",
     version: "1.22.2-7",
     url:
-      "https://github.com/kek/mayonnaios_apps/releases/download/v1.22.2-7/retroarch-1.22.2-aarch64.tar.gz",
+      "https://github.com/kek/mayonnaios_bundles/releases/download/v1.22.2-7/retroarch-1.22.2-aarch64.tar.gz",
     sha256: "fcfeafdf307afac56666a3c9f5004880bee3b9326401a720fe269338ce80824c"
   },
   # The sha256 is the one CI printed for the tarball it attached to the
@@ -352,7 +352,7 @@ config :mayonnaios, :bundles, %{
     name: "moonlight",
     version: "2.7.1-1",
     url:
-      "https://github.com/kek/mayonnaios_apps/releases/download/moonlight-v2.7.1-1/moonlight-2.7.1-aarch64.tar.gz",
+      "https://github.com/kek/mayonnaios_bundles/releases/download/moonlight-v2.7.1-1/moonlight-2.7.1-aarch64.tar.gz",
     sha256: "9208fc553210f82cb07828cd13e7d16609ec0734d540a36ceb33e17af44147db"
   }
 }
@@ -460,7 +460,7 @@ config :mayonnaios, :cores, %{
     systems: ["snes"],
     version: "1.22.2-6",
     url:
-      "https://github.com/kek/mayonnaios_apps/releases/download/v1.22.2-6/snes9x2010-1.22.2-aarch64.tar.gz",
+      "https://github.com/kek/mayonnaios_bundles/releases/download/v1.22.2-6/snes9x2010-1.22.2-aarch64.tar.gz",
     sha256: "9a492c7414330d07929d322bb3b643312eb3bafb7386543484d04b393abb7e85"
   },
   "2048": %{
@@ -469,7 +469,7 @@ config :mayonnaios, :cores, %{
     systems: [],
     version: "1.22.2-6",
     url:
-      "https://github.com/kek/mayonnaios_apps/releases/download/v1.22.2-6/2048-1.22.2-aarch64.tar.gz",
+      "https://github.com/kek/mayonnaios_bundles/releases/download/v1.22.2-6/2048-1.22.2-aarch64.tar.gz",
     sha256: "c6eba3f077baf5fe56766d8213424c38d5ff0787488d4fac455d4ff96ba86518"
   }
 }

--- a/lib/mayonnaios/cores.ex
+++ b/lib/mayonnaios/cores.ex
@@ -67,7 +67,7 @@ defmodule MayonnaiOS.Cores do
   cores to match this device's glibc and sysroot -- which they do not, because
   this system is built from its own Buildroot.
 
-  Cores are therefore built by `mayonnaios_apps` against the same sysroot as
+  Cores are therefore built by `mayonnaios_bundles` against the same sysroot as
   everything else and published as their own small tarballs, and installed
   here by the mechanism already proven for RetroArch itself: fetch, verify the
   SHA-256 *before* unpacking, install to a versioned directory, move a


### PR DESCRIPTION
## Summary
mayonnaios_apps was renamed to [mayonnaios_bundles](https://github.com/kek/mayonnaios_bundles) — the name now matches its output, the bundles `MayonnaiOS.Bundle` installs. GitHub redirects the old names, so the release URLs never broke; this updates the references so nothing depends on the redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)