### PR TITLE
Rebind the Bluetooth serdev when a boot leaves no hci0

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,29 @@ While the app runs it holds hci0, so `MayonnaiOS.Diagnostics.probe_bluetooth/0`
 answers `:eusers` until it is stopped. That is the same device being used for
 something, not a fault.
 
+### When hci0 is not there at all
+
+`:enodev` is a fault, and an intermittent one. The Bluetooth half of the
+RTL8821CS is UART-attached, so the kernel binds `hci_uart_h5` to a serdev
+child of `serial@5000400` and that bind is what produces hci0, eleven seconds
+into an ordinary boot. Once, on 2026-08-25, it did not: the driver was bound,
+`/sys/class/bluetooth` was empty, and `dmesg` for the whole boot carried not
+one RTL line — no probe error, no timeout, nothing to read. Both Bluetooth
+apps then fail to start with `:enodev`, which from the couch is a menu entry
+that does nothing.
+
+Rebinding the driver fixes it, and `MayonnaiOS.Bluetooth.Host` now does that
+once before reporting `:enodev`, so the device recovers without a reboot and
+without SSH. `MayonnaiOS.Bluetooth.Serdev` has the account. By hand it is:
+
+```elixir
+iex> MayonnaiOS.Bluetooth.Serdev.revive()
+:ok
+```
+
+Why the bring-up occasionally no-ops in silence is not understood. The
+recovery is verified; the cause is still open.
+
 What is deliberately not implemented is LE Secure Connections; a central that
 asks for it is answered with a pairing response that does not offer it, and
 every host tested falls back to legacy pairing. A host in Secure Connections

--- a/lib/mayonnaios/bluetooth/hci_socket.ex
+++ b/lib/mayonnaios/bluetooth/hci_socket.ex
@@ -66,7 +66,10 @@ defmodule MayonnaiOS.Bluetooth.HCISocket do
 
       :eperm     not CAP_NET_ADMIN. Nerves runs as root, so this means the
                  call came from somewhere else.
-      :enodev    no hci0 -- the serdev never bound, so btrtl never ran
+      :enodev    no hci0 -- btrtl never ran. Usually because the serdev never
+                 bound, but not always: it has also happened with the driver
+                 bound and no hci0 behind it, which is what
+                 `MayonnaiOS.Bluetooth.Serdev` is for
       :ebusy     HCI_INIT/HCI_SETUP/HCI_CONFIG in progress, or the controller
                  is powered up without the AUTO_OFF grace period
       :eusers    HCI_USER_CHANNEL is already set: another socket has it

--- a/lib/mayonnaios/bluetooth/host.ex
+++ b/lib/mayonnaios/bluetooth/host.ex
@@ -57,9 +57,15 @@ defmodule MayonnaiOS.Bluetooth.Host do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.Bluetooth.{Credits, HCI, HCISocket}
+  alias MayonnaiOS.Bluetooth.{Credits, HCI, HCISocket, Serdev}
 
   @command_timeout 5_000
+
+  # How long to keep answering :ebusy with another attempt after a rebind, and
+  # how often. See `open_when_ready/2`; the firmware download it waits out was
+  # measured at 840 ms on this part.
+  @setup_timeout 3_000
+  @setup_poll 100
 
   # Used only until LE Read Buffer Size answers. Small enough to be safe on
   # any controller, and never used to send anything before that answer.
@@ -79,6 +85,11 @@ defmodule MayonnaiOS.Bluetooth.Host do
 
   Fails with the bind error when the controller is not there or is already
   owned; `MayonnaiOS.Bluetooth.HCISocket`'s moduledoc has what each one means.
