### PR TITLE
Put a dead program's last words on the panel

### DIFF
--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -238,6 +238,16 @@ defmodule MayonnaiOS.Launcher do
   @up_button :btn_dpad_up
   @down_button :btn_dpad_down
 
+  # Physical B, which is BTN_SOUTH and therefore InputEvent's :btn_a -- the
+  # table at the top of this module is the authority. Bound only to clear the
+  # obituary line, which is also every other screen's "back" gesture, so the
+  # button does what the hand expects.
+  @back_button :btn_a
+
+  # How many of a program's last lines the obituary keeps. Three is what the
+  # panel has room to draw without pushing into the menu rows.
+  @obituary_lines 3
+
   # How long a stop waits for the program to go, per signal. See `do_stop/1`.
   #
   # SIGTERM gets the larger share because a program that honours it has work to
@@ -301,6 +311,16 @@ defmodule MayonnaiOS.Launcher do
   which is the part worth testing.
   """
   def selected, do: GenServer.call(__MODULE__, :selected)
+
+  @doc """
+  Why the last program died, or nil.
+
+  `%{name: name, status: status, lines: lines}` after a program exits nonzero
+  (`status` is the exit status) or refuses to spawn (`status` is nil and
+  `lines` is the spawn error). The home scene draws it; B clears it. Public
+  so a console can read the same thing the panel shows.
+  """
+  def obituary, do: GenServer.call(__MODULE__, :obituary)
 
   @doc """
   Sleep and wake without pressing anything, and ask which it is.
@@ -405,6 +425,16 @@ defmodule MayonnaiOS.Launcher do
       # and never true while anything is running -- the row can only be
       # activated from an idle menu.
       confirming: false,
+      # The last few lines the running program wrote, kept so that if it dies
+      # they can be put on the panel and not only in the ring logger. Reset
+      # on every launch; capped, because a chatty program earns no more rows.
+      output: [],
+      # Why the last program died, or nil. Set when a program exits nonzero
+      # or refuses to spawn, drawn by the home scene, cleared by B or by the
+      # next launch. It exists because a program that exits in its first
+      # hundred milliseconds is indistinguishable from "nothing happened"
+      # from the couch -- Moonlight without its config file taught that.
+      obituary: nil,
       # What actually switches the device off, injectable because the real
       # one cannot be called on a laptop and a confirmation flow nobody can
       # test is a confirmation flow that silently rots.
@@ -454,6 +484,8 @@ defmodule MayonnaiOS.Launcher do
   end
 
   def handle_call(:selected, _from, state), do: {:reply, state.selected, state}
+
+  def handle_call(:obituary, _from, state), do: {:reply, state.obituary, state}
   def handle_call(:asleep?, _from, state), do: {:reply, state.asleep, state}
 
   def handle_call(:sleep, _from, state) do
@@ -546,6 +578,13 @@ defmodule MayonnaiOS.Launcher do
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
     Logger.info("[launcher] #{name_of(state.running)} exited (#{status})")
 
+    # A nonzero exit becomes an obituary before the repaint, so the menu that
+    # comes back says what just happened instead of merely coming back. Zero
+    # is a program that meant to exit -- quitting RetroArch from its own menu
+    # -- and gets no banner. Deliberate stops never reach this clause at all:
+    # `await_exit/3` consumes their exit message itself.
+    state = %{state | obituary: obituary(state, status)}
+
     # Released before the repaint, and in that order: the repaint *is* a write
     # to the framebuffer, and it is only allowed because the program that
     # owned it is gone. This is the moment the display comes back.
@@ -560,7 +599,7 @@ defmodule MayonnaiOS.Launcher do
     # before this clause returns, so the panel comes back first.
     state.flush_saves.()
 
-    {:noreply, %{state | port: nil, running: nil}}
+    {:noreply, %{state | port: nil, running: nil, output: []}}
   end
 
   # Log what the program says, rather than dropping it.
@@ -579,21 +618,37 @@ defmodule MayonnaiOS.Launcher do
   # Trimmed and length-capped because a chatty program should not be able to
   # push everything else out of a fixed-size ring buffer.
   def handle_info({port, {:data, data}}, %{port: port} = state) do
-    log_output(state, data)
-    {:noreply, state}
+    {:noreply, log_output(state, data)}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
 
