### PR TITLE
Turn the launcher into a NeXTSTEP-style column browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ Software:
 - Sleep on the power button: the backlight goes off and any button brings it
   back. Not suspend — this board's only suspend mode would save almost
   nothing, and `MayonnaiOS.Sleep`'s moduledoc has the analysis
-- Orderly power off: the Select+Menu chord, or the **Power off** row at the
-  bottom of the menu
+- A NeXTSTEP-style column launcher: Games, Files, Pickles and Settings open
+  as columns, Y cycles between 1, 2 and 3 of them on screen, and Files
+  browses both cards in place
+- Orderly power off: the Select+Menu chord, or the **Power off** row under
+  Settings
 
 ## Building and flashing
 
@@ -104,8 +107,8 @@ firmware and install the same way games do:
 
 What a pickle can touch is declared in its manifest and enforced by the
 sandbox: HTTP, the local network, a small persistent store, timers, the
-panel — and nothing else. A pickle with the `ui` capability appears on the
-launcher menu and draws on the screen; the others run headless.
+panel — and nothing else. A pickle with the `ui` capability appears in the
+launcher's Pickles column and draws on the screen; the others run headless.
 [docs/pickles.md](docs/pickles.md) is the guide to writing one; the
 `pickle` Claude skill in `.claude/skills/` automates the whole
 develop-and-deploy loop.

--- a/docs/pickles.md
+++ b/docs/pickles.md
@@ -121,7 +121,8 @@ be retried, and a repeating log line is a report.
 
 ### `"ui"` -- a face on the panel
 
-A pickle with `ui` appears as a row on the launcher menu. Pressing A puts
+A pickle with `ui` appears as a row in the launcher's Pickles column.
+Pressing A puts
 its face on the screen; Menu takes the face off -- **the pickle keeps
 running** either way, because a ui pickle is still a background app, just
 one you can look at.

--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -1,0 +1,317 @@
+defmodule MayonnaiOS.Browser do
+  @moduledoc """
+  The launcher's menu as a column browser: a stack of levels, NeXTSTEP-style,
+  where the first column is the categories and every descent opens another
+  column to the right.
+
+  A pure data structure with no process. `MayonnaiOS.Launcher` holds one of
+  these in its own state -- the same place the flat cursor used to live, and
+  for the same two reasons: input only reaches Elixir through the device the
+  Launcher holds open, and `Scenic.ViewPort.set_root/3` restarts the scene on
+  every repaint, so anything a scene remembered would be gone the moment a
+  program exited. `MayonnaiOS.Scene.Home` draws whatever this module returns
+  and owns nothing.
+
+  ## The tree
+
+  The root column is fixed: Games, Files, Pickles, Settings. What each one
+  contains is classified out of the one `config :mayonnaios, :programs` list
+  the launcher already reads, so a row added to config appears in the right
+  column with no code change here:
+
+    * a `:path` entry is a game or program to run -- **Games**
+    * a pickle's row (`{MayonnaiOS.Pickles.App, name}`) -- **Pickles**
+    * the file manager app -- the first row of **Files**, above the roots
+    * any other app, and every `:action` -- **Settings**
+
+  Settings also carries two rows of the launcher's own, Diagnostics and
+  Sleep, so the things the device can do to itself are on the menu rather
+  than only on chords someone has to be told about. The chords still work;
+  `MayonnaiOS.Launcher` owns what every verb does, this module only names
+  them.
+
+  ## Files is the same tree, continued
+
+  Descending into Files lists the roots `MayonnaiOS.Files.places/0` offers,
+  and descending into a root just keeps browsing: every directory is another
+  column. All of it goes through `MayonnaiOS.Files` locations -- a root key
+  plus checked names -- so this module never assembles a path, and nothing
+  outside the configured roots is reachable from the panel. Browsing here is
+  looking; the file manager app (the first row of the column) is where
+  delete, rename, copy and move live, with their confirmations.
+
+  A directory is read once, when its column is opened. The listing is a
+  snapshot: cheap to move a cursor over, and refreshed by closing and
+  reopening the column rather than by re-reading the disk on every press.
+
+  ## Columns are a view setting, not a place
+
+  `columns` says how many of the deepest levels the panel draws -- 1, 2 or 3
+  -- and `cycle_columns/1` steps through them. It changes nothing about where
+  the cursor is: the model is always the full stack, and the scene shows the
+  tail of it.
+  """
+
+  alias MayonnaiOS.{Files, Pickles, Programs}
+
+  @typedoc "One entry in a column."
+  @type node_ :: %{
+          required(:kind) => :category | :place | :dir | :file | :program,
+          required(:name) => String.t(),
+          optional(atom()) => term()
+        }
+
+  @typedoc "One column: what it lists and which row is selected."
+  @type level :: %{
+          title: String.t(),
+          entries: [node_()],
+          cursor: non_neg_integer(),
+          note: String.t() | nil
+        }
+
+  @typedoc "The whole browser: a stack of levels and how many to draw."
+  @type t :: %{levels: [level()], columns: 1..3}
+
+  # The visible-column settings the shortcut cycles through, in order.
+  @column_settings [1, 2, 3]
+
+  @doc """
+  A fresh browser: the root column, cursor on the first category.
+
+  Reads nothing off the disk -- the root column is fixed -- so it is safe to
+  build at boot, before anything is mounted.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    %{levels: [root_level()], columns: Keyword.get(opts, :columns, 2)}
+  end
+
+  @doc "How many levels are open."
+  @spec depth(t()) :: pos_integer()
+  def depth(%{levels: levels}), do: length(levels)
+
+  @doc "The node the cursor is on, or `nil` in an empty column."
+  @spec selected(t()) :: node_() | nil
+  def selected(%{levels: levels}) do
+    %{entries: entries, cursor: cursor} = List.last(levels)
+    Enum.at(entries, cursor)
+  end
+
+  @doc """
+  Move the cursor in the deepest column, wrapping at both ends.
+
+  Wrapping rather than clamping because the D-pad is the only way to move:
+  the last row of a long column is one press up from the first.
+  """
+  @spec move(t(), integer()) :: t()
+  def move(%{levels: levels} = browser, delta) do
+    %{entries: entries, cursor: cursor} = level = List.last(levels)
+
+    case length(entries) do
+      0 -> browser
+      count -> put_last(browser, %{level | cursor: Integer.mod(cursor + delta, count)})
+    end
+  end
+
+  @doc """
+  Whether descending into this node opens another column.
+
+  The other kinds are leaves: a program is launched, a file is only named.
+  """
+  @spec expandable?(node_() | nil) :: boolean()
+  def expandable?(%{kind: kind}), do: kind in [:category, :place, :dir]
+  def expandable?(nil), do: false
+
+  @doc """
+  Open the selected node as a new column.
+
+  A leaf, or an empty column, leaves the browser unchanged -- the caller can
+  compare and skip the repaint. This is the one function that reads the disk:
+  a place or a directory is listed here, once, and the listing becomes the
+  new column.
+  """
+  @spec descend(t()) :: t()
+  def descend(%{levels: levels} = browser) do
+    node = selected(browser)
+
+    if expandable?(node) do
+      %{browser | levels: levels ++ [expand(node)]}
+    else
+      browser
+    end
+  end
+
+  @doc "Close the deepest column. At the root there is nothing to close."
+  @spec ascend(t()) :: t()
+  def ascend(%{levels: [_root]} = browser), do: browser
+  def ascend(%{levels: levels} = browser), do: %{browser | levels: Enum.drop(levels, -1)}
+
+  @doc "Back to the root column, keeping the column-count setting."
+  @spec reset(t()) :: t()
+  def reset(browser), do: %{browser | levels: [root_level()]}
+
+  @doc "The next visible-column setting: 1, 2, 3, and round again."
+  @spec cycle_columns(t()) :: t()
+  def cycle_columns(%{columns: columns} = browser) do
+    index = Enum.find_index(@column_settings, &(&1 == columns)) || 1
+
+    %{
+      browser
+      | columns: Enum.at(@column_settings, Integer.mod(index + 1, length(@column_settings)))
+    }
+  end
+
+  @doc """
+  The levels the panel should draw: the deepest ones, at most `columns`.
+
+  The head of the result is the leftmost column and the last is the focused
+  one -- the only one whose cursor the D-pad moves.
+  """
+  @spec visible(t()) :: [level()]
+  def visible(%{levels: levels, columns: columns}) do
+    Enum.take(levels, -min(columns, length(levels)))
+  end
+
+  @doc """
+  The titles of every open level, root first, for the breadcrumb line.
+
+  The panel draws all of them even when only the deepest columns fit, so a
+  one-column view still says where it is.
+  """
+  @spec trail(t()) :: [String.t()]
+  def trail(%{levels: levels}), do: Enum.map(levels, & &1.title)
+
+  defp put_last(%{levels: levels} = browser, level) do
+    %{browser | levels: List.replace_at(levels, -1, level)}
+  end
+
+  # -- the tree ---------------------------------------------------------------
+
+  defp root_level do
+    %{
+      title: "RG40XXV",
+      cursor: 0,
+      note: nil,
+      entries: [
+        %{kind: :category, id: :games, name: "Games"},
+        %{kind: :category, id: :files, name: "Files"},
+        %{kind: :category, id: :pickles, name: "Pickles"},
+        %{kind: :category, id: :settings, name: "Settings"}
+      ]
+    }
+  end
+
+  defp expand(%{kind: :category, id: id, name: name}), do: category_level(id, name)
+  defp expand(%{kind: :place} = node), do: place_level(node)
+  defp expand(%{kind: :dir} = node), do: dir_level(node)
+
+  defp category_level(:games, name) do
+    rows = for program <- classified(:games), do: program_node(program)
+    level(name, rows, "Nothing to run. Install a bundle, or check the config.")
+  end
+
+  defp category_level(:pickles, name) do
+    rows = for program <- classified(:pickles), do: program_node(program)
+    level(name, rows, "No pickles installed.")
+  end
+
+  defp category_level(:files, name) do
+    manager = for program <- classified(:files), do: program_node(program)
+    places = for place <- Files.places(), do: place_node(place)
+    level(name, manager ++ places, "No roots configured.")
+  end
+
+  defp category_level(:settings, name) do
+    {actions, apps} = Enum.split_with(classified(:settings), &(&1.action != nil))
+
+    rows =
+      Enum.map(apps, &program_node/1) ++
+        [
+          program_node(builtin("Diagnostics", :diagnostics)),
+          program_node(builtin("Sleep", :sleep))
+        ] ++
+        Enum.map(actions, &program_node/1)
+
+    level(name, rows, nil)
+  end
+
+  # The one config list, classified. `Programs.list/0` already appends the
+  # installed pickles' rows, which is what makes the Pickles column honest:
+  # it shows what is on the disk now, not what config promised.
+  defp classified(category) do
+    Enum.filter(Programs.list(), &(classify(&1) == category))
+  end
+
+  defp classify(%{action: action}) when action != nil, do: :settings
+  defp classify(%{app: {Pickles.App, _name}}), do: :pickles
+  defp classify(%{app: MayonnaiOS.FileManager}), do: :files
+  defp classify(%{app: app}) when app != nil, do: :settings
+  defp classify(_program), do: :games
+
+  # A verb of the launcher's own, shaped like a config row so the launcher's
+  # `start_program/2` needs no second vocabulary for it.
+  defp builtin(name, action) do
+    %{
+      name: name,
+      path: nil,
+      app: nil,
+      action: action,
+      args: [],
+      needs_udev: false,
+      installed?: true
+    }
+  end
+
+  defp program_node(program) do
+    %{kind: :program, name: program.name, program: program}
+  end
+
+  defp place_node(place) do
+    %{kind: :place, name: place.path, key: place.key, note: place.note}
+  end
+
+  defp place_level(%{key: key, name: name}) do
+    case Files.at(key) do
+      {:ok, location} -> listing_level(name, location)
+      {:error, reason} -> level(name, [], "cannot be opened: #{why(reason)}")
+    end
+  end
+
+  defp dir_level(%{name: name, location: location}), do: listing_level(name, location)
+
+  # A directory that cannot be read is a column to draw, not an error to
+  # raise: the games card's root does not exist with the card out, and the
+  # panel should say so where the listing would have been.
+  defp listing_level(title, location) do
+    case Files.list(location) do
+      {:ok, entries} ->
+        level(title, Enum.map(entries, &entry_node(location, &1)), "Empty.")
+
+      {:error, reason} ->
+        level(title, [], "cannot be read: #{why(reason)}")
+    end
+  end
+
+  # A directory entry becomes a column entry. The child location is built
+  # here, through the same checked constructor everything else uses -- a name
+  # the boundary refuses (it happens: a name can exceed the length cap) stays
+  # visible but is a leaf, so it can be seen and not entered.
+  defp entry_node(location, %{type: :directory, name: name} = entry) do
+    case Files.descend(location, name) do
+      {:ok, child} -> %{kind: :dir, name: name, location: child, entry: entry}
+      {:error, _reason} -> %{kind: :file, name: name, entry: entry}
+    end
+  end
+
+  defp entry_node(_location, %{name: name} = entry) do
+    %{kind: :file, name: name, entry: entry}
+  end
+
+  defp level(title, entries, empty_note) do
+    %{title: title, entries: entries, cursor: 0, note: if(entries == [], do: empty_note)}
+  end
+
+  # The same words the file manager uses for the same failures, because the
+  # two screens describe the same disk.
+  defp why(reason), do: MayonnaiOS.FileManager.why(reason)
+end

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -81,13 +81,17 @@ defmodule MayonnaiOS.Launcher do
 
   ## The full set of bindings
 
-      D-pad up/down move the menu cursor
-      A             launch the selected program
-      Menu          go back to the home screen
-      X             switch between the menu and diagnostics
-      Y             answer the Power off row's question, and nothing else
-      Power         sleep -- backlight off, and any press wakes it
-      Select+Menu   power off
+      D-pad up/down   move the cursor in the focused column
+      D-pad right     open the selected entry as another column
+      D-pad left      close a column
+      A               open the selected entry, or launch it
+      B               close a column; first, clear an obituary
+      Y               cycle how many columns are drawn -- 1, 2, 3 -- and
+                      answer the Power off row's question while it is asked
+      Menu            go back to the home screen, at its root column
+      X               switch between the menu and diagnostics
+      Power           sleep -- backlight off, and any press wakes it
+      Select+Menu     power off
 
   These are the buttons as printed on the shell. Two of the atoms above name
   the opposite button; see the note on the attributes below.
@@ -151,12 +155,14 @@ defmodule MayonnaiOS.Launcher do
   `MayonnaiOS.Diagnostics` owns the rocker and the jack for the same reason in
   reverse.
 
-  ## Where the menu lives, and why the cursor is here
+  ## Where the menu lives, and why the browser is here
 
-  The list of programs comes from `MayonnaiOS.Programs`, which reads
-  `config :mayonnaios, :programs`. The *cursor* -- which entry is
-  selected -- is state in this process rather than in the scene, for two
-  reasons that are both about how this device is put together.
+  The home screen is a column browser -- `MayonnaiOS.Browser`, whose root
+  column is the categories and whose deeper columns are whatever was opened:
+  games, pickles, settings, or the file tree. The browser -- which columns
+  are open and which row each cursor is on -- is state in this process rather
+  than in the scene, for two reasons that are both about how this device is
+  put together.
 
   First, the cairo-fb driver delivers no input. The gamepad reaches Elixir
   only through `InputEvent` on the `gpio-keys-gamepad` node, which this
@@ -169,14 +175,14 @@ defmodule MayonnaiOS.Launcher do
   top every time someone came back from a game -- the one moment it most
   obviously should not.
 
-  So the cursor is pushed *into* the scene as the `set_root/3` argument, and
-  the scene renders it. The scene reads the program list itself.
+  So the browser is pushed *into* the scene as the `set_root/3` argument, and
+  the scene renders it and owns nothing.
   """
 
   use GenServer
   require Logger
 
