### PR TITLE
Add a process readout: top for the BEAM and for the OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Software:
 - A web UI for uploading games from a phone
 - A file manager on the device: copy, move, rename and delete across both
   cards, with a clipboard instead of a destination to type
+- A process readout like `top`, twice: the BEAM's processes by reductions and
+  memory, and the Linux ones from `/proc`
 - Pickles: small sandboxed Lua apps, installed over the network like games,
   for things like controlling lamps on the LAN or polling a web API. See
   [docs/pickles.md](docs/pickles.md)

--- a/config/target.exs
+++ b/config/target.exs
@@ -280,6 +280,12 @@ config :mayonnaios, :programs, [
   # BR/EDR host in this firmware. `MayonnaiOS.Pairing` has the full account,
   # and the screen says it in the first line rather than in a footnote.
   %{name: "Bluetooth devices", app: MayonnaiOS.Pairing},
+  # Two rows, one app: `MayonnaiOS.Top` with which world to read as the
+  # argument, the same {module, arg} shape graphical pickles use. Both are
+  # readings of things that are always there -- the VM and /proc -- so unlike
+  # the Bluetooth apps neither takes a device away from anything.
+  %{name: "BEAM processes", app: {MayonnaiOS.Top, :beam}},
+  %{name: "OS processes", app: {MayonnaiOS.Top, :os}},
   # Neither a program nor an app: a verb of the launcher's own. Selecting it
   # asks rather than acts -- Y answers, anything else cancels -- and it ends
   # in the same `Nerves.Runtime.poweroff/0` the Select+Menu chord reaches.

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -21,6 +21,7 @@ defmodule MayonnaiOS.Application do
       [status()] ++
         viewport() ++
         [controller_sessions(), file_manager_sessions(), pairing_sessions(), pickle_sessions()] ++
+        [top_sessions()] ++
         target_children()
 
     # See https://elixir.hexdocs.pm/Supervisor.html
@@ -77,6 +78,10 @@ defmodule MayonnaiOS.Application do
   # `MayonnaiOS.Bluetooth.Host`'s registered name, which is a reason the panel
   # can print.
   defp pairing_sessions, do: MayonnaiOS.Pairing.sessions()
+
+  # The same arrangement for the process readout: empty until a menu row
+  # starts it, everywhere, so `MayonnaiOS.Top.start(:beam)` works on a laptop.
+  defp top_sessions, do: MayonnaiOS.Top.sessions()
 
   # The registry and DynamicSupervisor running pickles live under, empty
   # until one is started. Everywhere for the same reason as the others: the

--- a/lib/mayonnaios/scene/top.ex
+++ b/lib/mayonnaios/scene/top.ex
@@ -1,0 +1,266 @@
+defmodule MayonnaiOS.Scene.Top do
+  @moduledoc """
+  What the panel shows while the process readout has the buttons.
+
+  It draws `MayonnaiOS.Top.snapshot/0` and nothing else, told when to redraw
+  by `Top.watch/1` -- a refresh every couple of seconds, a scroll when a
+  button moved one. The same arrangement as the file manager's scene, for the
+  same reason: `set_root/3` terminates a scene on every repaint the launcher
+  does, so nothing may be remembered here.
+
+  The table is set in `:roboto_mono` and each row is one padded string.
+  Columns of numbers only line up in a monospace face, and one text primitive
+  per row is what keeps a screen that redraws every two seconds from being
+  eighty primitives deep.
+  """
+
+  use Scenic.Scene
+
+  alias MayonnaiOS.Top
+  alias MayonnaiOS.Scene.StatusBar
+  alias Scenic.Graph
+
+  import Scenic.Primitives
+
+  @width 640
+  @height 480
+
+  # Same palette as the other screens, so they read as one device.
+  @bg {12, 14, 22}
+  @title {235, 238, 245}
+  @head {90, 170, 255}
+  @label {150, 165, 195}
+  @fail {245, 110, 120}
+  @dim {110, 125, 155}
+
+  # The strip the shared top bar draws in; nothing is drawn above it.
+  @status_bar StatusBar.height()
+
+  @title_y 50
+  @stats_y 74
+  @rule_y 84
+  @columns_y 104
+  @top 124
+  @pitch 19
+
+  @range_y 434
+  @footer_rule 446
+  @footer_y 466
+
+  # The table's face and size. 13 px Roboto Mono runs about 7.8 px per glyph,
+  # so the 70-character BEAM row ends near x=566 on a 640 px panel.
+  @mono :roboto_mono
+  @mono_size 13
+
+  @impl Scenic.Scene
+  def init(scene, param, _opts) do
+    error = if is_map(param), do: Map.get(param, :error), else: nil
+
+    {:ok, scene |> assign(error: error) |> show(watch())}
+  end
+
+  @impl GenServer
+  def handle_info({:top, snapshot}, scene), do: {:noreply, show(scene, snapshot)}
+  def handle_info(_message, scene), do: {:noreply, scene}
+
+  # The app not running is a state to render rather than crash on: it is what
+  # the launcher shows when starting failed, and the reason is then the only
+  # useful thing on the panel.
+  defp watch do
+    Top.watch(self())
+  rescue
+    _error -> :stopped
+  catch
+    :exit, _reason -> :stopped
+  end
+
+  defp show(scene, snapshot), do: push_graph(scene, graph(snapshot, scene.assigns[:error]))
+
+  @doc """
+  The height of the strip this scene leaves for the shared top bar, public so
+  a test can assert that nothing is drawn above it.
+  """
+  @spec status_bar() :: pos_integer()
+  def status_bar, do: @status_bar
+
+  @doc """
+  Build the graph for a snapshot.
+
+  Public because it is the tested surface: no viewport, no driver and no
+  framebuffer, so a host test can assert what the panel says for both kinds
+  of row, for a machine with no `/proc`, and for the app not running.
+  """
+  @spec graph(map() | :stopped, term()) :: Scenic.Graph.t()
+  def graph(snapshot, error \\ nil)
+
+  def graph(:stopped, error) do
+    base("Processes")
+    |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, 120})
+    |> text(reason(error), font_size: 16, fill: {:color, @label}, translate: {20, 150})
+    |> footer("Menu goes back.")
+  end
+
+  # A machine whose sample failed -- a host with no /proc is the ordinary way
+  # here. The reason is the reading.
+  def graph(%{error: reason} = snapshot, _error) when reason != nil do
+    base(title(snapshot.kind))
+    |> text("No reading", font_size: 26, fill: {:color, @fail}, translate: {20, 120})
+    |> text("/proc: #{reason(reason)}",
+      font_size: 16,
+      fill: {:color, @label},
+      translate: {20, 150}
+    )
+    |> footer("Menu goes back.")
+  end
+
+  def graph(snapshot, _error) do
+    base(title(snapshot.kind))
+    |> stats(snapshot)
+    |> rect({@width - 40, 1}, fill: {:color, @head}, translate: {20, @rule_y})
+    |> mono(columns(snapshot.kind), @columns_y, @head)
+    |> table(snapshot)
+    |> range(snapshot)
+    |> footer(
+      "Up/Down scroll, Left/Right page. Y sorts by #{other_sort(snapshot)}. Menu goes back."
+    )
+  end
+
+  defp base(heading) do
+    Graph.build(font: :roboto, font_size: 14)
+    |> rect({@width, @height}, fill: {:color, @bg})
+    |> StatusBar.mount()
+    |> text(heading, font_size: 20, fill: {:color, @title}, translate: {20, @title_y})
+  end
+
+  defp title(:beam), do: "BEAM processes"
+  defp title(:os), do: "OS processes"
+
+  # -- the header line ---------------------------------------------------------
+
+  defp stats(graph, %{header: nil}), do: graph
+
+  defp stats(graph, %{kind: :beam, header: h}) do
+    m = h.memory
+
+    line =
+      "#{h.count} processes   run queue #{h.run_queue}   " <>
+        "memory #{bytes(m.total)} — processes #{bytes(m.processes)}, binary #{bytes(m.binary)}"
+
+    text(graph, line, font_size: 13, fill: {:color, @label}, translate: {20, @stats_y})
+  end
+
+  defp stats(graph, %{kind: :os, header: h}) do
+    m = h.memory
+
+    line =
+      "#{h.count} processes   #{h.cpus} cpus   load #{Enum.join(h.load, " ")}   " <>
+        "memory #{bytes(m.available)} free of #{bytes(m.total)}"
+
+    text(graph, line, font_size: 13, fill: {:color, @label}, translate: {20, @stats_y})
+  end
+
+  # -- the table ---------------------------------------------------------------
+
+  # The activity column is a rate on both screens, and the heading says the
+  # unit: reductions since the last refresh for the VM, percent of one core
+  # for the OS.
+  defp columns(:beam) do
+    pad("PID", 12) <>
+      pad("PROCESS", 33) <> lpad("MEMORY", 9) <> lpad("MSGQ", 6) <> lpad("REDS", 10)
+  end
+
+  defp columns(:os) do
+    lpad("PID", 6) <>
+      "  " <> pad("COMMAND", 28) <> pad("S", 4) <> lpad("%CPU", 7) <> lpad("RSS", 9)
+  end
+
+  defp table(graph, snapshot) do
+    snapshot.rows
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {row, index}, g ->
+      mono(g, row_line(snapshot.kind, row), @top + index * @pitch, @title)
+    end)
+  end
+
+  defp row_line(:beam, row) do
+    pad(pid_string(row.pid), 12) <>
+      pad(shorten(row.name, 32), 33) <>
+      lpad(bytes(row.mem), 9) <> lpad(to_string(row.mq), 6) <> lpad(count(row.cpu), 10)
+  end
+
+  defp row_line(:os, row) do
+    lpad(to_string(row.pid), 6) <>
+      "  " <>
+      pad(shorten(row.name, 27), 28) <>
+      pad(row.state, 4) <> lpad(percent(row.cpu), 7) <> lpad(bytes(row.mem), 9)
+  end
+
+  defp mono(graph, line, y, colour) do
+    text(graph, line,
+      font: @mono,
+      font_size: @mono_size,
+      fill: {:color, colour},
+      translate: {20, y}
+    )
+  end
+
+  # Where the window sits in the whole list, and which sort produced it --
+  # the two facts the table itself cannot show.
+  defp range(graph, %{total: 0}), do: graph
+
+  defp range(graph, snapshot) do
+    first = snapshot.offset + 1
+    last = snapshot.offset + length(snapshot.rows)
+
+    line = "#{first}–#{last} of #{snapshot.total}, by #{sort_name(snapshot)}"
+    text(graph, line, font_size: 13, fill: {:color, @dim}, translate: {20, @range_y})
+  end
+
+  defp sort_name(%{sort: :mem}), do: "memory"
+  defp sort_name(%{kind: :beam}), do: "reductions"
+  defp sort_name(%{kind: :os}), do: "cpu"
+
+  defp other_sort(%{sort: :mem} = snapshot), do: sort_name(%{snapshot | sort: :cpu})
+  defp other_sort(_snapshot), do: "memory"
+
+  defp footer(graph, words) do
+    graph
+    |> rect({@width - 40, 1}, fill: {:color, @dim}, translate: {20, @footer_rule})
+    |> text(words, font_size: 14, fill: {:color, @label}, translate: {20, @footer_y})
+  end
+
+  # -- formatting ----------------------------------------------------------------
+
+  defp pid_string(pid) when is_pid(pid), do: pid |> :erlang.pid_to_list() |> to_string()
+
+  # Cut long names keeping the tail: module names differ at the end --
+  # MayonnaiOS.Bluetooth.Scanner keeps Scanner, not the prefix every row shares.
+  defp shorten(name, max) do
+    if String.length(name) <= max do
+      name
+    else
+      "…" <> String.slice(name, -(max - 1), max - 1)
+    end
+  end
+
+  defp pad(string, width), do: String.pad_trailing(string, width)
+  defp lpad(string, width), do: String.pad_leading(string, width) <> " "
+
+  defp bytes(nil), do: "--"
+  defp bytes(b) when b >= 10 * 1024 * 1024, do: "#{div(b, 1024 * 1024)}M"
+  defp bytes(b) when b >= 1024 * 1024, do: "#{Float.round(b / (1024 * 1024), 1)}M"
+  defp bytes(b) when b >= 1024, do: "#{div(b, 1024)}K"
+  defp bytes(b), do: "#{b}"
+
+  defp count(nil), do: "--"
+  defp count(n) when n >= 10_000_000, do: "#{div(n, 1_000_000)}M"
+  defp count(n) when n >= 1_000_000, do: "#{Float.round(n / 1_000_000, 1)}M"
+  defp count(n) when n >= 10_000, do: "#{div(n, 1000)}k"
+  defp count(n), do: "#{n}"
+
+  defp percent(nil), do: "--"
+  defp percent(f), do: :erlang.float_to_binary(f, decimals: 1)
+
+  defp reason(nil), do: "It was not started."
+  defp reason(other), do: inspect(other)
+end