+  # What the panel will say about a program that died. Status zero is a
+  # program that meant to exit and merits nothing; anything else is paired
+  # with the last lines it wrote, because "exited (1)" without its dying
+  # words is a riddle and with them is usually the whole diagnosis.
+  defp obituary(_state, 0), do: nil
+
+  defp obituary(state, status),
+    do: %{name: name_of(state.running), status: status, lines: state.output}
+
   # Trimmed and length-capped because a chatty program should not be able to
   # push everything else out of a fixed-size ring buffer. Shared with the stop
-  # path, which reads the same pipe while it waits for the program to die.
+  # path, which reads the same pipe while it waits for the program to die --
+  # that caller drops the returned state, which is fine: a deliberate stop
+  # writes no obituary, so its tail of output is never read.
+  #
+  # Returns the state with the last few lines retained, which is what the
+  # obituary quotes if the program then exits nonzero.
   defp log_output(state, data) do
-    data
-    |> String.split("\n", trim: true)
-    |> Enum.each(fn line ->
-      Logger.info("[#{program_name(state)}] #{String.slice(line, 0, 300)}")
-    end)
+    lines =
+      data
+      |> String.split("\n", trim: true)
+      |> Enum.map(&String.slice(&1, 0, 300))
+
+    Enum.each(lines, fn line -> Logger.info("[#{program_name(state)}] #{line}") end)
+
+    %{state | output: Enum.take(state.output ++ lines, -@obituary_lines)}
   end
 
   # The running program's name, for log lines. Falls back to "program" rather
@@ -722,6 +777,7 @@ defmodule MayonnaiOS.Launcher do
   defp bound(state, @diagnostics_button), do: toggle_scene(state)
   defp bound(state, @up_button), do: move(state, -1)
   defp bound(state, @down_button), do: move(state, +1)
+  defp bound(state, @back_button), do: dismiss_obituary(state)
 
   # Menu: back to the home screen, or -- with Select held -- power off.
   #
@@ -742,6 +798,26 @@ defmodule MayonnaiOS.Launcher do
     # this board's device tree has been wrong before -- if up and down feel
     # swapped, this is the line that says which atom the hardware really sent.
     Logger.debug("[launcher] unhandled key #{inspect(key)}")
+    state
+  end
+
+  # B takes the obituary off the panel. Only that: with nothing to clear the
+  # button stays effectively unbound, so an idle B press does not tear down
+  # and rebuild the scene the way an unguarded repaint would.
+  #
+  # The repaint is gated the same way `move/2` gates its own: only when the
+  # menu is the thing on screen. A B pressed during a game reaches here (the
+  # pad is this process's), and the state clears either way -- only the write
+  # waits, and the exit-time repaint draws whatever the state then says.
+  defp dismiss_obituary(%{obituary: nil} = state), do: state
+
+  defp dismiss_obituary(state) do
+    state = %{state | obituary: nil}
+
+    if state.port == nil and state.scene == :home do
+      show(:home, state)
+    end
+
     state
   end
 
@@ -941,7 +1017,10 @@ defmodule MayonnaiOS.Launcher do
           args: program.args
         ])
 
-      %{state | port: port, running: program}
+      # A fresh spawn clears the previous obituary and starts a fresh tail of
+      # output: whatever the panel says when this program exits should be
+      # about this program.
+      %{state | port: port, running: program, obituary: nil, output: []}
     rescue
       e ->
         Logger.warning("[launcher] #{program.path} would not start: #{Exception.message(e)}")
@@ -951,6 +1030,17 @@ defmodule MayonnaiOS.Launcher do
         # screen to explain why -- the worst failure in this file, because it
         # looks exactly like a dead device.
         Panel.release()
+
+        # And the reason goes on the panel, not only in the log: a spawn that
+        # raised has status nil and the exception's message for last words.
+        # The repaint is safe -- the hold was just released -- and needed,
+        # because unlike an exit there is no later :exit_status to trigger one.
+        state = %{
+          state
+          | obituary: %{name: program.name, status: nil, lines: [Exception.message(e)]}
+        }
+
+        repaint(state)
         state
     end
   end
@@ -1130,7 +1220,11 @@ defmodule MayonnaiOS.Launcher do
   # a scene start on every keypress, and the two cannot disagree about order
   # because both derive from the same config.
   defp show(_home, state) do
-    set_root(default_scene(), %{selected: state.selected, confirming: state.confirming})
+    set_root(default_scene(), %{
+      selected: state.selected,
+      confirming: state.confirming,
+      obituary: state.obituary
+    })
   end
 
   defp set_root(nil, _param), do: :ok

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -72,7 +72,13 @@ defmodule MayonnaiOS.Scene.Home do
 
     confirming = match?(%{confirming: true}, param)
 