-  alias MayonnaiOS.{Input, Panel, Programs, Sleep}
+  alias MayonnaiOS.{Browser, Input, Panel, Sleep}
 
   # The name the driver gives the gamepad, which is the only thing this module
   # knows about which device it is. There is no numbered fallback: /dev/input
@@ -204,12 +210,13 @@ defmodule MayonnaiOS.Launcher do
   #
   # So :btn_y below really is the X button.
   #
-  # Y (:btn_x) has no plain binding. A key on a handheld that makes a noise
-  # when pressed by accident is not worth spending on a check that belongs in
-  # IEx (`MayonnaiOS.Audio.run/0`). Its one job is answering the Power off
-  # row's question -- the same "Y is the second verb" it has in
-  # `MayonnaiOS.Files`, and only while the question is on the panel.
+  # Y (:btn_x) has two jobs, and the panel says which is on. While the Power
+  # off row's question is up it is the answer -- the same "Y is the second
+  # verb" it has in `MayonnaiOS.Files`, and the confirming clause is tested
+  # before the plain bindings so the two can never fire together. The rest of
+  # the time it cycles how many columns the browser draws: 1, 2, 3.
   @confirm_button :btn_x
+  @columns_button :btn_x
   @diagnostics_button :btn_y
 
   # Menu, doing double duty: alone it is the way back to the home screen,
@@ -226,6 +233,12 @@ defmodule MayonnaiOS.Launcher do
   # immediately instead of leaving a menu that scrolls the wrong way.
   @up_button :btn_dpad_up
   @down_button :btn_dpad_down
+
+  # Left and right walk the columns: right opens the selected entry as a new
+  # column and left closes one. Right never launches -- A is the button that
+  # commits -- so walking the tree with the directions cannot start a game.
+  @left_button :btn_dpad_left
+  @right_button :btn_dpad_right
 
   # Physical B, which is BTN_SOUTH and therefore InputEvent's :btn_a -- the
   # table at the top of this module is the authority. Bound only to clear the
@@ -276,7 +289,8 @@ defmodule MayonnaiOS.Launcher do
   def os_pid, do: GenServer.call(__MODULE__, :os_pid)
 
   @doc """
-  Start or stop it from a console, without pressing anything.
+  Press A from a console, without pressing anything: open the selected
+  entry as a column, or launch it.
 
   `stop_program/0` returns `:ok` only when the OS process is confirmed gone.
   A program that survives both SIGTERM and SIGKILL comes back as
@@ -292,7 +306,7 @@ defmodule MayonnaiOS.Launcher do
   def stop_program(timeout \\ 10_000), do: GenServer.call(__MODULE__, :stop, timeout)
 
   @doc """
-  The index of the highlighted menu entry.
+  The index of the highlighted row in the focused column.
 
   Exposed so a console -- or a test that has just injected a synthetic D-pad
   event -- can read the cursor without looking at the panel. There is
@@ -300,6 +314,11 @@ defmodule MayonnaiOS.Launcher do
   which is the part worth testing.
   """
   def selected, do: GenServer.call(__MODULE__, :selected)
+
+  @doc """
+  The whole column browser, for a console: every open level and its cursor.
+  """
+  def browser, do: GenServer.call(__MODULE__, :browser)
 
   @doc """
   Why the last program died, or nil.
@@ -408,7 +427,10 @@ defmodule MayonnaiOS.Launcher do
       running: nil,
       held: MapSet.new(),
       scene: :home,