--- a/lib/mayonnaios/top.ex
+++ b/lib/mayonnaios/top.ex
@@ -1,0 +1,339 @@
+defmodule MayonnaiOS.Top do
+  @moduledoc """
+  The process readout app: `top`, for whichever of this device's two worlds
+  the menu row named.
+
+  One module, two menu entries -- `{MayonnaiOS.Top, :beam}` and
+  `{MayonnaiOS.Top, :os}`, the same `{module, arg}` shape graphical pickles
+  use -- because the two screens differ only in where the rows come from.
+  `MayonnaiOS.Top.Beam` reads the VM, `MayonnaiOS.Top.Os` reads `/proc`, and
+  everything else here -- the refresh clock, the scrolling, the sort, the
+  scene -- is shared.
+
+      iex> MayonnaiOS.Top.start(:beam)
+      iex> MayonnaiOS.Top.snapshot().rows |> hd()
+      iex> MayonnaiOS.Top.stop()
+
+  An app rather than a program: a module in this firmware, started in this
+  VM, with no external process and no screen handed over. See
+  `MayonnaiOS.Programs` for what that costs and buys. Like the file manager
+  it needs only the buttons and the panel, so two of these could run without
+  harm -- there is still one, because it is one named process and one row of
+  state.
+
+  ## The buttons
+
+      D-pad up/down    scroll one row
+      D-pad left/right scroll one screen
+      Y                flip the sort: activity or memory
+      Menu             leave, handled by the Launcher
+
+  A and B do nothing: the rows are readings, not things to open. Autorepeat
+  scrolls, as it does in the file manager, so holding a direction walks a
+  long list.
+
+  ## Both columns need a previous sample
+
+  Neither world accounts "busy right now" in a single reading -- the OS gives
+  cumulative jiffies and the VM gives cumulative reductions -- so the
+  activity column on both screens is a delta between refreshes. The first
+  frame shows `--` there and sorts those rows last; two seconds later the
+  numbers are real. The samplers own that arithmetic; this process only keeps
+  the previous sample's reference and hands it back.
+  """
+
+  use GenServer
+
+  alias MayonnaiOS.Top.{Beam, Os}
+
+  # The buttons as InputEvent names them, which is not what the shell prints;
+  # `MayonnaiOS.Launcher` has the account of the device tree lying about X/Y.
+  # Shell Y is 307, which InputEvent calls :btn_x.
+  @y_button :btn_x
+
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @left :btn_dpad_left
+  @right :btn_dpad_right
+
+  @dpad [@up, @down, @left, @right]
+
+  # Menu belongs to the Launcher: it is the way out of any app, and this one
+  # drops it on the floor exactly as the file manager does.
+  @menu :btn_mode
+
+  # One screen of rows. The scene draws exactly this many, and the snapshot
+  # carries the window rather than the whole list so the two cannot disagree
+  # about what a page is.
+  @visible 16
+
+  # top's own cadence. Once a second would double the sampling for a reading
+  # nobody can act on faster, and the deltas get less noisy with the longer
+  # baseline.
+  @refresh_ms 2_000
+
+  # -- the app protocol the Launcher uses -------------------------------------
+
+  @sessions MayonnaiOS.Top.Sessions
+
+  @doc """
+  Start the app on one of its two screens.
+
+  Under a DynamicSupervisor rather than linked to the caller, for the reason
+  the file manager is: the Launcher calls this from the process that owns the
+  gamepad, and a bug here must not take the buttons down with it.
+
+  Idempotent about the process and explicit about the screen: starting `:os`
+  while `:beam` is up switches the running one over rather than failing, so
+  the menu row pressed is the screen shown whatever a console did earlier.
+  """
+  @spec start(:beam | :os) :: {:ok, pid()} | {:error, term()}
+  def start(kind) when kind in [:beam, :os] do
+    case DynamicSupervisor.start_child(@sessions, {__MODULE__, []}) do
+      {:ok, pid} -> show(pid, kind)
+      {:error, {:already_started, pid}} -> show(pid, kind)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp show(pid, kind) do
+    GenServer.call(__MODULE__, {:show, kind})
+    {:ok, pid}
+  end
+
+  @doc "Stop the app."
+  @spec stop() :: :ok
+  def stop do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(@sessions, pid)
+    end
+  end
+
+  @doc "The DynamicSupervisor the app runs under, for the application tree."
+  @spec sessions() :: Supervisor.child_spec()
+  def sessions do
+    %{
+      id: @sessions,
+      start: {DynamicSupervisor, :start_link, [[name: @sessions, strategy: :one_for_one]]},
+      type: :supervisor
+    }
+  end
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      # Temporary for the reason the other app sessions are: whatever went
+      # wrong is in the log, and a readout that restarts itself back onto the
+      # screen someone just left is not help.
+      restart: :temporary
+    }
+  end
+
+  @doc false
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc """
+  Forward an evdev report from the Launcher.
+
+  A cast, so a slow sample can never make the buttons late, and safe when the
+  app is not running.
+  """
+  @spec input([tuple()]) :: :ok
+  def input(events) do
+    if Process.whereis(__MODULE__), do: GenServer.cast(__MODULE__, {:input, events}), else: :ok
+  end
+
+  @doc "The scene the launcher shows while this app has the buttons."
+  @spec scene() :: module()
+  def scene, do: MayonnaiOS.Scene.Top
+
+  @doc """
+  Everything the panel needs, as one map: the visible window of rows, how
+  many there are in all, the header stats, and which sort is on.
+
+  A call, so a test that has just cast a synthetic button press is ordered
+  behind it and does not have to sleep.
+  """
+  @spec snapshot() :: map() | :stopped
+  def snapshot do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, :snapshot), else: :stopped
+  end
+
+  @doc """
+  Be told when the snapshot changes, as `{:top, snapshot}`.
+
+  The scene does this instead of polling; a refresh arrives every couple of
+  seconds and a scroll arrives when a button moved it. The watcher is
+  monitored, so a scene torn down by `set_root/3` drops itself.
+  """
+  @spec watch(pid()) :: map() | :stopped
+  def watch(pid) do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, {:watch, pid}), else: :stopped
+  end
+
+  # -- state -------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    state = %{
+      kind: Keyword.get(opts, :kind, :beam),
+      # The proc directory, a parameter so the tests can run the :os screen
+      # against a fixture on a host that has no /proc.
+      proc: Keyword.get(opts, :proc, "/proc"),
+      refresh_ms: Keyword.get(opts, :refresh_ms, @refresh_ms),
+      rows: [],
+      header: nil,
+      error: nil,
+      prev: nil,
+      offset: 0,
+      sort: :cpu,
+      watchers: []
+    }
+
+    state = refresh(state)
+    schedule(state)
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:snapshot, _from, state), do: {:reply, snapshot_of(state), state}
+
+  def handle_call({:watch, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, snapshot_of(state), %{state | watchers: [pid | state.watchers]}}
+  end
+
+  # Switching screens resets the scroll and the sort -- the new list has no
+  # relation to the old position -- and keeps the previous sample only when it
+  # is a sample of the same world, so a :beam delta is never computed against
+  # an :os reading.
+  def handle_call({:show, kind}, _from, state) do
+    prev = if kind == state.kind, do: state.prev, else: nil
+
+    state = refresh(%{state | kind: kind, prev: prev, offset: 0, sort: :cpu})
+    {:reply, :ok, notify(state, nil)}
+  end
+
+  @impl GenServer
+  def handle_cast({:input, events}, state) do
+    {:noreply, state |> apply_events(events) |> notify(state)}
+  end
+
+  @impl GenServer
+  def handle_info(:refresh, state) do
+    state = refresh(state)
+    schedule(state)
+    {:noreply, notify(state, nil)}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | watchers: List.delete(state.watchers, pid)}}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # Rescheduled by hand rather than :timer.send_interval, so the timer dies
+  # with the process and a sample that ran long delays the next tick instead
+  # of stacking a second one behind it.
+  defp schedule(state), do: Process.send_after(self(), :refresh, state.refresh_ms)
+
+  defp snapshot_of(state) do
+    %{
+      kind: state.kind,
+      header: state.header,
+      rows: Enum.slice(state.rows, state.offset, @visible),
+      total: length(state.rows),
+      offset: state.offset,
+      sort: state.sort,
+      error: state.error
+    }
+  end
+
+  # `previous` is the state to diff against, or nil for "always send" -- a
+  # refresh is always news, a button press only when it changed something.
+  defp notify(state, previous) do
+    if previous != nil and snapshot_of(state) == snapshot_of(previous) do
+      state
+    else
+      snapshot = snapshot_of(state)
+      Enum.each(state.watchers, &send(&1, {:top, snapshot}))
+      state
+    end
+  end
+
+  # -- sampling ----------------------------------------------------------------
+
+  defp refresh(state) do
+    case take_sample(state) do
+      {:ok, sample} ->
+        rows = state.kind |> rows(sample, state.prev) |> sort(state.sort)
+
+        clamp(%{
+          state
+          | rows: rows,
+            header: header(state.kind, sample),
+            prev: ref(state.kind, sample),
+            error: nil
+        })
+
+      {:error, reason} ->
+        %{state | rows: [], header: nil, prev: nil, error: reason, offset: 0}
+    end
+  end
+
+  defp take_sample(%{kind: :beam}), do: {:ok, Beam.sample()}
+  defp take_sample(%{kind: :os, proc: proc}), do: Os.sample(proc)
+
+  defp rows(:beam, sample, prev), do: Beam.rows(sample, prev)
+  defp rows(:os, sample, prev), do: Os.rows(sample, prev)
+
+  defp ref(:beam, sample), do: Beam.ref(sample)
+  defp ref(:os, sample), do: Os.ref(sample)
+
+  defp header(:beam, sample), do: Beam.header(sample)
+  defp header(:os, sample), do: Os.header(sample)
+
+  # Rows with no delta yet sort below any row with one: a `--` that opened
+  # the screen at the top would put the stalest information first.
+  defp sort(rows, :cpu), do: Enum.sort_by(rows, &{&1.cpu || -1, &1.mem}, :desc)
+  defp sort(rows, :mem), do: Enum.sort_by(rows, &{&1.mem, &1.cpu || -1}, :desc)
+
+  # -- input -------------------------------------------------------------------
+
+  defp apply_events(state, events) do
+    Enum.reduce(events, state, fn
+      {:ev_key, key, 1}, acc -> press(acc, key)
+      # Autorepeat, for the D-pad only: a held direction scrolls, a held Y
+      # does not flip the sort back and forth.
+      {:ev_key, key, 2}, acc when key in @dpad -> press(acc, key)
+      _event, acc -> acc
+    end)
+  end
+
+  defp press(state, @menu), do: state
+  defp press(state, @up), do: scroll(state, -1)
+  defp press(state, @down), do: scroll(state, +1)
+  defp press(state, @left), do: scroll(state, -@visible)
+  defp press(state, @right), do: scroll(state, +@visible)
+
+  # Flipping the sort re-sorts what is already on hand rather than waiting for
+  # the next tick, and goes back to the top: the point of a sort is its head.
+  defp press(state, @y_button) do
+    sort = if state.sort == :cpu, do: :mem, else: :cpu
+    %{state | sort: sort, rows: sort(state.rows, sort), offset: 0}
+  end
+
+  defp press(state, _key), do: state
+
+  # Clamped rather than wrapped: a list of readings has a top and a bottom,
+  # and scrolling off the end of one hundred processes back to the first reads
+  # as the screen having lost its place.
+  defp scroll(state, delta), do: clamp(%{state | offset: state.offset + delta})
+
+  defp clamp(state) do
+    %{state | offset: state.offset |> min(length(state.rows) - @visible) |> max(0)}
+  end
+end