-    {:ok, push_graph(scene, graph(Programs.list(), selected, confirming))}
+    obituary =
+      case param do
+        %{obituary: %{} = obituary} -> obituary
+        _ -> nil
+      end
+
+    {:ok, push_graph(scene, graph(Programs.list(), selected, confirming, obituary))}
   end
 
   @doc """
@@ -83,10 +89,10 @@ defmodule MayonnaiOS.Scene.Home do
   empty list, one entry, and a selection at the last index -- the three
   shapes that would otherwise only be found by looking at the device.
   """
-  @spec graph([Programs.program()], integer(), boolean()) :: Scenic.Graph.t()
-  def graph(programs, selected \\ 0, confirming \\ false)
+  @spec graph([Programs.program()], integer(), boolean(), map() | nil) :: Scenic.Graph.t()
+  def graph(programs, selected \\ 0, confirming \\ false, obituary \\ nil)
 
-  def graph([], _selected, _confirming) do
+  def graph([], _selected, _confirming, _obituary) do
     base()
     |> text("No programs configured.",
       font_size: 20,
@@ -100,7 +106,7 @@ defmodule MayonnaiOS.Scene.Home do
     )
   end
 
-  def graph(programs, selected, confirming) do
+  def graph(programs, selected, confirming, obituary) do
     count = length(programs)
     selected = Integer.mod(selected, count)
 
@@ -120,20 +126,55 @@ defmodule MayonnaiOS.Scene.Home do
 
     graph
     |> position(start, count)
-    |> confirm(confirming)
+    |> notice(confirming, obituary)
   end
+
+  # The bottom of the panel carries one notice at a time. The power-off
+  # question wins over an obituary: it is the panel asking for a decision,
+  # and the obituary keeps -- it is still in the Launcher's state, and comes
+  # back the moment the question is answered.
+  defp notice(graph, true, _obituary), do: confirm(graph, true)
+  defp notice(graph, false, obituary), do: obituary(graph, obituary)
 
   # The Power off row's question, on the bottom line the way the file
   # manager's bottom line names its second verb. Amber, because it is the
   # panel asking for a decision rather than describing a state.
-  defp confirm(graph, false), do: graph
-
   defp confirm(graph, true) do
     text(graph, "Power off? Y switches off. Any other button keeps it on.",
       font_size: 16,
       fill: {:color, @wait},
       translate: {20, @height - 16}
     )
+  end
+
+  # Why the last program died, quoted from its own last words. The headline
+  # is amber like the power-off question -- the panel reporting, not asking --
+  # and the quoted lines are dim so the reason reads before the evidence.
+  # Status nil is a spawn that raised rather than a program that exited; the
+  # words are then the exception's, and "exited" would be a lie.
+  defp obituary(graph, nil), do: graph
+
+  defp obituary(graph, %{name: name, status: status, lines: lines}) do
+    headline =
+      case status do
+        nil -> "#{name} would not start. B clears this."
+        status -> "#{name} exited (#{status}). B clears this."
+      end
+
+    lines
+    # Two lines and 88 characters: what fits above the headline at this font
+    # without climbing into the menu's last row.
+    |> Enum.take(-2)
+    |> Enum.reverse()
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {line, up}, g ->
+      text(g, String.slice(line, 0, 88),
+        font_size: 14,
+        fill: {:color, @dim},
+        translate: {20, @height - 36 - up * 18}
+      )
+    end)
+    |> text(headline, font_size: 16, fill: {:color, @wait}, translate: {20, @height - 16})
   end
 
   defp base do

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -128,6 +128,34 @@ defmodule MayonnaiOS.LauncherTest do
       refute Enum.any?(idle, &(&1 =~ "Y switches off"))
     end
 