-      selected: 0,
+      # The home screen's column browser: which columns are open, which row
+      # each cursor is on, and how many columns the panel draws. Here rather
+      # than in the scene so it survives every repaint; see the moduledoc.
+      browser: Browser.new(),
       # Whether the Power off row has asked its question and is waiting for
       # Y. Armed by `start_program/2`, answered or dismissed by `press/2`,
       # and never true while anything is running -- the row can only be
@@ -472,7 +494,11 @@ defmodule MayonnaiOS.Launcher do
     {:reply, result, state}
   end
 
-  def handle_call(:selected, _from, state), do: {:reply, state.selected, state}
+  def handle_call(:selected, _from, state) do
+    {:reply, List.last(state.browser.levels).cursor, state}
+  end
+
+  def handle_call(:browser, _from, state), do: {:reply, state.browser, state}
 
   def handle_call(:obituary, _from, state), do: {:reply, state.obituary, state}
   def handle_call(:asleep?, _from, state), do: {:reply, state.asleep, state}
@@ -763,7 +789,10 @@ defmodule MayonnaiOS.Launcher do
   defp bound(state, @diagnostics_button), do: toggle_scene(state)
   defp bound(state, @up_button), do: move(state, -1)
   defp bound(state, @down_button), do: move(state, +1)
-  defp bound(state, @back_button), do: dismiss_obituary(state)
+  defp bound(state, @left_button), do: browse(state, Browser.ascend(state.browser))
+  defp bound(state, @right_button), do: browse(state, Browser.descend(state.browser))
+  defp bound(state, @columns_button), do: browse(state, Browser.cycle_columns(state.browser))
+  defp bound(state, @back_button), do: back(state)
 
   # Menu: back to the home screen, or -- with Select held -- power off.
   #
@@ -787,16 +816,17 @@ defmodule MayonnaiOS.Launcher do
     state
   end
 
-  # B takes the obituary off the panel. Only that: with nothing to clear the
-  # button stays effectively unbound, so an idle B press does not tear down
-  # and rebuild the scene the way an unguarded repaint would.
-  #
-  # The repaint is gated the same way `move/2` gates its own: only when the
-  # menu is the thing on screen. A B pressed during a game reaches here (the
-  # pad is this process's), and the state clears either way -- only the write
-  # waits, and the exit-time repaint draws whatever the state then says.
-  defp dismiss_obituary(%{obituary: nil} = state), do: state
+  # B: the obituary goes first -- it is the thing most recently put on the
+  # panel, and "back" should take back the last thing shown. With nothing to
+  # clear, B closes a column, which is what B means on every other screen.
+  defp back(%{obituary: nil} = state), do: browse(state, Browser.ascend(state.browser))
+  defp back(state), do: dismiss_obituary(state)
 
+  # Takes the obituary off the panel. The repaint is gated the same way
+  # `browse/2` gates its own: only when the menu is the thing on screen. A B
+  # pressed during a game reaches here (the pad is this process's), and the
+  # state clears either way -- only the write waits, and the exit-time repaint
+  # draws whatever the state then says.
   defp dismiss_obituary(state) do
     state = %{state | obituary: nil}
 
@@ -807,37 +837,38 @@ defmodule MayonnaiOS.Launcher do
     state
   end
 
-  # Move the menu cursor. The list is re-read here rather than kept in state:
-  # it is deterministic, cheap, and there is then no way for the cursor to be
-  # bounded by a stale length.
-  defp move(state, delta) do
-    programs = Programs.list()
-    moved = Programs.step(programs, state.selected, delta)
+  defp move(state, delta), do: browse(state, Browser.move(state.browser, delta))
 
-    # Repaint only when the menu is actually the thing on screen. While an
-    # external program is running it owns KMS, and pushing the viewport would
-    # write the menu into /dev/fb0 underneath its output -- visible as the
-    # menu bleeding through a game. On the diagnostics screen the cursor is
-    # not drawn at all, so a repaint there would be pure cost. The cursor
-    # still moves in both cases; only the redraw waits.
-    #
-    # The program half of that is now also enforced one level down --
-    # `set_root/2` refuses while `MayonnaiOS.Panel` is held, which is what
-    # catches the buttons this clause does not. It stays here because the
-    # diagnostics half is this function's own business and because a guard
-    # that says why it exists is worth more than one line saved.
-    #
-    # And only when the cursor actually moved. `set_root/3` is not a redraw:
-    # it stops the running scene process and starts a new one. At the ends of
-    # the list -- and with the single-entry list this ships with, on every
-    # press -- `step/3` returns the index it was given, so without this guard
-    # holding down a direction would tear down and rebuild the scene at the
-    # repeat rate for no visible change.
-    if moved != state.selected and state.port == nil and state.scene == :home do
-      show(:home, %{state | selected: moved})
+  # Adopt a changed browser, and repaint only when the menu is actually the
+  # thing on screen. While an external program is running it owns KMS, and
+  # pushing the viewport would write the menu into /dev/fb0 underneath its
+  # output -- visible as the menu bleeding through a game. On the diagnostics
+  # screen the browser is not drawn at all, so a repaint there would be pure
+  # cost. The state still moves in both cases; only the redraw waits.
+  #
+  # The program half of that is also enforced one level down -- `set_root/2`
+  # refuses while `MayonnaiOS.Panel` is held, which is what catches the
+  # buttons this clause does not. It stays here because the diagnostics half
+  # is this function's own business and because a guard that says why it
+  # exists is worth more than one line saved.
+  #
+  # And only when something actually changed. `set_root/3` is not a redraw:
+  # it stops the running scene process and starts a new one. A move in an
+  # empty column, a descend on a leaf and an ascend at the root all return
+  # the browser they were given, so an idle press does not tear down and
+  # rebuild the scene for no visible change.
+  defp browse(state, browser) do
+    if browser == state.browser do
+      state
+    else
+      state = %{state | browser: browser}
+
+      if state.port == nil and state.scene == :home do
+        show(:home, state)
+      end
+
+      state
     end
-
-    %{state | selected: moved}
   end
 
   # Back to the menu, from wherever we are.
@@ -862,12 +893,14 @@ defmodule MayonnaiOS.Launcher do
         show(:home, home)
         home
 
-      # Already home with nothing running. Deliberately not a repaint: this is
-      # the button people press when unsure, and `set_root/3` tears the scene
-      # down and builds a new one, so answering an idle press with a rebuild
-      # would make the panel flicker for no reason.
+      # Already home with nothing running: back to the root column. This is
+      # the button people press to get out of wherever they are, and deep in
+      # the file tree that is the top of the menu, not one column up. When the
+      # browser is already at its root the reset changes nothing and nothing
+      # repaints -- `browse/2` is the guard -- so an idle press does not make
+      # the panel flicker.
       true ->
-        state
+        browse(state, Browser.reset(state.browser))
     end
   end
 
@@ -897,21 +930,22 @@ defmodule MayonnaiOS.Launcher do
     state
   end
 
-  # Three outcomes, logged apart from each other on purpose. "Nothing
-  # configured" and "configured but not in the image" are different bugs in
-  # different files, and a single "could not launch" would hide which.
+  # A on the browser: a category, a root or a directory opens as another
+  # column; a program, a pickle or a verb starts. A plain file is the one
+  # kind of leaf with nothing to start, and A on it does nothing -- the file
+  # manager app at the top of the Files column is where files are acted on.
   defp do_launch(%{port: nil, app: nil} = state) do
-    programs = Programs.list()
-    start_program(Programs.at(programs, state.selected), state)
+    node = Browser.selected(state.browser)
+
+    cond do
+      Browser.expandable?(node) -> browse(state, Browser.descend(state.browser))
+      match?(%{kind: :program}, node) -> start_program(node.program, state)
+      true -> state
+    end
   end
 
   defp do_launch(state) do
     Logger.info("[launcher] already running")
-    state
-  end
-
-  defp start_program(nil, state) do
-    Logger.warning("[launcher] no programs configured (config :mayonnaios, :programs)")
     state
   end
 
@@ -927,6 +961,21 @@ defmodule MayonnaiOS.Launcher do
   defp start_program(%{action: :poweroff}, state) do
     state = %{state | confirming: true}
     show(:home, state)
+    state
+  end
+
+  # The Diagnostics row: the same screen X toggles, on the menu so it can be
+  # found without being told about the button.
+  defp start_program(%{action: :diagnostics}, state) do
+    state = %{state | scene: :diagnostics}
+    show(:diagnostics, state)
+    state
+  end
+
+  # The Sleep row: the same backlight-off the power key does, and waking is
+  # unchanged -- the next press is consumed on turning the panel back on.
+  defp start_program(%{action: :sleep}, state) do
+    {_result, state} = enter_sleep(state)
     state
   end
 
@@ -1200,13 +1249,12 @@ defmodule MayonnaiOS.Launcher do
   # in the ordinary case.
   defp show({:app, app}, state), do: set_root(app_module(app).scene(), %{error: state.app_error})
 
-  # The cursor travels as the scene's start argument. Deliberately only the
-  # index: the scene calls `Programs.list/0` itself, so no list is copied into
-  # a scene start on every keypress, and the two cannot disagree about order
-  # because both derive from the same config.
+  # The browser travels as the scene's start argument, whole: the scene draws
+  # exactly the columns this process navigates, and the two cannot disagree
+  # because there is one copy and it is here.
   defp show(_home, state) do
     set_root(default_scene(), %{
-      selected: state.selected,
+      browser: state.browser,
       confirming: state.confirming,
       obituary: state.obituary
     })

--- a/lib/mayonnaios/pairing.ex
+++ b/lib/mayonnaios/pairing.ex
@@ -149,8 +149,7 @@ defmodule MayonnaiOS.Pairing do
         scan: Scanner.status(),
         devices: Scanner.devices(),
         bonds: bonds,