--- a/lib/mayonnaios/top/beam.ex
+++ b/lib/mayonnaios/top/beam.ex
@@ -1,0 +1,115 @@
+defmodule MayonnaiOS.Top.Beam do
+  @moduledoc """
+  The BEAM's processes, read from the BEAM.
+
+  `Process.list/0` plus one `Process.info/2` per process. Cheap enough to do
+  every couple of seconds -- this firmware runs a few hundred processes -- and
+  it needs nothing that is not already in the VM, so unlike the OS half there
+  is no seam to inject and no way for the reading to be absent.
+
+  ## What stands in for CPU
+
+  The scheduler does not account CPU time per process, but every process
+  counts its reductions -- roughly, function calls -- and a process that is
+  burning a core is burning reductions. So the activity column is the
+  reduction delta between two samples, computed by `rows/2` against the
+  previous sample's `ref/1`, which is the same trick `etop` uses. The first
+  sample has nothing to diff against and the column is `nil`; a cumulative
+  count in that slot would rank every old process over every busy one.
+
+  ## Naming a process
+
+  A registered name is the name. For the rest, `:proc_lib.translate_initial_call/1`
+  digs the real entry point out of the process dictionary -- without it every
+  GenServer in the VM is `:proc_lib.init_p/5`, which distinguishes nothing.
+  A process that dies mid-question, or one whose dictionary cannot be read,
+  falls back to its pid, because a row that crashes the sampler is a screen
+  that dies exactly when someone is watching a leak.
+  """
+
+  @type row :: %{
+          pid: pid(),
+          name: String.t(),
+          reds: non_neg_integer(),
+          mem: non_neg_integer(),
+          mq: non_neg_integer()
+        }
+
+  @doc """
+  One reading: every process the VM will answer for.
+
+  A process that exits between `Process.list/0` and its `Process.info/2` --
+  which happens, that is what processes do -- answers `nil` and is dropped
+  rather than crashing the sample.
+  """
+  @spec sample() :: [row()]
+  def sample do
+    for pid <- Process.list(),
+        info = Process.info(pid, [:registered_name, :reductions, :memory, :message_queue_len]),
+        info != nil do
+      %{
+        pid: pid,
+        name: name(pid, info[:registered_name]),
+        reds: info[:reductions],
+        mem: info[:memory],
+        mq: info[:message_queue_len]
+      }
+    end
+  end
+
+  @doc """
+  The rows for one sample, with the activity column computed against `prev`.
+
+  `prev` is the `ref/1` of the previous sample, or `nil`. The column is `nil`
+  for a pid the previous sample did not have -- including every pid on the
+  first sample -- and for a count that went down, which is the VM reusing a
+  pid for a new process.
+  """
+  @spec rows([row()], map() | nil) :: [map()]
+  def rows(sample, prev) do
+    Enum.map(sample, fn p ->
+      cpu =
+        case prev && prev[p.pid] do
+          old when is_integer(old) and old <= p.reds -> p.reds - old
+          _ -> nil
+        end
+
+      Map.put(p, :cpu, cpu)
+    end)
+  end
+
+  @doc "What the next sample's deltas are computed against."
+  @spec ref([row()]) :: map()
+  def ref(sample), do: Map.new(sample, &{&1.pid, &1.reds})
+
+  @doc "The line above the table: counts, the run queue, and the VM's memory."
+  @spec header([row()]) :: map()
+  def header(sample) do
+    %{
+      count: length(sample),
+      run_queue: :erlang.statistics(:run_queue),
+      memory: %{
+        total: :erlang.memory(:total),
+        processes: :erlang.memory(:processes),
+        binary: :erlang.memory(:binary)
+      }
+    }
+  end
+
+  # `Process.info/2` answers `{:registered_name, []}` for a process with no
+  # name, so an atom here really is a name.
+  defp name(_pid, name) when is_atom(name) and name != nil, do: inspect(name)
+
+  defp name(pid, _unregistered) do
+    case :proc_lib.translate_initial_call(pid) do
+      {mod, fun, arity} -> "#{inspect(mod)}.#{fun}/#{arity}"
+      _other -> pid_string(pid)
+    end
+  rescue
+    _ -> pid_string(pid)
+  catch
+    :exit, _ -> pid_string(pid)
+  end
+
+  defp pid_string(pid), do: pid |> :erlang.pid_to_list() |> to_string()
+end