+
+  One of them is answered rather than reported. `:enodev` on hci0 means the
+  Realtek serdev did not produce a device at boot, so this rebinds the driver
+  and opens again before giving up -- see `MayonnaiOS.Bluetooth.Serdev`, and
+  `open/1` below for the boundaries on it.
   """
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
@@ -179,13 +190,71 @@ defmodule MayonnaiOS.Bluetooth.Host do
   def init(opts) do
     Process.flag(:trap_exit, true)
 
-    case HCISocket.open(Keyword.get(opts, :dev, 0)) do
+    case open(Keyword.get(opts, :dev, 0)) do
       {:ok, socket} ->
         state = %__MODULE__{socket: socket}
         {:ok, poll(state)}
 
       {:error, reason} ->
         {:stop, reason}
+    end
+  end
+
+  # `:enodev` is the one bind error this device can recover from by itself. It
+  # means the Realtek serdev never produced hci0, and rebinding the driver
+  # produces it -- `MayonnaiOS.Bluetooth.Serdev` has the account of the boot
+  # failure that makes this worth doing, and of why it is done here rather
+  # than in `HCISocket.open/1`: the diagnostics probe goes through that
+  # function and is meant to report the device, not repair it.
+  #
+  # Once, and only for hci0. A device number other than zero is somebody
+  # else's controller, and nothing here knows how that one is attached.
+  defp open(0 = dev) do
+    case HCISocket.open(dev) do
+      {:error, :enodev} -> revive_and_open(dev)
+      other -> other
+    end
+  end
+
+  defp open(dev), do: HCISocket.open(dev)
+
+  defp revive_and_open(dev) do
+    case Serdev.revive() do
+      :ok ->
+        open_when_ready(dev, @setup_timeout)
+
+      {:error, reason} ->
+        Logger.error(
+          "[host] hci0 is missing and the rebind did not bring it back: #{inspect(reason)}"
+        )
+
+        # The original reason rather than the rebind's. What the screen and the
+        # log are both about is a controller that is not there, and `:enodev`
+        # is the sentence the controller scene already knows how to say.
+        {:error, :enodev}
+    end
+  end
+
+  # The firmware download runs *after* hci0 is registered and holds
+  # `HCI_SETUP` while it does, so the bind answers `:ebusy` until it finishes
+  # -- 840 ms on this part, measured from the first RTL line to the fw version
+  # in `dmesg`. So this one path waits `:ebusy` out.
+  #
+  # Only this path. An ordinary start that meets `:ebusy` has met something
+  # that powered the controller up through mgmt, which waiting does not fix
+  # and which `MayonnaiOS.Bluetooth.HCISocket` has the escape hatch for. The
+  # last attempt is deliberately not swallowed: whatever it answers is what
+  # the caller gets.
+  defp open_when_ready(dev, remaining) when remaining <= 0, do: HCISocket.open(dev)
+
+  defp open_when_ready(dev, remaining) do
+    case HCISocket.open(dev) do
+      {:error, :ebusy} ->
+        Process.sleep(@setup_poll)
+        open_when_ready(dev, remaining - @setup_poll)
+
+      other ->
+        other
     end
   end
 

--- a/lib/mayonnaios/bluetooth/serdev.ex
+++ b/lib/mayonnaios/bluetooth/serdev.ex
@@ -1,0 +1,129 @@
+defmodule MayonnaiOS.Bluetooth.Serdev do
+  @moduledoc """
+  Bringing hci0 back when the Realtek part did not appear at boot.
+
+  The Bluetooth half of the RTL8821CS is a UART part rather than a USB one.
+  The device tree hangs a `bluetooth` node off `serial@5000400`, so the kernel
+  binds `hci_uart_h5` to a serdev child named `serial0-0` -- which is why this
+  image has no `/dev/ttyS1` and needs no `btattach`. See
+  `MayonnaiOS.Bluetooth.HCISocket` for what being serdev-bound buys.
+
+  That bind is what produces hci0, and it ordinarily happens on its own about
+  eleven seconds into the boot:
+
+      Bluetooth: hci0: RTL: examining hci_ver=08 ... lmp_subver=8821
+      Bluetooth: hci0: RTL: loading rtl_bt/rtl8821cs_fw.bin
+      Bluetooth: hci0: RTL: fw version 0x75b8f098
+
+  ## The failure this module exists for
+
+  Sometimes it does not happen. Observed on this device on 2026-08-25: the
+  driver was bound -- `/sys/bus/serial/drivers/hci_uart_h5/serial0-0` was
+  there, and so was the serdev child -- and yet `/sys/class/bluetooth` was
+  empty, hci0 had never been registered, and `dmesg` for the entire boot
+  carried not one RTL line. No probe error, no command timeout, no H5 resync:
+  nothing to read anywhere. Every Bluetooth app then fails to start with
+  `:enodev`, which on the couch is a menu entry that does nothing at all.
+
+  Writing the device name to the driver's `unbind` and then to its `bind` is
+  what fixes it, and the firmware download that should have happened at boot
+  happens then instead. Verified on the device in both directions: unbinding
+  reproduces `:enodev` exactly, and rebinding brings hci0 back with a full
+  `MayonnaiOS.Diagnostics.probe_bluetooth/0` -- Realtek, core spec 4.2 --
+  answering behind it. A reboot fixes it too, and that is the part worth
+  knowing: the fault is intermittent, so a boot that works proves nothing
+  about the next one.
+
+  Why the bring-up silently no-ops is still unexplained. This module is the
+  recovery, not the diagnosis, and it says so rather than implying the bug is
+  understood.
+
+  ## Why this is not a retry loop
+
+  `MayonnaiOS.Controller`'s moduledoc says that nothing retries, and that
+  still holds. This runs once, when a person has pressed A on a Bluetooth app
+  and the open came back `:enodev`. It is the way out of a state the device
+  otherwise cannot leave without a reboot -- not a background poll of a radio,
+  which is how a handheld ends up with a flat battery and no explanation.
+  """
+
+  require Logger
+
+  @driver "/sys/bus/serial/drivers/hci_uart_h5"
+  @device "serial0-0"
+  @hci0 "/sys/class/bluetooth/hci0"
+
+  # How long to wait for hci0 after the bind, and how often to look.
+  # Registration is the first thing the probe does rather than the last, so
+  # this is generous: on the device the first RTL line follows the write by
+  # well under a tenth of a second.
+  @appear_timeout 2_000
+  @poll 50
+
+  @doc "Whether hci0 exists right now."
+  @spec present?() :: boolean()
+  def present?, do: File.dir?(@hci0)
+
+  @doc """
+  Rebind the Bluetooth serdev, and wait for hci0 to appear.
+
+  `:ok` when hci0 is there -- including when it was there all along and
+  nothing had to be done.
+
+  Present is not the same as ready. The firmware download runs *after*
+  registration and holds `HCI_SETUP` while it does, so a user-channel bind
+  answers `:ebusy` for about another second afterwards. A caller is expected
+  to wait that out; `MayonnaiOS.Bluetooth.Host` is the one that does, and its
+  `open_when_ready/2` is where the waiting lives.
+  """
+  @spec revive() :: :ok | {:error, term()}
+  def revive do
+    if present?(), do: :ok, else: rebind()
+  end
+
+  defp rebind do
+    Logger.info("[serdev] no hci0; rebinding #{@device} on #{Path.basename(@driver)}")
+
+    # A failed unbind is not a reason to stop. If the driver is already
+    # detached there is nothing to release and the bind below is the whole
+    # job. It is logged rather than dropped, because "was not bound" and the
+    # observed failure -- bound, with no hci0 behind it -- are different
+    # faults, and this log line is the only place that difference shows.
+    case write("unbind") do
+      :ok -> :ok
+      {:error, reason} -> Logger.info("[serdev] nothing to unbind (#{inspect(reason)})")
+    end
+
+    case write("bind") do
+      :ok ->
+        await(@appear_timeout)
+
+      {:error, reason} = error ->
+        Logger.error("[serdev] bind #{@device}: #{inspect(reason)}")
+        error
+    end
+  end
+
+  # Deliberately quiet: the two call sites above disagree about what a failure
+  # means -- one is routine and one is the end of the road -- so the level and
+  # the wording belong to them rather than to here.
+  defp write(action), do: File.write(Path.join(@driver, action), @device)
+
+  # Polled rather than watched: sysfs offers nothing to select on, this
+  # happens once per button press, and the whole wait is two seconds at the
+  # outside.
+  defp await(remaining) when remaining <= 0 do
+    Logger.error("[serdev] hci0 did not appear within #{@appear_timeout} ms of the bind")
+    {:error, :enodev}
+  end
+
+  defp await(remaining) do
+    if present?() do
+      Logger.info("[serdev] hci0 is back")
+      :ok
+    else
+      Process.sleep(@poll)
+      await(remaining - @poll)
+    end
+  end
+end

--- a/lib/mayonnaios/controller.ex
+++ b/lib/mayonnaios/controller.ex
@@ -42,11 +42,17 @@ defmodule MayonnaiOS.Controller do
   `start/0` returns `{:error, reason}` when the controller cannot be opened,
   and the reasons are the bind errors listed in
   `MayonnaiOS.Bluetooth.HCISocket`. The common one on a device where something
-  else took Bluetooth first is `:eusers`; `:enodev` means the Realtek part
-  never appeared, which is a boot-time problem and not this app's.
+  else took Bluetooth first is `:eusers`. `:enodev` means the Realtek part
+  never appeared at boot, and `MayonnaiOS.Bluetooth.Host` tries to fix that
+  one before reporting it: it rebinds the serdev driver and opens again, which
+  on this device is the difference between a menu entry that works and one
+  that needs a reboot. `MayonnaiOS.Bluetooth.Serdev` has the account. Reaching
+  the caller as `:enodev` therefore means the rebind was tried and hci0 still
+  did not appear.
 
-  Nothing retries. A handheld that silently retries a radio it cannot open is
-  a handheld with a flat battery and no explanation.
+  Nothing retries beyond that. One rebind on an explicit press is a recovery;
+  a handheld that silently retries a radio it cannot open is a handheld with a
+  flat battery and no explanation.
   """
 
   use Supervisor