-        # Bounded here rather than trusted, for the same reason
-        # `MayonnaiOS.Programs.at/2` does it: the list is re-read on every
+        # Bounded here rather than trusted: the list is re-read on every
         # refresh and a bond forgotten a moment ago would otherwise leave the
         # cursor pointing past the end.
         selected: bounded(cursor.selected, length(bonds)),

--- a/lib/mayonnaios/programs.ex
+++ b/lib/mayonnaios/programs.ex
@@ -66,29 +66,6 @@ defmodule MayonnaiOS.Programs do
     _ -> []
   end
 
-  @doc """
-  The program at `index`, or `nil` when nothing is configured.
-
-  The index is taken modulo the list length rather than trusted. The cursor
-  lives in the Launcher and the list is re-read on every use, so a config
-  that lost an entry (or a firmware update that shortened it) would otherwise
-  leave the cursor pointing past the end and make A do nothing at all.
-  """
-  @spec at([program()], integer()) :: program() | nil
-  def at([], _index), do: nil
-  def at(programs, index), do: Enum.at(programs, Integer.mod(index, length(programs)))
-
-  @doc """
-  Move the cursor by `delta`, wrapping at both ends.
-
-  Wrapping rather than clamping because the D-pad is the only way to move:
-  with six entries, reaching the last one from the first is one press up
-  instead of five presses down.
-  """
-  @spec step([program()], integer(), integer()) :: non_neg_integer()
-  def step([], _index, _delta), do: 0
-  def step(programs, index, delta), do: Integer.mod(index + delta, length(programs))
-
   defp normalize(entry) when is_list(entry), do: entry |> Map.new() |> normalize()
 
   # A pickle's row: the app module is shared and the argument names which

--- a/lib/mayonnaios/scene/file_manager.ex
+++ b/lib/mayonnaios/scene/file_manager.ex
@@ -6,7 +6,7 @@ defmodule MayonnaiOS.Scene.FileManager do
   its own, no listing of its own, no path of its own. `set_root/3` terminates
   a scene and starts a new one on every repaint the launcher does, so anything
   remembered here would be lost at the first opportunity -- the same reason
-  `MayonnaiOS.Scene.Home` takes its cursor as a start argument.
+  `MayonnaiOS.Scene.Home` takes its column browser as a start argument.
 
   It is told when to redraw rather than polling for it. `FileManager.watch/1`
   registers this process, and a snapshot arrives as `{:file_manager, snapshot}`

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -1,40 +1,51 @@
 defmodule MayonnaiOS.Scene.Home do
   @moduledoc """
-  The launcher menu: what can be run, and which entry is selected.
+  The home screen: the column browser, drawn NeXTSTEP-style.
 
-  ## Where the selection comes from
+  ## Where the columns come from
 
-  This scene renders the cursor, it does not own it. `MayonnaiOS.Launcher`
-  owns the gamepad and therefore the D-pad, and it passes the selected index in
-  as the scene's start argument. That has to be the direction of travel:
-  `Scenic.ViewPort.set_root/3` terminates this process and starts a new one on
-  every repaint, so anything this scene remembered would be lost the moment a
-  program exited.
+  This scene renders `MayonnaiOS.Browser` and owns none of it.
+  `MayonnaiOS.Launcher` owns the gamepad and therefore every cursor, and it
+  passes the whole browser in as the scene's start argument. That has to be
+  the direction of travel: `Scenic.ViewPort.set_root/3` terminates this
+  process and starts a new one on every repaint, so anything this scene
+  remembered would be lost the moment a program exited.
 
-  The list itself is read here from `MayonnaiOS.Programs`, the same
-  deterministic source the Launcher indexes into, so the row highlighted on
-  screen is the row A will start.
+  ## What the panel shows
+
+  The breadcrumb line names every open level even when only the deepest
+  columns fit on the panel, so a one-column view still says where it is.
+  Below it, the last one, two or three levels -- the browser's `columns`
+  setting, cycled with Y -- drawn side by side. The cursor lives in the
+  rightmost column; in the columns left of it the highlighted row is the one
+  that is open, which is how a column browser shows where you came from.
+
+  The footer names the buttons, because a handheld has no tooltips: the same
+  rule as `MayonnaiOS.Scene.FileManager`, and the same bottom line carries
+  the power-off question and a program's obituary when there is one -- the
+  panel asking or reporting outranks it labelling.
   """
 
   use Scenic.Scene
 
-  alias Scenic.Graph
-  alias MayonnaiOS.Programs
+  alias MayonnaiOS.Browser
   alias MayonnaiOS.Scene.StatusBar
+  alias Scenic.Graph
   import Scenic.Primitives
 
   @width 640
   @height 480
 
   # The shared top bar owns the top of the panel on every screen, so this one
-  # starts its title below it rather than at the top edge. The height comes
-  # from the bar rather than being copied, so moving it moves every screen.
+  # starts its breadcrumb below it rather than at the top edge. The height
+  # comes from the bar rather than being copied, so moving it moves every
+  # screen.
   @status_bar StatusBar.height()
   @title_y @status_bar + 20
   @rule_y @status_bar + 30
 
-  # Same palette as MayonnaiOS.Scene.Diagnostics, so the two screens read
-  # as one device rather than two programs that happen to share a panel.
+  # Same palette as MayonnaiOS.Scene.Diagnostics and Scene.FileManager, so
+  # the screens read as one device rather than three programs sharing a panel.
   @bg {12, 14, 22}
   @title {235, 238, 245}
   @head {90, 170, 255}
@@ -43,21 +54,30 @@ defmodule MayonnaiOS.Scene.Home do
   @dim {110, 125, 155}
   @row_bg {26, 34, 52}
 
-  # 34 px of pitch at font_size 20 leaves the rows legible at arm's length on
-  # a 640x480 panel held in two hands. Ten rows from 86 end at 426, clear of
-  # the bottom of the panel.
-  @top 86
-  @pitch 34
+  # The column area: captions first, rows below, ten to a column. Ten rows of
+  # 26 px pitch end well clear of the message lines and the footer, which is
+  # where the power-off question and an obituary go.
+  @top @rule_y + 16
+  @caption_y @top + 10
+  @rows_top @top + 20
+  @pitch 26
   @visible 10
+
+  @left 20
+  @span @width - 40
+  @gutter 12
+
+  @footer_rule 430
+  @footer_y 452
 
   @impl Scenic.Scene
   def init(scene, param, _opts) do
     # The boot root comes from `default_scene:` in config, which Scenic starts
     # with a nil param -- only the Launcher's own set_root/3 passes the map.
-    selected =
+    browser =
       case param do
-        %{selected: i} when is_integer(i) -> i
-        _ -> 0
+        %{browser: %{levels: _} = browser} -> browser
+        _ -> Browser.new()
       end
 
     confirming = match?(%{confirming: true}, param)
@@ -68,73 +88,224 @@ defmodule MayonnaiOS.Scene.Home do
         _ -> nil
       end
 
-    {:ok, push_graph(scene, graph(Programs.list(), selected, confirming, obituary))}
+    {:ok, push_graph(scene, graph(browser, confirming, obituary))}
   end
 
   @doc """
-  Build the menu graph for `programs` with row `selected` highlighted.
+  Build the column graph for a browser.
 
   Public because it is the tested surface: it needs no viewport, no driver
-  and no framebuffer, so the host test can assert that a menu builds for an
-  empty list, one entry, and a selection at the last index -- the three
-  shapes that would otherwise only be found by looking at the device.
+  and no framebuffer, so a host test can assert what the panel says for the
+  root column, a deep descent, each column-count setting, the power-off
+  question and an obituary -- the shapes that would otherwise only be found
+  by looking at the device.
   """
-  @spec graph([Programs.program()], integer(), boolean(), map() | nil) :: Scenic.Graph.t()
-  def graph(programs, selected \\ 0, confirming \\ false, obituary \\ nil)
-
-  def graph([], _selected, _confirming, _obituary) do
+  @spec graph(Browser.t(), boolean(), map() | nil) :: Scenic.Graph.t()
+  def graph(browser, confirming \\ false, obituary \\ nil) do
     base()