--- a/lib/mayonnaios/top/os.ex
+++ b/lib/mayonnaios/top/os.ex
@@ -1,0 +1,258 @@
+defmodule MayonnaiOS.Top.Os do
+  @moduledoc """
+  The operating system's processes, read from `/proc`.
+
+  Everything comes from four files: `/proc/stat` for the machine's total
+  jiffies and its CPU count, `/proc/loadavg`, `/proc/meminfo`, and one
+  `/proc/<pid>/stat` per process. No `ps`, no `top`: neither is in this image,
+  and both are themselves just readers of these files.
+
+  ## CPU percent needs two samples
+
+  `/proc/<pid>/stat` gives cumulative jiffies, so a single reading says how
+  much a process has used since it started -- for the BEAM, that is most of a
+  boot's worth, which is not what "is it busy right now" asks. The percentage
+  is a delta: this process's jiffies against the machine's, between two
+  samples. `rows/2` takes the previous sample's `ref/1` and computes it;
+  passed `nil` -- the first reading -- the column is `nil` and the panel says
+  so rather than showing a since-boot number dressed up as a rate.
+
+  The percent is of one core, `top`'s convention, so RetroArch pegging a core
+  on this four-core SoC reads as 100 rather than 25.
+
+  ## The comm field is hostile to naive parsing
+
+  A process names itself in `stat` inside parentheses, and the name may
+  contain spaces and close-parens -- `(tmux: server)`, `((sd-pam))`. Splitting
+  on whitespace mis-parses those, so `parse_stat/1` takes the name as
+  everything between the first `(` and the *last* `) `, which is what the
+  kernel's own documentation prescribes.
+
+  ## The paths are parameters
+
+  `sample/1` takes the proc directory so a test can point it at a fixture --
+  the host this suite runs on has no `/proc` at all, and the target cannot be
+  in the test loop. On a machine without procfs the sample is an error, and
+  the screen renders the reason rather than an empty list pretending to be a
+  quiet machine.
+  """
+
+  # This board's kernel uses 4 KiB pages, and `rss` in stat is in pages.
+  @page_bytes 4096
+
+  @type row :: %{
+          pid: pos_integer(),
+          name: String.t(),
+          state: String.t(),
+          jiffies: non_neg_integer(),
+          mem: non_neg_integer()
+        }
+
+  @type sample :: %{
+          total: non_neg_integer(),
+          cpus: pos_integer(),
+          processes: [row()],
+          load: [String.t()],
+          memory: %{total: non_neg_integer() | nil, available: non_neg_integer() | nil}
+        }
+
+  @doc """
+  One reading of the whole machine, or why there is none.
+
+  A process that vanishes between the directory listing and the read of its
+  `stat` -- which happens constantly, that is what processes do -- is simply
+  absent from the list rather than an error.
+  """
+  @spec sample(Path.t()) :: {:ok, sample()} | {:error, term()}
+  def sample(proc \\ "/proc") do
+    case File.read(Path.join(proc, "stat")) do
+      {:ok, stat} ->
+        {:ok,
+         %{
+           total: total_jiffies(stat),
+           cpus: cpu_count(stat),
+           processes: processes(proc),
+           load: load(proc),
+           memory: read_memory(proc)
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  The rows for one sample, with the CPU column computed against `prev`.
+
+  `prev` is the `ref/1` of the previous sample, or `nil` when there is none.
+  The column is `nil` when it cannot be honest: no previous sample, a pid the
+  previous sample did not have, or a pid whose jiffies went *down* -- which is
+  pid reuse, a different process wearing a dead one's number.
+  """
+  @spec rows(sample(), map() | nil) :: [map()]
+  def rows(%{processes: procs, total: total, cpus: cpus}, prev) do
+    dtotal = if prev, do: total - prev.total, else: 0
+
+    Enum.map(procs, fn p ->
+      cpu =
+        with true <- dtotal > 0,
+             old when is_integer(old) <- prev.jiffies[p.pid],
+             delta when delta >= 0 <- p.jiffies - old do
+          Float.round(100.0 * cpus * delta / dtotal, 1)
+        else
+          _ -> nil
+        end
+
+      Map.put(p, :cpu, cpu)
+    end)
+  end
+
+  @doc "What the next sample's deltas are computed against."
+  @spec ref(sample()) :: map()
+  def ref(%{total: total, processes: procs}) do
+    %{total: total, jiffies: Map.new(procs, &{&1.pid, &1.jiffies})}
+  end
+
+  @doc "The line above the table: counts, load, and memory."
+  @spec header(sample()) :: map()
+  def header(sample) do
+    %{
+      count: length(sample.processes),
+      cpus: sample.cpus,
+      load: sample.load,
+      memory: sample.memory
+    }
+  end
+
+  # -- parsing, pure and public so the host tests can feed it strings ---------
+
+  @doc """
+  One `/proc/<pid>/stat` into a row, or `:error` for a line that is not one.
+
+  See the moduledoc for the comm field; the numeric fields are indexed from
+  proc(5): utime and stime are fields 14 and 15, rss is field 24, and after
+  the close-paren split those are offsets 11, 12 and 21 with `state` at 0.
+  """
+  @spec parse_stat(String.t()) :: {:ok, row()} | :error
+  def parse_stat(text) do
+    with {:ok, pid, comm, rest} <- split_comm(String.trim(text)),
+         fields = String.split(rest, " ", trim: true),
+         [state | _rest] <- fields,
+         {utime, ""} <- Integer.parse(Enum.at(fields, 11) || ""),
+         {stime, ""} <- Integer.parse(Enum.at(fields, 12) || ""),
+         {rss, ""} <- Integer.parse(Enum.at(fields, 21) || "") do
+      {:ok,
+       %{
+         pid: pid,
+         name: comm,
+         state: state,
+         jiffies: utime + stime,
+         mem: max(rss, 0) * @page_bytes
+       }}
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
+  The machine's total jiffies: the sum of every column on `/proc/stat`'s
+  aggregate `cpu` line, idle included. That sum only ever grows, which is what
+  makes it a denominator.
+  """
+  @spec total_jiffies(String.t()) :: non_neg_integer()
+  def total_jiffies(stat_text) do
+    case String.split(stat_text, "\n", parts: 2) do
+      ["cpu " <> numbers | _] ->
+        numbers
+        |> String.split()
+        |> Enum.reduce(0, fn field, acc ->
+          case Integer.parse(field) do
+            {n, ""} -> acc + n
+            _ -> acc
+          end
+        end)
+
+      _ ->
+        0
+    end
+  end
+
+  @doc """
+  How many cores `/proc/stat` lists, floored at one so it can be multiplied
+  and divided by without a guard at every use.
+  """
+  @spec cpu_count(String.t()) :: pos_integer()
+  def cpu_count(stat_text) do
+    stat_text
+    |> String.split("\n")
+    |> Enum.count(&Regex.match?(~r/^cpu\d+ /, &1))
+    |> max(1)
+  end
+
+  @doc """
+  Total and available memory in bytes, from a `/proc/meminfo` text.
+
+  MemAvailable rather than MemFree, because free is what nothing has touched
+  and available is what a new allocation could actually get -- the kernel
+  counts reclaimable cache into the latter, and the latter is the number that
+  answers "is this device short of memory".
+  """
+  @spec memory(String.t()) :: %{
+          total: non_neg_integer() | nil,
+          available: non_neg_integer() | nil
+        }
+  def memory(text) do
+    %{total: meminfo_kb(text, "MemTotal"), available: meminfo_kb(text, "MemAvailable")}
+  end
+
+  defp meminfo_kb(text, key) do
+    case Regex.run(~r/^#{key}:\s+(\d+) kB/m, text) do
+      [_, kb] -> String.to_integer(kb) * 1024
+      nil -> nil
+    end
+  end
+
+  # -- reading -----------------------------------------------------------------
+
+  defp processes(proc) do
+    case File.ls(proc) do
+      {:ok, entries} ->
+        for name <- entries,
+            Regex.match?(~r/^\d+$/, name),
+            {:ok, stat} <- [File.read(Path.join([proc, name, "stat"]))],
+            {:ok, row} <- [parse_stat(stat)] do
+          row
+        end
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  defp load(proc) do
+    case File.read(Path.join(proc, "loadavg")) do
+      {:ok, text} -> text |> String.split() |> Enum.take(3)
+      {:error, _reason} -> []
+    end
+  end
+
+  defp read_memory(proc) do
+    case File.read(Path.join(proc, "meminfo")) do
+      {:ok, text} -> memory(text)
+      {:error, _reason} -> %{total: nil, available: nil}
+    end
+  end
+
+  # The pid is everything before the first " (", the name everything up to the
+  # *last* ") " -- see the moduledoc for the process names that make the
+  # distinction matter.
+  defp split_comm(text) do
+    with [pid_s, rest] <- String.split(text, " (", parts: 2),
+         {pid, ""} <- Integer.parse(pid_s),
+         parts when length(parts) > 1 <- String.split(rest, ") ") do
+      {:ok, pid, Enum.join(:lists.droplast(parts), ") "), List.last(parts)}
+    else
+      _ -> :error
+    end
+  end
+end

--- a/test/top_test.exs
+++ b/test/top_test.exs
@@ -1,0 +1,332 @@
+defmodule MayonnaiOS.TopTest do
+  # Not async: the app is a named process.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Top
+  alias MayonnaiOS.Top.{Beam, Os}
+  alias MayonnaiOS.Scene.Top, as: Scene
+
+  # The buttons as InputEvent names them, not as the shell prints them.
+  # Spelled out here rather than reused from the module under test: if these
+  # ever disagree, the test is the thing that should notice.
+  #
+  #   shell Y = 307 -> :btn_x
+  @y :btn_x
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @left :btn_dpad_left
+  @right :btn_dpad_right
+  @menu :btn_mode
+
+  # input/1 is a cast and snapshot/0 is a call, so the call is ordered behind
+  # the press and no test has to sleep.
+  defp press(key, value \\ 1) do
+    Top.input([{:ev_key, key, value}])
+    Top.snapshot()
+  end
+
+  # A /proc/<pid>/stat line with the fields this app reads in their proc(5)
+  # positions: state 3, utime 14, stime 15, rss 24 -- and a few more after,
+  # because the real file does not stop where the interest does.
+  defp stat_line(pid, comm, state, utime, stime, rss) do
+    fields =
+      [state] ++
+        List.duplicate("0", 10) ++
+        ["#{utime}", "#{stime}"] ++
+        List.duplicate("0", 8) ++ ["#{rss}"] ++ List.duplicate("0", 5)
+
+    "#{pid} (#{comm}) " <> Enum.join(fields, " ") <> "\n"
+  end
+
+  describe "parsing /proc" do
+    test "an ordinary stat line" do
+      assert {:ok, row} = Os.parse_stat(stat_line(42, "init", "S", 10, 5, 3))
+      assert row == %{pid: 42, name: "init", state: "S", jiffies: 15, mem: 3 * 4096}
+    end
+
+    test "a comm with spaces and close-parens in it" do
+      # Both real: tmux names its server "tmux: server", systemd's per-user
+      # helper is "(sd-pam)". Splitting on whitespace or on the first paren
+      # mis-parses each.
+      assert {:ok, %{name: "tmux: server"}} =
+               Os.parse_stat(stat_line(7, "tmux: server", "S", 1, 1, 1))
+
+      assert {:ok, %{name: "(sd-pam)", state: "S"}} =
+               Os.parse_stat(stat_line(8, "(sd-pam)", "S", 1, 1, 1))
+    end
+
+    test "garbage is an error rather than a row" do
+      assert :error = Os.parse_stat("")
+      assert :error = Os.parse_stat("not a stat line at all")
+      assert :error = Os.parse_stat("12 (short) S 0 0")
+    end
+
+    test "total jiffies is the sum of the aggregate cpu line, idle included" do
+      stat = "cpu  10 20 30 40\ncpu0 5 10 15 20\ncpu1 5 10 15 20\nintr 12345\n"
+      assert Os.total_jiffies(stat) == 100
+      assert Os.cpu_count(stat) == 2
+    end
+
+    test "a machine that lists no per-cpu lines still counts as one cpu" do
+      assert Os.cpu_count("cpu  1 2 3\n") == 1
+    end
+
+    test "meminfo gives total and available in bytes" do
+      text =
+        "MemTotal:         510432 kB\nMemFree:           98000 kB\nMemAvailable:     301234 kB\n"
+
+      assert Os.memory(text) == %{total: 510_432 * 1024, available: 301_234 * 1024}
+    end
+  end
+
+  describe "the OS cpu column" do
+    defp os_sample(total, jiffies) do
+      %{
+        total: total,
+        cpus: 4,
+        processes: [%{pid: 1, name: "init", state: "S", jiffies: jiffies, mem: 4096}],
+        load: [],
+        memory: %{total: nil, available: nil}
+      }
+    end
+
+    test "is a delta between two samples, as percent of one core" do
+      first = os_sample(1000, 100)
+      second = os_sample(1400, 150)
+
+      # 50 of the machine's 400 jiffies, on a 4-cpu machine: half a core.
+      assert [%{cpu: 50.0}] = Os.rows(second, Os.ref(first))
+    end
+
+    test "is honest about not knowing" do
+      # No previous sample; a pid the previous sample did not have; and a
+      # count that went down, which is pid reuse.
+      assert [%{cpu: nil}] = Os.rows(os_sample(1000, 100), nil)
+
+      other = %{Os.ref(os_sample(500, 0)) | jiffies: %{99 => 1}}
+      assert [%{cpu: nil}] = Os.rows(os_sample(1000, 100), other)
+
+      reused = Os.ref(os_sample(500, 999))
+      assert [%{cpu: nil}] = Os.rows(os_sample(1000, 100), reused)
+    end
+  end
+
+  describe "the BEAM sampler" do
+    test "names registered processes by their name" do
+      Process.register(self(), :top_test_named)
+
+      assert Enum.any?(Beam.sample(), &(&1.name == ":top_test_named"))
+    after
+      Process.unregister(:top_test_named)
+    end
+
+    test "the activity column is a reduction delta, nil on the first sample" do
+      sample = Beam.sample()
+
+      assert Enum.all?(Beam.rows(sample, nil), &(&1.cpu == nil))
+
+      later = Beam.sample()
+      rows = Beam.rows(later, Beam.ref(sample))
+      me = Enum.find(rows, &(&1.pid == self()))
+
+      # This process has burned reductions between the two samples -- it took
+      # them. The exact number is nobody's business, but it exists.
+      assert is_integer(me.cpu)
+    end
+  end
+
+  describe "the app" do
+    # The refresh clock is pinned far away so a tick cannot re-sample the VM
+    # between a press and its assertion; refreshing has its own describe.
+    setup do
+      start_supervised!({Top, kind: :beam, refresh_ms: 60_000})
+      :ok
+    end
+
+    test "a snapshot is one screen of a larger, sorted list" do
+      snapshot = Top.snapshot()
+
+      assert snapshot.kind == :beam
+      assert snapshot.total > length(snapshot.rows)
+      assert length(snapshot.rows) == 16
+      assert snapshot.header.count == snapshot.total
+    end
+
+    test "the d-pad scrolls, clamped at both ends" do
+      assert Top.snapshot().offset == 0
+      assert press(@up).offset == 0
+
+      assert press(@down).offset == 1
+      # Autorepeat scrolls too, so a held direction walks the list.
+      assert press(@down, 2).offset == 2
+
+      assert press(@right).offset == 2 + 16
+
+      # All the way down: clamped to the last full screen, not past it.
+      last = Enum.reduce(1..1000, nil, fn _n, _acc -> press(@down) end)
+      assert last.offset == last.total - 16
+      assert press(@down).offset == last.offset
+
+      assert press(@left).offset == last.offset - 16
+    end
+
+    test "Y flips the sort and goes back to the top" do
+      press(@down)
+
+      assert %{sort: :mem, offset: 0} = press(@y)
+
+      # Sorted by memory means descending in it.
+      mems = Enum.map(Top.snapshot().rows, & &1.mem)
+      assert mems == Enum.sort(mems, :desc)
+
+      assert %{sort: :cpu} = press(@y)
+    end
+
+    test "Menu and the face buttons change nothing" do
+      before = Top.snapshot()
+
+      assert press(@menu) == before
+      assert press(:btn_a) == before
+      assert press(:btn_b) == before
+    end
+
+    test "starting the other screen switches the running app over" do
+      assert {:ok, _pid} = Top.start(:os)
+      assert Top.snapshot().kind == :os
+    end
+  end
+
+  describe "refreshing" do
+    test "pushes a new snapshot to watchers, and deltas appear" do
+      {:ok, pid} = Top.start_link(kind: :beam, refresh_ms: 30)
+      Top.watch(self())
+
+      assert_receive {:top, _first}, 1000
+      assert_receive {:top, second}, 1000
+
+      # By the second tick there is a previous sample, so the busy rows carry
+      # a reduction delta.
+      assert Enum.any?(second.rows, &is_integer(&1.cpu))
+
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "the OS screen" do
+    # A /proc a laptop can offer: the host this suite runs on has none.
+    defp fixture do
+      dir = Path.join(System.tmp_dir!(), "top-proc-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(Path.join(dir, "12"))
+      File.mkdir_p!(Path.join(dir, "340"))
+
+      File.write!(
+        Path.join(dir, "stat"),
+        "cpu  100 0 100 800\ncpu0 50 0 50 400\ncpu1 50 0 50 400\n"
+      )
+
+      File.write!(Path.join(dir, "loadavg"), "0.42 0.38 0.31 2/189 12345\n")
+
+      File.write!(
+        Path.join(dir, "meminfo"),
+        "MemTotal:         510432 kB\nMemAvailable:     301234 kB\n"
+      )
+
+      File.write!(Path.join([dir, "12", "stat"]), stat_line(12, "retroarch", "R", 50, 10, 2000))
+      File.write!(Path.join([dir, "340", "stat"]), stat_line(340, "kworker/0:1", "I", 1, 0, 0))
+
+      dir
+    end
+
+    test "reads processes, load and memory from a proc directory" do
+      dir = fixture()
+      {:ok, pid} = Top.start_link(kind: :os, proc: dir, refresh_ms: 60_000)
+
+      snapshot = Top.snapshot()
+
+      assert snapshot.kind == :os
+      assert snapshot.error == nil
+      assert snapshot.total == 2
+      assert snapshot.header.cpus == 2
+      assert snapshot.header.load == ["0.42", "0.38", "0.31"]
+      assert snapshot.header.memory.total == 510_432 * 1024
+
+      # Sorted: no deltas yet, so by memory within the nil-cpu tier --
+      # retroarch's 2000 pages over the kworker's none.
+      assert [%{name: "retroarch", state: "R"}, %{name: "kworker/0:1"}] = snapshot.rows
+
+      assert %Scenic.Graph{} = Scene.graph(snapshot)
+
+      GenServer.stop(pid)
+      File.rm_rf!(dir)
+    end
+
+    test "a machine with no proc is a reading of its own, not a crash" do
+      dir = Path.join(System.tmp_dir!(), "top-no-proc-#{System.unique_integer([:positive])}")
+      {:ok, pid} = Top.start_link(kind: :os, proc: dir, refresh_ms: 60_000)
+
+      snapshot = Top.snapshot()
+      assert snapshot.error == :enoent
+      assert snapshot.rows == []
+
+      assert %Scenic.Graph{} = Scene.graph(snapshot)
+
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "the panel" do
+    setup do
+      start_supervised!({Top, kind: :beam, refresh_ms: 60_000})
+      :ok
+    end
+
+    test "every snapshot builds a graph, including the app not running" do
+      assert %Scenic.Graph{} = Scene.graph(:stopped)
+      assert %Scenic.Graph{} = Scene.graph(:stopped, :eusers)
+      assert %Scenic.Graph{} = Scene.graph(Top.snapshot())
+      assert %Scenic.Graph{} = Scene.graph(press(@y))
+    end
+
+    test "nothing is drawn in the strip reserved for the shared top bar" do
+      for {y, primitive} <- placements(Scene.graph(Top.snapshot())) do
+        assert y >= Scene.status_bar(),
+               "#{inspect(primitive)} is at y=#{y}, inside the top #{Scene.status_bar()} px"
+      end
+    end
+
+    test "the table says where in the list the window sits" do
+      press(@down)
+      words = texts(Scene.graph(Top.snapshot()))
+
+      assert Enum.any?(words, &String.match?(&1, ~r/^2–17 of \d+, by reductions$/))
+    end
+
+    test "the header line carries the VM's own numbers" do
+      words = texts(Scene.graph(Top.snapshot()))
+
+      assert Enum.any?(words, &String.contains?(&1, "run queue"))
+    end
+
+    defp texts(graph) do
+      Scenic.Graph.reduce(graph, [], fn
+        %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+        _primitive, acc -> acc
+      end)
+    end
+
+    # Every primitive's y, except the full-screen background: the status bar
+    # paints over that, and a screen with no background is not a screen.
+    defp placements(graph) do
+      Scenic.Graph.reduce(graph, [], fn
+        %Scenic.Primitive{data: {640, 480}}, acc ->
+          acc
+
+        %Scenic.Primitive{} = primitive, acc ->
+          case get_in(primitive.transforms, [:translate]) do
+            {_x, y} -> [{y, primitive.module} | acc]
+            _none -> acc
+          end
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Two new launcher rows, BEAM processes and OS processes, showing a scrollable, sortable `top`-style table on the panel. Flashed and verified on the device: both screens render real data (574 VM processes; 139 OS processes off `/proc`), scroll and sort work, and the full suite passes on the host.

## Approach
One app serves both rows via the `{module, arg}` menu shape the pickles already use, since the screens differ only in their sampler. The activity column is a delta between refreshes on both screens — reductions for the VM (etop's trick), jiffies-per-core for the OS — because neither world exposes "busy right now" in a single reading; the first frame shows `--` rather than dressing a since-boot total up as a rate. The OS sampler reads `/proc` directly (no ps/top in the image) with the proc path injectable, which is what lets the host suite exercise the whole OS screen from a fixture on a machine that has no procfs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)