@@ -146,8 +152,9 @@ defmodule MayonnaiOS.Controller do
       start: {__MODULE__, :start_link, [opts]},
       type: :supervisor,
       # A session that cannot start should not be started again by a
-      # supervisor: the reason is on the panel and in the log, and retrying a
-      # radio that answered :enodev will answer :enodev again.
+      # supervisor: the reason is on the panel and in the log, and a radio that
+      # answered :enodev will answer :enodev again -- `Host` has already spent
+      # its one rebind on it by the time the reason gets this far.
       restart: :temporary
     }
   end

--- a/lib/mayonnaios/pairing.ex
+++ b/lib/mayonnaios/pairing.ex
@@ -81,8 +81,10 @@ defmodule MayonnaiOS.Pairing do
 
   The failure reasons are the bind errors in
   `MayonnaiOS.Bluetooth.HCISocket`, plus `{:already_started, pid}` from `Host`
-  when the controller app has hci0. Nothing retries; the reason goes to the
-  panel.
+  when the controller app has hci0. Nothing retries, with the one exception
+  `Host` makes for `:enodev` -- it rebinds the serdev driver once and opens
+  again, so a missing hci0 is recovered here as well as in the controller app.
+  See `MayonnaiOS.Bluetooth.Serdev`. Otherwise the reason goes to the panel.
   """
   @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
   def start(opts \\ []) do

--- a/lib/mayonnaios/scene/controller.ex
+++ b/lib/mayonnaios/scene/controller.ex
@@ -241,8 +241,8 @@ defmodule MayonnaiOS.Scene.Controller do
   defp explain(:enodev) do
     [
       {"", "There is no hci0 at all.", @label},
-      {"", "The Realtek firmware did not load;", @dim},
-      {"", "dmesg at boot says why.", @dim}
+      {"", "Rebinding the driver did not bring", @dim},
+      {"", "it back either. dmesg over SSH.", @dim}
     ]
   end
 

--- a/lib/mayonnaios/scene/pairing.ex
+++ b/lib/mayonnaios/scene/pairing.ex
@@ -374,8 +374,8 @@ defmodule MayonnaiOS.Scene.Pairing do
   defp explain(:enodev) do
     [
       {"", "There is no hci0 at all.", @label},
-      {"", "The Realtek firmware did not load;", @dim},
-      {"", "dmesg at boot says why.", @dim}
+      {"", "Rebinding the driver did not bring", @dim},
+      {"", "it back either. dmesg over SSH.", @dim}
     ]
   end
 


### PR DESCRIPTION
## Summary

The Bluetooth controller app was reported broken. Nothing above the socket was
wrong: there was no hci0 to open. The `hci_uart_h5` driver was bound to
`serial0-0` and yet `/sys/class/bluetooth` was empty and the whole boot's
`dmesg` carried not one RTL line — no probe error, no command timeout, no H5
resync. Both Bluetooth apps then fail with `:enodev`, and the screen's advice
was to go read a `dmesg` that says nothing.

Rebinding the driver brings hci0 up with the firmware download that should
have happened at boot, so `Host` now spends one rebind on `:enodev` before
reporting it.

## Approach

Two placement calls worth a look. The rebind is in `Host` rather than
`HCISocket.open/1` because the diagnostics probe goes through that function
and should report the device, not repair it — putting it in `Host` also means
both apps get it, since both open the controller through `Host`.

And it is one rebind on an explicit press, not a retry loop, which keeps
`Controller`'s standing "nothing retries" rule intact. That rule was written
against a background poll flattening the battery; this is the only way out of
a state the device otherwise cannot leave without a reboot.

The `:ebusy` wait needed measuring rather than guessing: hci0 is registered
*before* the firmware download, not after, so the bind that follows a rebind
answers `:ebusy` for the ~840 ms btrtl holds `HCI_SETUP`. Only this path waits
that out — an ordinary `:ebusy` means something powered the controller up
through mgmt, which waiting does not fix.

Verified on the device both directions and end to end: unbinding reproduces
`:enodev` exactly, and from there `Controller.start()` comes up in 1.8 s,
whereupon the paired host reconnected on its stored bond, encrypted the link,
took a 247-byte MTU and read the report map.

## Follow-ups for reviewer

- Why the bring-up occasionally no-ops in silence is not understood, and this
  does not pretend otherwise. A reboot also cures it, so a working boot proves
  nothing about the next one. Worth a BSP-side look at the H5 serdev probe, or
  is living with the recovery fine?
- `@setup_timeout` is 3 s against a measured 840 ms. Generous on purpose, but
  it is a number I picked — happy to tighten it.