-    |> text("No programs configured.",
-      font_size: 20,
+    |> breadcrumb(browser)
+    |> columns(browser)
+    |> notice(browser, confirming, obituary)
+  end
+
+  defp base do
+    Graph.build(font: :roboto, font_size: 16)
+    |> rect({@width, @height}, fill: {:color, @bg})
+    |> StatusBar.mount()
+    |> rect({@span, 2}, fill: {:color, @head}, translate: {@left, @rule_y})
+  end
+
+  # Every open level by name, however many columns are drawn. The tail is
+  # kept when it runs long: where you are matters more than where you began,
+  # and the root is always one Menu press away.
+  defp breadcrumb(graph, browser) do
+    trail = browser |> Browser.trail() |> Enum.join(" > ")
+
+    text(graph, truncate_left(trail, 64),
+      font_size: 18,
       fill: {:color, @title},
-      translate: {20, @top + 26}
-    )
-    |> text("Set config :mayonnaios, :programs in config/target.exs.",
-      font_size: 14,
-      fill: {:color, @label},
-      translate: {20, @top + 52}
+      translate: {@left, @title_y}
     )
   end
 
-  def graph(programs, selected, confirming, obituary) do
-    count = length(programs)
-    selected = Integer.mod(selected, count)
+  defp columns(graph, browser) do
+    levels = Browser.visible(browser)
+    count = length(levels)
+    width = div(@span - @gutter * (count - 1), count)
 
-    # Window the rows when the list outgrows the panel. Without this a twelfth
-    # entry would be selected off-screen and nothing would look wrong.
-    start = min(max(0, selected - @visible + 1), max(0, count - @visible))
-    rows = Enum.slice(programs, start, @visible)
+    levels
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {level, index}, acc ->
+      x = @left + index * (width + @gutter)
 
-    # Compare indices, not entries: two entries with the same name and path is
-    # a silly config but a legal one, and comparing maps would highlight both.
+      acc
+      |> separator(x, index)
+      |> column(level, x, width, index == count - 1)
+    end)
+  end
+
+  # A hairline between columns, so two listings never read as one.
+  defp separator(graph, _x, 0), do: graph
+
+  defp separator(graph, x, _index) do
+    rect(graph, {1, @rows_top + @visible * @pitch - @top},
+      fill: {:color, @row_bg},
+      translate: {x - div(@gutter, 2) - 1, @top}
+    )
+  end
+
+  defp column(graph, level, x, width, focused?) do
+    graph
+    |> caption(level, x, width, focused?)
+    |> rows(level, x, width, focused?)
+  end
+
+  # The column's name, and -- for the focused column when the listing is
+  # windowed -- where the cursor is in it, as a count rather than a scrollbar.
+  defp caption(graph, level, x, width, focused?) do
+    count = length(level.entries)
+
+    position =
+      if focused? and count > @visible, do: "  #{level.cursor + 1} of #{count}", else: ""
+
+    text(graph, truncate(level.title, name_chars(width)) <> position,
+      font_size: 12,
+      fill: {:color, @dim},
+      translate: {x, @caption_y}
+    )
+  end
+
+  # An empty column says why it is empty -- "Empty.", "No pickles installed.",
+  # or what went wrong reading it -- where its rows would have been.
+  defp rows(graph, %{entries: [], note: note}, x, width, _focused?) do
+    text(graph, truncate(note || "Empty.", name_chars(width) + 14),
+      font_size: 13,
+      fill: {:color, @dim},
+      translate: {x, @rows_top + 16}
+    )
+  end
+
+  defp rows(graph, %{entries: entries, cursor: cursor}, x, width, focused?) do
+    window = window(entries, cursor, @visible)
+
     {graph, _y} =