+    test "an obituary quotes the program's dying words" do
+      programs = Programs.list([%{path: "/a"}])
+      obituary = %{name: "Moonlight", status: 1, lines: ["Can't open configuration file"]}
+
+      says = texts(Home.graph(programs, 0, false, obituary))
+      assert Enum.any?(says, &(&1 =~ "Moonlight exited (1)"))
+      assert Enum.any?(says, &(&1 =~ "Can't open configuration file"))
+
+      idle = texts(Home.graph(programs, 0))
+      refute Enum.any?(idle, &(&1 =~ "exited"))
+    end
+
+    test "a spawn that raised says would not start, not exited" do
+      obituary = %{name: "Doom", status: nil, lines: ["enoent"]}
+      says = texts(Home.graph(Programs.list([%{path: "/a"}]), 0, false, obituary))
+
+      assert Enum.any?(says, &(&1 =~ "Doom would not start"))
+      refute Enum.any?(says, &(&1 =~ "exited"))
+    end
+
+    test "the power-off question outranks the obituary" do
+      obituary = %{name: "Moonlight", status: 1, lines: ["nope"]}
+      says = texts(Home.graph(Programs.list([%{path: "/a"}]), 0, true, obituary))
+
+      assert Enum.any?(says, &(&1 =~ "Power off?"))
+      refute Enum.any?(says, &(&1 =~ "exited"))
+    end
+
     # Every text primitive's string, so a test can assert what the panel says
     # rather than only that a graph exists.
     defp texts(graph) do
@@ -456,6 +484,84 @@ defmodule MayonnaiOS.LauncherTest do
       assert Launcher.stop_program() == :ok
       refute Launcher.running?()
       assert gone?(os_pid)
+    end
+  end
+
+  # A program that exits in its first hundred milliseconds is invisible from
+  # the couch -- the panel flashes and the menu is back, with the reason only
+  # in the ring logger. These run real processes for the same reason the stop
+  # tests do: the thing asserted is what an exit status and a pipe actually
+  # deliver, and a fake delivers whatever the test wants to hear.
+  describe "why a program died" do
+    alias MayonnaiOS.Panel
+
+    setup do
+      on_exit(fn ->
+        Panel.release()
+        Application.delete_env(:mayonnaios, :programs)
+      end)
+
+      :ok
+    end
+
+    defp run(script) do
+      Application.put_env(:mayonnaios, :programs, [
+        %{name: "sh", path: "/bin/sh", args: ["-c", script]}
+      ])
+
+      start_supervised!({Launcher, device: "/nonexistent/event0"})
+      Launcher.launch()
+    end
+
+    defp reaped?(attempts \\ 500) do
+      cond do
+        not Launcher.running?() -> true
+        attempts == 0 -> false
+        true -> Process.sleep(10) && reaped?(attempts - 1)
+      end
+    end
+
+    test "a nonzero exit leaves an obituary quoting the last lines" do
+      run("echo one; echo nope; exit 3")
+      assert reaped?()
+
+      assert %{name: "sh", status: 3, lines: lines} = Launcher.obituary()
+      assert "nope" in lines
+    end
+
+    test "a clean exit leaves nothing" do
+      run("echo fine; exit 0")
+      assert reaped?()
+      assert Launcher.obituary() == nil
+    end
+
+    test "a deliberate stop leaves nothing, whatever the exit status" do
+      # SIGTERM ends this shell with a nonzero status; the point is that a
+      # stop the user asked for is not a death worth reporting.
+      run("while :; do sleep 1; done")
+      assert Launcher.stop_program() == :ok
+      assert Launcher.obituary() == nil
+    end
+
+    test "B takes it off, the D-pad leaves it alone" do
+      run("exit 5")
+      assert reaped?()
+      assert %{status: 5} = Launcher.obituary()
+
+      tap_key(:btn_dpad_down)
+      assert %{status: 5} = Launcher.obituary()
+
+      # Physical B is BTN_SOUTH, which InputEvent reports as :btn_a -- the
+      # launcher moduledoc's table is the authority on that swap.
+      tap_key(:btn_a)
+      assert Launcher.obituary() == nil
+    end
+
+    defp tap_key(key) do
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 1}]})
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 0}]})
+      # A call, so both casts above have been handled before the test asserts.
+      Launcher.selected()
     end
   end
 


### PR DESCRIPTION
## Summary
A program that exits in its first hundred milliseconds looks like nothing happened — the reason lives only in the ring logger. Moonlight without its config file demonstrated this. The launcher now keeps a program's last three output lines, and a nonzero exit (or a spawn that raises) puts name, status and those dying words at the bottom of the menu. B clears it; exit zero and user-initiated stops show nothing.

## Approach
The obituary travels the same road the cursor and the power-off question already do — launcher state passed into the home scene as its start argument — so nothing new survives a scene rebuild by accident. Deliberate stops write no obituary because `await_exit/3` already consumes their exit message; that existing asymmetry is what distinguishes "died" from "was told to leave" without tracking intent.

## Follow-ups for reviewer
- The panel shows at most two quoted lines at 88 chars; is that enough, or should Moonlight-style multi-line errors get a dedicated scene?

🤖 Generated with [Claude Code](https://claude.com/claude-code)