-      rows
-      |> Enum.with_index(start)
-      |> Enum.reduce({base(), @top}, fn {program, index}, {g, y} ->
-        {row(g, program, y, index == selected), y + @pitch}
+      Enum.reduce(window.rows, {graph, @rows_top}, fn {node, index}, {acc, y} ->
+        {row(acc, node, x, width, y, index == window.cursor, focused?), y + @pitch}
       end)
 
     graph
-    |> position(start, count)
-    |> notice(confirming, obituary)
   end
 
-  # The bottom of the panel carries one notice at a time. The power-off
-  # question wins over an obituary: it is the panel asking for a decision,
-  # and the obituary keeps -- it is still in the Launcher's state, and comes
-  # back the moment the question is answered.
-  defp notice(graph, true, _obituary), do: confirm(graph, true)
-  defp notice(graph, false, obituary), do: obituary(graph, obituary)
+  defp row(graph, node, x, width, y, selected?, focused?) do
+    graph
+    |> highlight(x, width, y, selected?, focused?)
+    |> text(truncate(node.name, name_chars(width)),
+      font_size: 16,
+      fill: {:color, name_colour(node, selected? and focused?)},
+      translate: {x + 12, y + 17}
+    )
+    |> marker(node, x, width, y)
+  end
 
-  # The Power off row's question, on the bottom line the way the file
-  # manager's bottom line names its second verb. Amber, because it is the
-  # panel asking for a decision rather than describing a state.
-  defp confirm(graph, true) do
-    text(graph, "Power off? Y switches off. Any other button keeps it on.",
+  # One filled rect for the open row in any column; the accent bar only in
+  # the focused one, so a glance says which column the D-pad is moving.
+  defp highlight(graph, _x, _width, _y, false, _focused?), do: graph
+
+  defp highlight(graph, x, width, y, true, focused?) do
+    graph = rect(graph, {width, @pitch - 4}, fill: {:color, @row_bg}, translate: {x, y})
+
+    if focused? do
+      rect(graph, {4, @pitch - 4}, fill: {:color, @head}, translate: {x, y})
+    else
+      graph
+    end
+  end
+
+  # The right edge of a row: a chevron on anything that opens as another
+  # column, words on the leaves that have something to say -- a size, a link,
+  # a binary the image does not have.
+  defp marker(graph, node, x, width, y) do
+    if Browser.expandable?(node) do
+      text(graph, ">", font_size: 14, fill: {:color, @dim}, translate: {x + width - 12, y + 17})
+    else
+      case detail(node, width) do
+        "" ->
+          graph
+
+        words ->
+          text(graph, words,
+            font_size: 12,
+            fill: {:color, detail_colour(node)},
+            translate: {x + width - 96, y + 16}
+          )
+      end
+    end
+  end
+
+  # Details need room; the narrow three-column setting drops them and keeps
+  # the names, which is the trade the person cycling columns chose.
+  defp detail(_node, width) when width < 240, do: ""
+
+  defp detail(%{kind: :program, program: %{installed?: false}}, _width), do: "not installed"
+  defp detail(%{kind: :file, entry: %{broken?: true}}, _width), do: "broken link"
+  defp detail(%{kind: :file, entry: %{link: link}}, _width) when is_binary(link), do: "link"
+  defp detail(%{kind: :file, entry: %{type: :regular, size: size}}, _width), do: size(size)
+  defp detail(%{kind: :file, entry: %{type: type}}, _width), do: to_string(type)
+  defp detail(_node, _width), do: ""
+
+  defp detail_colour(%{kind: :program, program: %{installed?: false}}), do: @wait
+  defp detail_colour(%{kind: :file, entry: %{broken?: true}}), do: @wait
+  defp detail_colour(_node), do: @dim
+
+  defp name_colour(%{kind: :file, entry: %{broken?: true}}, _selected?), do: @wait
+  defp name_colour(_node, true), do: @title
+  defp name_colour(%{kind: :program, program: %{installed?: false}}, _selected?), do: @dim
+
+  defp name_colour(%{kind: kind}, false) when kind in [:category, :place, :dir], do: @head
+  defp name_colour(_node, false), do: @label
+
+  # How many characters fit a column at this width, at font 16 with the
+  # highlight inset on the left and the chevron or detail on the right.
+  defp name_chars(width) when width >= 500, do: 52
+  defp name_chars(width) when width >= 240, do: 22
+  defp name_chars(_width), do: 18
+
+  # Window the rows when a listing outgrows its column, keeping the cursor on
+  # screen. Without this the hundredth ROM in a directory would be selected
+  # somewhere nobody can see, and nothing would look wrong.
+  defp window(items, cursor, visible) do
+    count = length(items)
+    cursor = if count == 0, do: 0, else: min(max(cursor, 0), count - 1)
+    start = min(max(0, cursor - visible + 1), max(0, count - visible))
+
+    %{rows: items |> Enum.slice(start, visible) |> Enum.with_index(start), cursor: cursor}
+  end
+
+  # -- the bottom line ----------------------------------------------------------
+
+  # One notice at a time, on the footer line. The power-off question wins
+  # over an obituary: it is the panel asking for a decision, and the obituary
+  # keeps -- it is still in the Launcher's state, and comes back the moment
+  # the question is answered. With nothing to ask or report, the line labels
+  # the buttons.
+  defp notice(graph, _browser, true, _obituary) do
+    graph
+    |> footer_rule()
+    |> text("Power off? Y switches off. Any other button keeps it on.",
       font_size: 16,
       fill: {:color, @wait},
-      translate: {20, @height - 16}
+      translate: {@left, @footer_y}
     )
+  end
+
+  defp notice(graph, browser, false, nil) do
+    hint =
+      "A opens. B closes a column. Y cycles columns (#{browser.columns}). " <>
+        "X diagnostics. Menu goes to the top."
+
+    graph
+    |> footer_rule()
+    |> text(hint, font_size: 13, fill: {:color, @dim}, translate: {@left, @footer_y})
   end
 
   # Why the last program died, quoted from its own last words. The headline
@@ -142,80 +313,64 @@ defmodule MayonnaiOS.Scene.Home do
   # and the quoted lines are dim so the reason reads before the evidence.
   # Status nil is a spawn that raised rather than a program that exited; the
   # words are then the exception's, and "exited" would be a lie.
-  defp obituary(graph, nil), do: graph
-
-  defp obituary(graph, %{name: name, status: status, lines: lines}) do
+  defp notice(graph, _browser, false, %{name: name, status: status, lines: lines}) do
     headline =
       case status do
         nil -> "#{name} would not start. B clears this."
         status -> "#{name} exited (#{status}). B clears this."
       end
 
+    graph = footer_rule(graph)
+
     lines
-    # Two lines and 88 characters: what fits above the headline at this font
-    # without climbing into the menu's last row.
+    # Two lines and 88 characters: what fits between the rows and the
+    # headline at this font.
     |> Enum.take(-2)
     |> Enum.reverse()
     |> Enum.with_index()
     |> Enum.reduce(graph, fn {line, up}, g ->
       text(g, String.slice(line, 0, 88),
-        font_size: 14,
+        font_size: 13,
         fill: {:color, @dim},
-        translate: {20, @height - 36 - up * 18}
+        translate: {@left, @footer_rule - 8 - up * 18}
       )
     end)
-    |> text(headline, font_size: 16, fill: {:color, @wait}, translate: {20, @height - 16})
+    |> text(headline, font_size: 16, fill: {:color, @wait}, translate: {@left, @footer_y})
   end
 
-  defp base do
-    Graph.build(font: :roboto, font_size: 20)
-    |> rect({@width, @height}, fill: {:color, @bg})
-    |> StatusBar.mount()
-    |> text("RG40XXV", font_size: 20, fill: {:color, @title}, translate: {20, @title_y})
-    |> rect({@width - 40, 2}, fill: {:color, @head}, translate: {20, @rule_y})
+  defp footer_rule(graph) do
+    rect(graph, {@span, 1}, fill: {:color, @dim}, translate: {@left, @footer_rule})
   end
 
-  defp row(graph, program, y, selected?) do
-    graph
-    |> highlight(y, selected?)
-    |> text(program.name,
-      fill: {:color, name_colour(program, selected?)},
-      translate: {36, y + 21}
-    )
-    |> missing(program, y)
+  # -- words --------------------------------------------------------------------
+
+  # Powers of 1024 with df's one-letter units, because that is what the rest
+  # of this project's numbers are quoted in.
+  defp size(nil), do: ""
+  defp size(bytes) when bytes < 1024, do: "#{bytes} B"
+
+  defp size(bytes) do
+    {value, unit} =
+      cond do
+        bytes >= 1024 * 1024 * 1024 -> {bytes / (1024 * 1024 * 1024), "G"}
+        bytes >= 1024 * 1024 -> {bytes / (1024 * 1024), "M"}
+        true -> {bytes / 1024, "K"}
+      end
+
+    "#{:erlang.float_to_binary(value, decimals: 1)}#{unit}"
   end
 
-  # One filled rect plus a 4 px accent bar. A filled row alone is hard to see
-  # on a dim panel in daylight; the bar survives it.
-  defp highlight(graph, _y, false), do: graph
-
-  defp highlight(graph, y, true) do
-    graph
-    |> rect({@width - 40, @pitch - 4}, fill: {:color, @row_bg}, translate: {20, y})
-    |> rect({4, @pitch - 4}, fill: {:color, @head}, translate: {20, y})
+  defp truncate(text, limit) do
+    if String.length(text) > limit, do: String.slice(text, 0, limit - 1) <> "…", else: text
   end
 
-  defp missing(graph, %{installed?: true}, _y), do: graph
-
-  defp missing(graph, _program, y) do
-    # Amber, and the word rather than an icon: this is the panel telling
-    # whoever holds the device that the firmware and the config disagree.
-    text(graph, "not installed", font_size: 14, fill: {:color, @wait}, translate: {470, y + 21})
-  end
-
-  defp name_colour(%{installed?: false}, _selected?), do: @dim
-  defp name_colour(_program, true), do: @title
-  defp name_colour(_program, false), do: @label
-
-  # Only when the list is windowed, and then only as a count: the point is to
-  # say that rows exist above or below, not to draw a scrollbar.
-  defp position(graph, _start, count) when count <= @visible, do: graph
-
-  defp position(graph, start, count) do
-    text(graph, "#{start + 1}-#{min(start + @visible, count)} of #{count}",
-      font_size: 14,
-      fill: {:color, @dim},
-      translate: {520, @title_y}
-    )
+  # For the breadcrumb, keep the end: where you are matters more than where
+  # you began.
+  defp truncate_left(text, limit) do
+    if String.length(text) > limit do
+      "…" <> String.slice(text, String.length(text) - limit + 1, limit)
+    else
+      text
+    end
   end
 end

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -1,0 +1,214 @@
+defmodule MayonnaiOS.BrowserTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Browser
+
+  # No process and no panel: the browser is a value, and these tests move it
+  # the way the Launcher's bindings do and look at what a scene would draw.
+
+  setup do
+    # `Programs.list/0` appends a row for every installed pickle, read from
+    # disk on every call -- so without this, the Pickles column is however
+    # many pickles the developer happens to have installed on the host.
+    pickles_root =
+      Path.join(System.tmp_dir!(), "browser-test-pickles-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(pickles_root)
+    previous = Application.get_env(:mayonnaios, :pickles_root)
+    Application.put_env(:mayonnaios, :pickles_root, pickles_root)
+
+    on_exit(fn ->
+      File.rm_rf(pickles_root)
+      Application.delete_env(:mayonnaios, :programs)
+      Application.delete_env(:mayonnaios, :file_roots)
+
+      case previous do
+        nil -> Application.delete_env(:mayonnaios, :pickles_root)
+        value -> Application.put_env(:mayonnaios, :pickles_root, value)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "the root column" do
+    test "names the categories, in order" do
+      browser = Browser.new()
+
+      assert names(browser) == ["Games", "Files", "Pickles", "Settings"]
+      assert Browser.depth(browser) == 1
+      assert Browser.selected(browser).name == "Games"
+    end
+
+    test "the cursor wraps at both ends" do
+      browser = Browser.new()
+
+      assert Browser.selected(Browser.move(browser, -1)).name == "Settings"
+      assert Browser.selected(Browser.move(browser, 4)).name == "Games"
+    end
+
+    test "ascend at the root is a no-op, so B cannot fall off the top" do
+      browser = Browser.new()
+      assert Browser.ascend(browser) == browser
+    end
+  end
+
+  describe "classifying the one config list" do
+    setup do
+      Application.put_env(:mayonnaios, :programs, [
+        %{name: "RetroArch", path: "/nonexistent/retroarch"},
+        %{name: "Files", app: MayonnaiOS.FileManager},
+        %{name: "Bluetooth controller", app: MayonnaiOS.Controller},
+        %{name: "Paint", app: {MayonnaiOS.Pickles.App, "paint"}},
+        %{name: "Power off", action: :poweroff}
+      ])
+
+      :ok
+    end
+
+    test "a path entry is a game" do
+      games = open(Browser.new(), "Games")
+      assert names(games) == ["RetroArch"]
+    end
+
+    test "a pickle's row is a pickle" do
+      pickles = open(Browser.new(), "Pickles")
+      assert names(pickles) == ["Paint"]
+    end
+
+    test "the file manager app is the first row of Files, above the roots" do
+      Application.put_env(:mayonnaios, :file_roots, [%{key: "r", path: "/tmp", note: ""}])
+
+      files = open(Browser.new(), "Files")
+      assert ["Files", "/tmp"] = names(files)
+      assert Browser.selected(files).kind == :program
+    end
+
+    test "other apps and the actions land in Settings, verbs last" do
+      settings = open(Browser.new(), "Settings")
+
+      assert names(settings) == ["Bluetooth controller", "Diagnostics", "Sleep", "Power off"]
+    end
+
+    test "the built-in Settings rows carry the launcher's own verbs" do
+      settings = open(Browser.new(), "Settings")
+
+      actions =
+        for node <- List.last(settings.levels).entries, do: node.program.action
+
+      assert actions == [nil, :diagnostics, :sleep, :poweroff]
+    end
+  end
+
+  describe "an empty category" do
+    test "says why instead of listing nothing" do
+      Application.put_env(:mayonnaios, :programs, [])
+
+      pickles = open(Browser.new(), "Pickles")
+      assert names(pickles) == []
+      assert List.last(pickles.levels).note == "No pickles installed."
+    end
+  end
+
+  describe "browsing files" do
+    setup do
+      root = Path.join(System.tmp_dir!(), "browser-test-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(Path.join(root, "snes"))
+      File.write!(Path.join(root, "snes/chrono.sfc"), "123456789")
+      File.write!(Path.join(root, "readme.txt"), "hi")
+
+      Application.put_env(:mayonnaios, :programs, [])
+
+      Application.put_env(:mayonnaios, :file_roots, [
+        %{key: "games", path: root, note: "the test card"},
+        %{key: "missing", path: Path.join(root, "not-there"), note: "a card that is out"}
+      ])
+
+      on_exit(fn -> File.rm_rf(root) end)
+
+      %{root: root}
+    end
+
+    test "a root opens as a column of its entries", %{root: root} do
+      browser = Browser.new() |> open("Files")
+
+      assert Browser.selected(browser).name == root
+      browser = Browser.descend(browser)
+
+      # Directories first is Files.list/1's order; the browser keeps it.
+      assert names(browser) == ["snes", "readme.txt"]
+      assert Browser.trail(browser) == ["RG40XXV", "Files", root]
+    end
+
+    test "a directory keeps opening columns, and ascend walks back" do
+      browser = Browser.new() |> open("Files") |> Browser.descend() |> Browser.descend()
+
+      assert names(browser) == ["chrono.sfc"]
+      assert Browser.depth(browser) == 4
+
+      assert browser |> Browser.ascend() |> names() == ["snes", "readme.txt"]
+    end
+
+    test "a file is a leaf: descend does nothing" do
+      browser =
+        Browser.new() |> open("Files") |> Browser.descend() |> Browser.move(1)
+
+      assert %{kind: :file, name: "readme.txt"} = Browser.selected(browser)
+      refute Browser.expandable?(Browser.selected(browser))
+      assert Browser.descend(browser) == browser
+    end
+
+    test "a root that is not there is a column that says so" do
+      browser = Browser.new() |> open("Files") |> Browser.move(1) |> Browser.descend()
+
+      assert names(browser) == []
+      assert List.last(browser.levels).note =~ "cannot be read"
+    end
+  end
+
+  describe "the column-count setting" do
+    test "Y cycles 2, 3, 1 and round again" do
+      browser = Browser.new()
+      assert browser.columns == 2
+
+      browser = Browser.cycle_columns(browser)
+      assert browser.columns == 3
+
+      browser = Browser.cycle_columns(browser)
+      assert browser.columns == 1
+
+      assert Browser.cycle_columns(browser).columns == 2
+    end
+
+    test "visible/1 is the tail of the stack, at most the setting" do
+      browser = Browser.new() |> open("Files")
+
+      assert length(Browser.visible(browser)) == 2
+      assert length(Browser.visible(%{browser | columns: 1})) == 1
+
+      # Three columns wanted, two levels open: the panel gets what exists.
+      assert length(Browser.visible(%{browser | columns: 3})) == 2
+    end
+  end
+
+  describe "reset/1" do
+    test "goes back to the root column but keeps the column setting" do
+      browser =
+        Browser.new() |> Browser.cycle_columns() |> open("Files") |> Browser.reset()
+
+      assert Browser.depth(browser) == 1
+      assert browser.columns == 3
+    end
+  end
+
+  # Move the cursor onto the category named `name` and open it.
+  defp open(browser, name) do
+    %{entries: entries} = hd(browser.levels)
+    index = Enum.find_index(entries, &(&1.name == name))
+    browser |> Browser.move(index) |> Browser.descend()
+  end
+
+  defp names(browser) do
+    for node <- List.last(browser.levels).entries, do: node.name
+  end
+end

--- a/test/controller/app_test.exs
+++ b/test/controller/app_test.exs
@@ -78,6 +78,12 @@ defmodule MayonnaiOS.Controller.AppTest do
       on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
 
       start_supervised!({Launcher, device: "/nonexistent"})
+
+      # Onto the app's row: up wraps the root column onto Settings, where an
+      # app's row lives, and A opens the column with the cursor on it. The
+      # tests then press A to start the app itself.
+      press(:btn_dpad_up)
+      press(:btn_b)
       :ok
     end
 

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -1,7 +1,7 @@
 defmodule MayonnaiOS.LauncherTest do
   use ExUnit.Case, async: false
 
-  alias MayonnaiOS.{Launcher, Programs}
+  alias MayonnaiOS.{Browser, Launcher, Programs}
   alias MayonnaiOS.Scene.Home
 
   # No viewport, no driver, no framebuffer. Everything here runs on the host,
@@ -41,108 +41,93 @@ defmodule MayonnaiOS.LauncherTest do
     end
   end
 
-  describe "Programs.step/3" do
+  describe "Scene.Home.graph/3" do
     setup do
-      %{programs: Programs.list([%{path: "/a"}, %{path: "/b"}, %{path: "/c"}])}
+      on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
+      :ok
     end
 
-    test "moves down and wraps past the end", %{programs: programs} do
-      assert Programs.step(programs, 0, 1) == 1
-      assert Programs.step(programs, 2, 1) == 0
+    test "the root column names the categories" do
+      says = texts(Home.graph(Browser.new()))
+
+      for category <- ["Games", "Files", "Pickles", "Settings"] do
+        assert category in says
+      end
     end
 
-    test "moves up and wraps past the start", %{programs: programs} do
-      assert Programs.step(programs, 1, -1) == 0
-      assert Programs.step(programs, 0, -1) == 2
+    test "builds at every column-count setting" do
+      browser = Browser.new() |> Browser.descend()
+
+      assert %Scenic.Graph{} = Home.graph(%{browser | columns: 1})
+      assert %Scenic.Graph{} = Home.graph(%{browser | columns: 2})
+      assert %Scenic.Graph{} = Home.graph(%{browser | columns: 3})
     end
 
-    test "is 0 for an empty list" do
-      # An empty menu must not divide by zero on a D-pad press.
-      assert Programs.step([], 0, 1) == 0
-      assert Programs.step([], 3, -1) == 0
-    end
-  end
+    test "the breadcrumb names every open level, not only the drawn ones" do
+      Application.put_env(:mayonnaios, :programs, [%{path: "/a"}])
 
-  describe "Programs.at/2" do
-    test "tolerates an index past the end of a shrunken list" do
-      programs = Programs.list([%{path: "/a"}, %{path: "/b"}])
-      assert Programs.at(programs, 5).path == "/b"
-      assert Programs.at(programs, -1).path == "/b"
-    end
+      browser = %{Browser.new() | columns: 1} |> Browser.descend()
 
-    test "is nil when nothing is configured" do
-      assert Programs.at([], 0) == nil
-    end
-  end
-
-  describe "Scene.Home.graph/2" do
-    test "builds for an empty list" do
-      assert %Scenic.Graph{} = Home.graph([], 0)
-    end
-
-    test "builds for a single entry" do
-      assert %Scenic.Graph{} = Home.graph(Programs.list([%{path: "/usr/bin/kmscube"}]), 0)
-    end
-
-    test "builds with the selection on the last row" do
-      programs = Programs.list([%{path: "/a"}, %{path: "/b"}, %{path: "/c"}])
-      assert %Scenic.Graph{} = Home.graph(programs, 2)
+      assert Enum.any?(texts(Home.graph(browser)), &(&1 =~ "RG40XXV > Games"))
     end
 
     test "windows the rows so the selection is always drawn" do
       # "It built without raising" is not enough here: Enum.slice returns []
       # for an out-of-range start, so a broken window would still produce a
-      # graph -- an empty menu that looks like a rendering bug on the device.
-      programs = Programs.list(for i <- 1..20, do: %{path: "/bin/prog#{i}"})
+      # graph -- an empty column that looks like a rendering bug on the device.
+      Application.put_env(
+        :mayonnaios,
+        :programs,
+        for(i <- 1..20, do: %{path: "/bin/prog#{i}"})
+      )
 
-      last = texts(Home.graph(programs, 19))
-      assert "prog20" in last
-      refute "prog1" in last
+      browser = Browser.new() |> Browser.descend()
 
-      first = texts(Home.graph(programs, 0))
+      first = texts(Home.graph(browser))
       assert "prog1" in first
       refute "prog20" in first
+
+      last = texts(Home.graph(Browser.move(browser, 19)))
+      assert "prog20" in last
+      refute "prog1" in last
     end
 
     test "says so on the row when a configured path is not in the image" do
-      graph = Home.graph(Programs.list([%{path: "/usr/bin/definitely-not-here"}]), 0)
+      Application.put_env(:mayonnaios, :programs, [%{path: "/usr/bin/definitely-not-here"}])
+
+      graph = Home.graph(Browser.new() |> Browser.descend())
       assert "not installed" in texts(graph)
     end
 
-    test "an action entry is an ordinary, always-installed row" do
-      assert [entry] = Programs.list([%{name: "Power off", action: :poweroff}])
-      assert entry.installed?
-      assert entry.action == :poweroff
+    test "an empty column says why instead of listing nothing" do
+      Application.put_env(:mayonnaios, :programs, [])
 
-      assert "Power off" in texts(Home.graph([entry], 0))
-      refute "not installed" in texts(Home.graph([entry], 0))
+      graph = Home.graph(Browser.new() |> Browser.descend())
+      assert Enum.any?(texts(graph), &(&1 =~ "Nothing to run"))
     end
 
     test "the power-off question is on the panel only while it is being asked" do
-      programs = Programs.list([%{name: "Power off", action: :poweroff}])
-
-      asked = texts(Home.graph(programs, 0, true))
+      asked = texts(Home.graph(Browser.new(), true))
       assert Enum.any?(asked, &(&1 =~ "Power off? Y switches off"))
 
-      idle = texts(Home.graph(programs, 0))
+      idle = texts(Home.graph(Browser.new()))
       refute Enum.any?(idle, &(&1 =~ "Y switches off"))
     end
 
     test "an obituary quotes the program's dying words" do
-      programs = Programs.list([%{path: "/a"}])
       obituary = %{name: "Moonlight", status: 1, lines: ["Can't open configuration file"]}
 
-      says = texts(Home.graph(programs, 0, false, obituary))
+      says = texts(Home.graph(Browser.new(), false, obituary))
       assert Enum.any?(says, &(&1 =~ "Moonlight exited (1)"))
       assert Enum.any?(says, &(&1 =~ "Can't open configuration file"))
 
-      idle = texts(Home.graph(programs, 0))
+      idle = texts(Home.graph(Browser.new()))
       refute Enum.any?(idle, &(&1 =~ "exited"))
     end
 
     test "a spawn that raised says would not start, not exited" do
       obituary = %{name: "Doom", status: nil, lines: ["enoent"]}
-      says = texts(Home.graph(Programs.list([%{path: "/a"}]), 0, false, obituary))
+      says = texts(Home.graph(Browser.new(), false, obituary))
 
       assert Enum.any?(says, &(&1 =~ "Doom would not start"))
       refute Enum.any?(says, &(&1 =~ "exited"))
@@ -150,10 +135,18 @@ defmodule MayonnaiOS.LauncherTest do
 
     test "the power-off question outranks the obituary" do
       obituary = %{name: "Moonlight", status: 1, lines: ["nope"]}
-      says = texts(Home.graph(Programs.list([%{path: "/a"}]), 0, true, obituary))
+      says = texts(Home.graph(Browser.new(), true, obituary))
 
       assert Enum.any?(says, &(&1 =~ "Power off?"))
       refute Enum.any?(says, &(&1 =~ "exited"))
+    end
+
+    test "the footer says how many columns Y is on" do
+      two = texts(Home.graph(Browser.new()))
+      assert Enum.any?(two, &(&1 =~ "Y cycles columns (2)"))
+
+      three = texts(Home.graph(Browser.cycle_columns(Browser.new())))
+      assert Enum.any?(three, &(&1 =~ "Y cycles columns (3)"))
     end
 
     # Every text primitive's string, so a test can assert what the panel says
@@ -188,34 +181,11 @@ defmodule MayonnaiOS.LauncherTest do
     setup do
       # The Launcher is not in the host supervision tree, and there is no
       # /dev/input here, so it starts with no device and the synthetic events
-      # below stand in for the pad.
+      # below stand in for the pad. The root column is fixed -- four
+      # categories -- so nothing on this host can change what these wrap over.
       programs = [%{path: "/a"}, %{path: "/b"}, %{path: "/c"}]
       Application.put_env(:mayonnaios, :programs, programs)
       on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
-
-      # `Programs.list/0` appends a row for every installed pickle that asked
-      # for the `ui` capability, read from disk on every call -- so without
-      # this, the menu these tests wrap around is however many pickles the
-      # developer happens to have installed on the host. It was one, and the
-      # wrap-around test below failed on that machine and nowhere else.
-      pickles_root =
-        Path.join(
-          System.tmp_dir!(),
-          "launcher-test-pickles-#{System.unique_integer([:positive])}"
-        )
-
-      File.mkdir_p!(pickles_root)
-      previous = Application.get_env(:mayonnaios, :pickles_root)
-      Application.put_env(:mayonnaios, :pickles_root, pickles_root)
-
-      on_exit(fn ->
-        File.rm_rf(pickles_root)
-
-        case previous do
-          nil -> Application.delete_env(:mayonnaios, :pickles_root)
-          value -> Application.put_env(:mayonnaios, :pickles_root, value)
-        end
-      end)
 
       start_supervised!({Launcher, device: "/nonexistent/event0"})
       :ok
@@ -236,7 +206,7 @@ defmodule MayonnaiOS.LauncherTest do
 
     test "up from the top wraps to the bottom" do
       press(:btn_dpad_up)
-      assert Launcher.selected() == 2
+      assert Launcher.selected() == 3
     end
 
     test "autorepeat does not move the cursor" do
@@ -246,17 +216,65 @@ defmodule MayonnaiOS.LauncherTest do
       assert Launcher.selected() == 0
     end
 
+    test "A opens a category and B closes it" do
+      # :btn_b is the button silkscreened A; see the Launcher moduledoc.
+      press(:btn_b)
+
+      browser = Launcher.browser()
+      assert Browser.depth(browser) == 2
+      assert Browser.trail(browser) == ["RG40XXV", "Games"]
+      assert Enum.map(List.last(browser.levels).entries, & &1.name) == ["a", "b", "c"]
+
+      press(:btn_a)
+      assert Browser.depth(Launcher.browser()) == 1
+    end
+
+    test "right opens a column and left closes it, and neither launches" do
+      press(:btn_dpad_right)
+      assert Browser.depth(Launcher.browser()) == 2
+
+      # Right on a leaf: /a is a program, not a column, and right must not
+      # start it -- A is the button that commits.
+      press(:btn_dpad_right)
+      assert Browser.depth(Launcher.browser()) == 2
+      refute Launcher.running?()
+
+      press(:btn_dpad_left)
+      assert Browser.depth(Launcher.browser()) == 1
+    end
+
+    test "Y cycles how many columns are drawn: 2, 3, 1" do
+      assert Launcher.browser().columns == 2
+
+      press(:btn_x)
+      assert Launcher.browser().columns == 3
+
+      press(:btn_x)
+      assert Launcher.browser().columns == 1
+
+      press(:btn_x)
+      assert Launcher.browser().columns == 2
+    end
+
+    test "Menu goes back to the root column from deep in the tree" do
+      press(:btn_b)
+      press(:btn_dpad_down)
+      assert Browser.depth(Launcher.browser()) == 2
+
+      press(:btn_mode)
+      assert Browser.depth(Launcher.browser()) == 1
+    end
+
     defp press(key) do
       send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 1}]})
-      # selected/0 is a call, so it is ordered behind the cast above.
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 0}]})
+      # selected/0 is a call, so it is ordered behind the casts above.
       Launcher.selected()
     end
   end
 
   describe "the Power off row" do
     setup do
-      # A real program above it, so the tests can also show that cancelling
-      # does not leak the cancelling press into a launch.
       programs = [%{path: "/a"}, %{name: "Power off", action: :poweroff}]
       Application.put_env(:mayonnaios, :programs, programs)
       on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
@@ -267,8 +285,14 @@ defmodule MayonnaiOS.LauncherTest do
         {Launcher, device: "/nonexistent/event0", poweroff: fn -> send(test, :powered_off) end}
       )
 
-      # Onto the Power off row.
+      # Into Settings -- the last category -- and down past Diagnostics and
+      # Sleep onto the Power off row, which sits last on purpose.
+      tap(:btn_dpad_up)
+      tap(:btn_b)
       tap(:btn_dpad_down)
+      tap(:btn_dpad_down)
+
+      assert Browser.selected(Launcher.browser()).name == "Power off"
       :ok
     end
 
@@ -280,28 +304,31 @@ defmodule MayonnaiOS.LauncherTest do
       assert_receive :powered_off
     end
 
-    test "any other button keeps the device on, and Y afterwards is nothing" do
+    test "any other button keeps the device on, and Y afterwards does not switch off" do
       tap(:btn_b)
       tap(:btn_a)
 
       # The question is gone, so the button that would have answered it is
-      # back to being unbound.
+      # back to its day job of cycling columns.
       tap(:btn_x)
       refute_received :powered_off
     end
 
     test "the cancelling press is swallowed, not dispatched" do
       tap(:btn_b)
-      # A again would launch whatever the cursor is on if it were dispatched;
-      # here it may only cancel. Y proving the question is gone also proves
-      # no second question was opened.
+      # A again would re-open the question if it were dispatched -- the cursor
+      # is still on the Power off row; here it may only cancel. Y proving no
+      # question is up also proves no second question was opened.
       tap(:btn_b)
       tap(:btn_x)
       refute_received :powered_off
     end
 
-    test "Y with no question pending is unbound" do
+    test "Y with no question pending cycles the columns instead" do
+      assert Launcher.browser().columns == 2
       tap(:btn_x)
+
+      assert Launcher.browser().columns == 3
       refute_received :powered_off
     end
 
@@ -356,6 +383,9 @@ defmodule MayonnaiOS.LauncherTest do
 
       start_supervised!({Launcher, [device: "/nonexistent/event0"] ++ opts})
 
+      # Into the Games column, where the configured shell is the first row.
+      # `launch/0` is A: the first press opens the category, the second runs.
+      Launcher.launch()
       Launcher.launch()
       assert Launcher.running?()
       os_pid = Launcher.os_pid()
@@ -533,6 +563,9 @@ defmodule MayonnaiOS.LauncherTest do
       ])
 
       start_supervised!({Launcher, device: "/nonexistent/event0"})
+
+      # A twice: into the Games column, then the shell on its first row.
+      Launcher.launch()
       Launcher.launch()
     end
 

--- a/test/panel_test.exs
+++ b/test/panel_test.exs
@@ -243,7 +243,9 @@ defmodule MayonnaiOS.PanelTest do
       # `cat` with no arguments stands in for RetroArch: a real external
       # process, spawned the same way through `Port.open/2`, that stays up
       # until it is killed. What it draws is irrelevant -- the launcher's job
-      # here is not drawing.
+      # here is not drawing. `launch/0` is A: the first press opens the Games
+      # column, the second runs its first row.
+      Launcher.launch()
       Launcher.launch()
       assert Panel.owner() == {:program, "sleeper"}
       settle()

--- a/test/sleep_test.exs
+++ b/test/sleep_test.exs
@@ -256,7 +256,11 @@ defmodule MayonnaiOS.SleepTest do
 
       start_supervised!({Launcher, device: "/nonexistent/event0"})
 
-      # A starts it. :btn_b is the button silkscreened A; see the Launcher.
+      # Up wraps the root column onto Settings, where an app's row lives; A
+      # opens it, and A again starts the app. :btn_b is the button
+      # silkscreened A; see the Launcher.
+      press(:btn_dpad_up)
+      press(:btn_b)
       press(:btn_b)
       assert FakeApp.log().started == 1
       :ok

--- a/test/status_bar_test.exs
+++ b/test/status_bar_test.exs
@@ -382,8 +382,9 @@ defmodule MayonnaiOS.StatusBarTest do
   # into the strip.
   defp scenes do
     [
-      {"Scene.Home", MayonnaiOS.Scene.Home.graph(Programs.list([%{path: "/bin/sh"}]), 0)},
-      {"Scene.Home (empty)", MayonnaiOS.Scene.Home.graph([], 0)},
+      {"Scene.Home", MayonnaiOS.Scene.Home.graph(MayonnaiOS.Browser.new())},
+      {"Scene.Home (columns)",
+       MayonnaiOS.Scene.Home.graph(MayonnaiOS.Browser.descend(MayonnaiOS.Browser.new()))},
       {"Scene.Diagnostics", MayonnaiOS.Scene.Diagnostics.graph(%MayonnaiOS.Diagnostics{})},
       {"Scene.Diagnostics (no collector)", MayonnaiOS.Scene.Diagnostics.graph(nil)},
       {"Scene.FileManager", MayonnaiOS.Scene.FileManager.graph(:stopped)},


### PR DESCRIPTION
## Summary
The home screen is now a Miller-column browser: the root column holds four categories — Games, Files, Pickles, Settings — classified out of the existing `:programs` config, and every descent opens another column. Going into Files continues straight into the cards' directory tree through the same checked `MayonnaiOS.Files` locations the file manager uses; Settings gains Diagnostics and Sleep rows. Y cycles between 1, 2 and 3 visible columns (and still answers the power-off question while it is asked).

## Approach
Browsing moved into the launcher, but the destructive verbs did not: the file manager app keeps delete/rename/copy/move with their confirmation flows, and sits as the first row of the Files column. That keeps the launcher's columns read-only — nothing you can lose by walking around — and leaves the existing two-button delete safety story untouched. The browser itself lives in the Launcher's state and travels whole into the scene, for the same reason the flat cursor did: `set_root/3` restarts the scene on every repaint.

## Follow-ups for reviewer
- Should the file manager's verbs eventually fold into the Files columns (Y as the actions sheet, as in the app), retiring the separate browse view there?
- Directory columns are snapshots, refreshed by closing and reopening the column — fine for a handheld, or should a descend re-read siblings too?

Already flashed and validated on the device (slot B, UUID `able-yard`); the root column and column cycling verified over ssh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)