### PR TITLE
Rework the launcher menu: Apps, System, and a whole-filesystem root

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ Software:
 - Sleep on the power button: the backlight goes off and any button brings it
   back. Not suspend — this board's only suspend mode would save almost
   nothing, and `MayonnaiOS.Sleep`'s moduledoc has the analysis
-- A NeXTSTEP-style column launcher: Games, Files, Pickles and Settings open
-  as columns, three on screen, and Files browses both cards in place
+- A NeXTSTEP-style column launcher: Games, Files, Apps and System open
+  as columns, three on screen, and Files browses the whole filesystem in
+  place
 - Orderly power off: the Select+Menu chord, or the **Power off** row under
-  Settings
+  System
 - An indicator LED that means something: quick flashing green while starting,
   solid green running, slow flashing green asleep, blinking red when the
   application fails to start. The yellow light in the other window is the
@@ -112,7 +113,7 @@ firmware and install the same way games do:
 What a pickle can touch is declared in its manifest and enforced by the
 sandbox: HTTP, the local network, a small persistent store, timers, the
 panel — and nothing else. A pickle with the `ui` capability appears in the
-launcher's Pickles column and draws on the screen; the others run headless.
+launcher's Apps column and draws on the screen; the others run headless.
 [docs/pickles.md](docs/pickles.md) is the guide to writing one; the
 `pickle` Claude skill in `.claude/skills/` automates the whole
 develop-and-deploy loop.
@@ -140,8 +141,8 @@ power.
 
 Pick **Files** in the launcher: copy, move, rename and delete across both
 cards, browsing from the ROM roots, the installed bundles, the installed
-cores and `/root`. Copy and move go through a clipboard, since there is
-nothing to type a destination with.
+cores, `/root` and the whole filesystem from `/`. Copy and move go through
+a clipboard, since there is nothing to type a destination with.
 
 Two guarantees that are not visible on screen: nothing ever overwrites — an
 existing destination is refused, because on this device the file being
@@ -319,13 +320,12 @@ host-only path:
 |---|---|
 | arrows, `h` `j` `k` `l` | D-pad |
 | `z` | A — launch the highlighted entry |
-| `c` | X — the diagnostics screen |
 | enter | Menu — back to the home screen |
 | backspace | Select |
 | `p` | the power button — sleep, and any key wakes it |
 | escape | Select+Menu, the power-off chord |
 
-`x`, `v` and `s` are sent too, as B, Y and Start. None of this is
+`x`, `c`, `v` and `s` are sent too, as B, X, Y and Start. None of this is
 conditional on the target, so a USB keyboard plugged into the handheld gets
 the same bindings. `p` is the one key that is not a pad button: it sends
 `KEY_POWER`, which on the device arrives from `axp20x-pek` rather than from

--- a/config/target.exs
+++ b/config/target.exs
@@ -257,14 +257,18 @@ config :mayonnaios, :programs, [
   # It takes hci0 for as long as it runs, so it cannot be up at the same time
   # as anything else that wants the Bluetooth controller. That is why it is
   # here as a menu entry and not in the boot supervision tree.
-  %{name: "Bluetooth controller", app: MayonnaiOS.Controller},
+  #
+  # `category: :apps` puts it in the launcher's Apps column, next to the
+  # pickles: it is a thing to use, not a setting. Rows without a category are
+  # classified by `MayonnaiOS.Browser`.
+  %{name: "Bluetooth controller", app: MayonnaiOS.Controller, category: :apps},
   # There is no file manager row: the launcher's own Files column *is* the
   # file manager. It reaches only the roots `MayonnaiOS.Files` derives from
-  # the configuration below -- the ROM roots, the bundles, the cores, and
-  # /root -- and it builds every path from a root key plus checked names
-  # rather than from a string. See that module's moduledoc for what the
-  # boundary does and does not promise; the symlink caveat is the part worth
-  # reading.
+  # the configuration below -- the ROM roots, the bundles, the cores, /root,
+  # and `/` for the whole filesystem -- and it builds every path from a root
+  # key plus checked names rather than from a string. See that module's
+  # moduledoc for what the boundary does and does not promise; the symlink
+  # caveat is the part worth reading.
   #
   # The other direction, and it takes hci0 for the same reason, so these two
   # are mutually exclusive and the launcher's one-app-at-a-time rule is what

--- a/docs/pickles.md
+++ b/docs/pickles.md
@@ -121,7 +121,7 @@ be retried, and a repeating log line is a report.
 
 ### `"ui"` -- a face on the panel
 
-A pickle with `ui` appears as a row in the launcher's Pickles column.
+A pickle with `ui` appears as a row in the launcher's Apps column.
 Pressing A puts
 its face on the screen; Menu takes the face off -- **the pickle keeps
 running** either way, because a ui pickle is still a background app, just

--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -14,18 +14,22 @@ defmodule MayonnaiOS.Browser do
 
   ## The tree
 
-  The root column is fixed: Games, Files, Pickles, Settings. What each one
+  The root column is fixed: Games, Files, Apps, System. What each one
   contains is classified out of the one `config :mayonnaios, :programs` list
   the launcher already reads, so a row added to config appears in the right
   column with no code change here:
 
     * a `:path` entry is a game or program to run -- **Games**
-    * a pickle's row (`{MayonnaiOS.Pickles.App, name}`) -- **Pickles**
-    * any other app, and every `:action` -- **Settings**
+    * a pickle's row (`{MayonnaiOS.Pickles.App, name}`) -- **Apps**
+    * any other app, and every `:action` -- **System**
 
-  Settings also carries two rows of the launcher's own, Diagnostics and
+  A row can also name its column outright with `:category`, which overrides
+  the rules above -- that is how the Bluetooth controller sits under **Apps**
+  while the other built-in apps stay under **System**.
+
+  System also carries two rows of the launcher's own, Diagnostics and
   Sleep, so the things the device can do to itself are on the menu rather
-  than only on chords someone has to be told about. The chords still work;
+  than only on chords someone has to be told about.
   `MayonnaiOS.Launcher` owns what every verb does, this module only names
   them.
 
@@ -551,8 +555,8 @@ defmodule MayonnaiOS.Browser do
     category_names = [
       %{kind: :category, id: :games, name: "Games"},
       %{kind: :category, id: :files, name: "Files"},
-      %{kind: :category, id: :pickles, name: "Pickles"},
-      %{kind: :category, id: :settings, name: "Settings"}
+      %{kind: :category, id: :apps, name: "Apps"},
+      %{kind: :category, id: :system, name: "System"}
     ]
 
     level("RG40XXV", category_names, nil)
@@ -567,9 +571,9 @@ defmodule MayonnaiOS.Browser do
     level(name, rows, "Nothing to run. Install a bundle, or check the config.")
   end
 
-  defp category_level(:pickles, name) do
-    rows = for program <- classified(:pickles), do: program_node(program)
-    level(name, rows, "No pickles installed.")
+  defp category_level(:apps, name) do
+    rows = for program <- classified(:apps), do: program_node(program)
+    level(name, rows, "No apps installed.")
   end
 
   defp category_level(:files, name) do
@@ -577,8 +581,8 @@ defmodule MayonnaiOS.Browser do
     level(name, places, "No roots configured.")
   end
 
-  defp category_level(:settings, name) do
-    {actions, apps} = Enum.split_with(classified(:settings), &(&1.action != nil))
+  defp category_level(:system, name) do
+    {actions, apps} = Enum.split_with(classified(:system), &(&1.action != nil))
 
     rows =
       Enum.map(apps, &program_node/1) ++
@@ -592,15 +596,18 @@ defmodule MayonnaiOS.Browser do
   end
 
   # The one config list, classified. `Programs.list/0` already appends the
-  # installed pickles' rows, which is what makes the Pickles column honest:
+  # installed pickles' rows, which is what makes the Apps column honest:
   # it shows what is on the disk now, not what config promised.
   defp classified(category) do
     Enum.filter(Programs.list(), &(classify(&1) == category))
   end
 
-  defp classify(%{action: action}) when action != nil, do: :settings
-  defp classify(%{app: {Pickles.App, _name}}), do: :pickles
-  defp classify(%{app: app}) when app != nil, do: :settings
+  # A row's own `:category` wins, so config can put an app wherever it
+  # belongs -- the Bluetooth controller is a thing to use, not a setting.
+  defp classify(%{category: category}) when category != nil, do: category
+  defp classify(%{action: action}) when action != nil, do: :system
+  defp classify(%{app: {Pickles.App, _name}}), do: :apps
+  defp classify(%{app: app}) when app != nil, do: :system
   defp classify(_program), do: :games
 
   # A verb of the launcher's own, shaped like a config row so the launcher's

--- a/lib/mayonnaios/files.ex
+++ b/lib/mayonnaios/files.ex
@@ -21,10 +21,11 @@ defmodule MayonnaiOS.Files do
 
   The roots come from the configuration this application already has --
   `:rom_roots`, `:bundle_root`, `:core_root` -- plus `/root` itself, because
-  the writable partition is the thing a file manager on this device is for.
-  Nothing names `/`: that is a 69 MB read-only squashfs and there is nothing
-  a file manager could do to it. `:file_roots` overrides the list, which is
-  how the tests point it at a temporary directory.
+  the writable partition is where everything worth editing lives, and `/`,
+  so the whole filesystem can be browsed. The rootfs is a read-only squashfs,
+  so a write anywhere under it fails with `:erofs` and the panel says so.
+  `:file_roots` overrides the list, which is how the tests point it at a
+  temporary directory.
 
   ## Names are rejected, not repaired
 
@@ -171,7 +172,8 @@ defmodule MayonnaiOS.Files do
       [
         %{key: "bundles", path: Bundle.root(), note: "installed bundles"},
         %{key: "cores", path: Cores.root(), note: "installed cores"},
-        %{key: "root", path: "/root", note: "the writable partition"}
+        %{key: "root", path: "/root", note: "the writable partition"},
+        %{key: "fs", path: "/", note: "the whole filesystem"}
       ]
   end
 

--- a/lib/mayonnaios/keyboard.ex
+++ b/lib/mayonnaios/keyboard.ex
@@ -28,7 +28,7 @@ defmodule MayonnaiOS.Keyboard do
 
       up / down / k / j   the D-pad
       z                   A -- launch the highlighted program
-      c                   X -- the diagnostics screen
+      c                   X -- bound to nothing, sent anyway
       enter               Menu -- back to the home screen
       backspace           Select
       p                   the power button -- sleep, and any key wakes
@@ -98,7 +98,7 @@ defmodule MayonnaiOS.Keyboard do
     "z" => :btn_b,
     # B: back -- close a column, clear an obituary
     "x" => :btn_a,
-    # X: diagnostics
+    # X, which the Launcher does not bind
     "c" => :btn_y,
     # Y: the second verb -- the actions sheet, and the answers it labels
     "v" => :btn_x,

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -46,8 +46,8 @@ defmodule MayonnaiOS.Launcher do
   before `Port.open/2` and releases when the program is reaped, which is the
   same pair of moments that already bracket the handover. Everything that
   draws consults it. And `set_root/2` below refuses while it is held, because
-  re-rooting the viewport is itself a write -- pressing X during a game would
-  otherwise paint the diagnostics screen into a framebuffer the game owns.
+  re-rooting the viewport is itself a write -- a button pressed during a game
+  must not paint a menu into a framebuffer the game owns.
 
   ## Giving the screen back requires the program to actually be dead
 
@@ -93,7 +93,6 @@ defmodule MayonnaiOS.Launcher do
                       confirmation, remove-a-character in the rename editor,
                       and the answer to the Power off row's question
       Menu            go back to the home screen, at its root column
-      X               switch between the menu and diagnostics
       Power           sleep -- backlight off, and any press wakes it
       Select+Menu     power off
 
@@ -219,7 +218,8 @@ defmodule MayonnaiOS.Launcher do
   # emits 308 and the one silkscreened Y emits 307: the DT's X/Y labels are
   # the wrong way round for this board's shell, the same way A and B are.
   #
-  # So :btn_y below really is the X button.
+  # So :btn_x below really is the Y button, and :btn_y -- physical X -- is
+  # bound to nothing.
   #
   # Y (:btn_x) is the second verb, and the panel says what it is. While the
   # Power off row's question is up it is the answer -- the confirming clause
@@ -228,7 +228,6 @@ defmodule MayonnaiOS.Launcher do
   # the delete on a confirmation, remove-a-character in the rename editor.
   @confirm_button :btn_x
   @actions_button :btn_x
-  @diagnostics_button :btn_y
 
   # Menu, doing double duty: alone it is the way back to the home screen,
   # and held with Select it powers off. The chord is tested first.
@@ -846,7 +845,6 @@ defmodule MayonnaiOS.Launcher do
   end
 
   defp bound(state, @launch_button), do: do_launch(state)
-  defp bound(state, @diagnostics_button), do: toggle_scene(state)
   defp bound(state, @up_button), do: move(state, -1)
   defp bound(state, @down_button), do: move(state, +1)
   defp bound(state, @left_button), do: browse(state, Browser.ascend(state.browser))
@@ -966,15 +964,6 @@ defmodule MayonnaiOS.Launcher do
     end
   end
 
-  # Flip between the menu and the diagnostics readout. The readout is
-  # what makes the physical checks -- charger, volume keys, headphone jack --
-  # answerable by looking at the device instead of over SSH.
-  defp toggle_scene(state) do
-    next = if state.scene == :home, do: :diagnostics, else: :home
-    show(next, state)
-    %{state | scene: next}
-  end
-
   defp poweroff(state, how) do
     Logger.info("[launcher] #{how}: powering off")
 
@@ -1031,8 +1020,9 @@ defmodule MayonnaiOS.Launcher do
     state
   end
 
-  # The Diagnostics row: the same screen X toggles, on the menu so it can be
-  # found without being told about the button.
+  # The Diagnostics row: the readout that makes the physical checks --
+  # charger, volume keys, headphone jack -- answerable by looking at the
+  # device instead of over SSH. Menu is the way back out.
   defp start_program(%{action: :diagnostics}, state) do
     state = %{state | scene: :diagnostics}
     show(:diagnostics, state)
@@ -1330,9 +1320,9 @@ defmodule MayonnaiOS.Launcher do
   defp set_root(nil, _param), do: :ok
 
   # Re-rooting the viewport is a repaint of the whole panel, so it is exactly
-  # what must not happen while a program holds the display. Two buttons reach
-  # here during a game: X, which flips to the diagnostics screen, and a D-pad
-  # press, which `move/2` already guards for the same reason.
+  # what must not happen while a program holds the display. The pad is this
+  # process's even during a game, so presses still arrive; `browse/2` already
+  # guards its own writes for the same reason, and this catches the rest.
   #
   # The state still moves -- the scene flips, the cursor moves -- and only the
   # write waits. `repaint/1` on the way out is what puts whichever screen that

--- a/lib/mayonnaios/panel.ex
+++ b/lib/mayonnaios/panel.ex
@@ -65,7 +65,7 @@ defmodule MayonnaiOS.Panel do
   ## Ownership is not the same question as which scene is showing
 
   The suppression is about who owns the panel, not about what is on it.
-  Someone can press X during a game and sit on the diagnostics screen while
+  Someone can launch a game from the diagnostics screen and sit on it while
   kmscube runs: the scene is alive, its one-second refresh is running, and
   every one of those refreshes would be a write into the framebuffer of a
   program that owns the display. That is why scenes ask this module rather

--- a/lib/mayonnaios/programs.ex
+++ b/lib/mayonnaios/programs.ex
@@ -36,6 +36,7 @@ defmodule MayonnaiOS.Programs do
           app: module() | {module(), term()} | nil,
           action: atom() | nil,
           args: [String.t()],
+          category: atom() | nil,
           installed?: boolean()
         }
 
@@ -79,6 +80,10 @@ defmodule MayonnaiOS.Programs do
       app: {module, arg},
       action: nil,
       args: [],
+      # Which launcher column the row lands in, or nil to let
+      # `MayonnaiOS.Browser` classify it. Carried through explicitly because
+      # this function rebuilds the map rather than merging into it.
+      category: Map.get(entry, :category),
       needs_udev: false,
       installed?: true
     }
@@ -107,6 +112,7 @@ defmodule MayonnaiOS.Programs do
       app: nil,
       action: action,
       args: [],
+      category: Map.get(entry, :category),
       needs_udev: false,
       installed?: true
     }
@@ -119,6 +125,7 @@ defmodule MayonnaiOS.Programs do
       app: module,
       action: nil,
       args: [],
+      category: Map.get(entry, :category),
       needs_udev: false,
       installed?: true
     }
@@ -131,6 +138,7 @@ defmodule MayonnaiOS.Programs do
       app: nil,
       action: nil,
       args: Map.get(entry, :args, []),
+      category: Map.get(entry, :category),
       # Programs that read input through udev; see MayonnaiOS.Udev. Carried
       # through explicitly because this function rebuilds the map rather than
       # merging into it, so anything not named here is dropped -- and a flag
@@ -160,6 +168,7 @@ defmodule MayonnaiOS.Programs do
       app: nil,
       action: nil,
       args: [],
+      category: nil,
       needs_udev: false,
       installed?: false
     }

--- a/lib/mayonnaios/scene/diagnostics.ex
+++ b/lib/mayonnaios/scene/diagnostics.ex
@@ -19,8 +19,8 @@ defmodule MayonnaiOS.Scene.Diagnostics do
   ## Once a second, unless a program owns the panel
 
   This is the only screen in this firmware that redraws itself on a clock
-  while the launcher may have handed the display to somebody else. Press X
-  during a game, or start a game from this screen, and the scene stays alive
+  while the launcher may have handed the display to somebody else. Start a
+  game from this screen and the scene stays alive
   with its one-second refresh running: every refresh is a changed graph, and
   Scenic writing `/dev/fb0` under a program that holds DRM hangs this board.
 

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -11,7 +11,7 @@ defmodule MayonnaiOS.BrowserTest do
 
   setup do
     # `Programs.list/0` appends a row for every installed pickle, read from
-    # disk on every call -- so without this, the Pickles column is however
+    # disk on every call -- so without this, the Apps column is however
     # many pickles the developer happens to have installed on the host.
     pickles_root =
       Path.join(System.tmp_dir!(), "browser-test-pickles-#{System.unique_integer([:positive])}")
@@ -38,7 +38,7 @@ defmodule MayonnaiOS.BrowserTest do
     test "names the categories, in order" do
       browser = Browser.new()
 
-      assert names(browser) == ["Games", "Files", "Pickles", "Settings"]
+      assert names(browser) == ["Games", "Files", "Apps", "System"]
       assert Browser.depth(browser) == 1
       assert Browser.selected(browser).name == "Games"
     end
@@ -46,7 +46,7 @@ defmodule MayonnaiOS.BrowserTest do
     test "the cursor wraps at both ends" do
       browser = Browser.new()
 
-      assert Browser.selected(Browser.move(browser, -1)).name == "Settings"
+      assert Browser.selected(Browser.move(browser, -1)).name == "System"
       assert Browser.selected(Browser.move(browser, 4)).name == "Games"
     end
 
@@ -60,7 +60,8 @@ defmodule MayonnaiOS.BrowserTest do
     setup do
       Application.put_env(:mayonnaios, :programs, [
         %{name: "RetroArch", path: "/nonexistent/retroarch"},
-        %{name: "Bluetooth controller", app: MayonnaiOS.Controller},
+        %{name: "Bluetooth controller", app: MayonnaiOS.Controller, category: :apps},
+        %{name: "Bluetooth devices", app: MayonnaiOS.Pairing},
         %{name: "Paint", app: {MayonnaiOS.Pickles.App, "paint"}},
         %{name: "Power off", action: :poweroff}
       ])
@@ -73,9 +74,9 @@ defmodule MayonnaiOS.BrowserTest do
       assert names(games) == ["RetroArch"]
     end
 
-    test "a pickle's row is a pickle" do
-      pickles = open(Browser.new(), "Pickles")
-      assert names(pickles) == ["Paint"]
+    test "pickles land in Apps, and so does a row whose config names the category" do
+      apps = open(Browser.new(), "Apps")
+      assert names(apps) == ["Bluetooth controller", "Paint"]
     end
 
     test "Files lists the roots" do
@@ -86,17 +87,17 @@ defmodule MayonnaiOS.BrowserTest do
       assert Browser.selected(files).kind == :place
     end
 
-    test "other apps and the actions land in Settings, verbs last" do
-      settings = open(Browser.new(), "Settings")
+    test "other apps and the actions land in System, verbs last" do
+      system = open(Browser.new(), "System")
 
-      assert names(settings) == ["Bluetooth controller", "Diagnostics", "Sleep", "Power off"]
+      assert names(system) == ["Bluetooth devices", "Diagnostics", "Sleep", "Power off"]
     end
 
-    test "the built-in Settings rows carry the launcher's own verbs" do
-      settings = open(Browser.new(), "Settings")
+    test "the built-in System rows carry the launcher's own verbs" do
+      system = open(Browser.new(), "System")
 
       actions =
-        for node <- List.last(settings.levels).entries, do: node.program.action
+        for node <- List.last(system.levels).entries, do: node.program.action
 
       assert actions == [nil, :diagnostics, :sleep, :poweroff]
     end
@@ -106,9 +107,9 @@ defmodule MayonnaiOS.BrowserTest do
     test "says why instead of listing nothing" do
       Application.put_env(:mayonnaios, :programs, [])
 
-      pickles = open(Browser.new(), "Pickles")
-      assert names(pickles) == []
-      assert List.last(pickles.levels).note == "No pickles installed."
+      apps = open(Browser.new(), "Apps")
+      assert names(apps) == []
+      assert List.last(apps.levels).note == "No apps installed."
     end
   end
 

--- a/test/files_test.exs
+++ b/test/files_test.exs
@@ -412,9 +412,8 @@ defmodule MayonnaiOS.FilesTest do
       assert "/root/ROMS" in paths
       assert "/root/mnt/games/ROMS" in paths
       assert "/root" in paths
-      # Nothing outside /root is offered, and there is no key that reaches
-      # the read-only squashfs.
-      assert Enum.all?(paths, &String.starts_with?(&1, "/root"))
+      # The whole filesystem is browsable from its own root.
+      assert "/" in paths
     end
   end
 end

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -50,7 +50,7 @@ defmodule MayonnaiOS.LauncherTest do
     test "the root column names the categories" do
       says = texts(Home.graph(Browser.new()))
 
-      for category <- ["Games", "Files", "Pickles", "Settings"] do
+      for category <- ["Games", "Files", "Apps", "System"] do
         assert category in says
       end
     end
@@ -341,7 +341,7 @@ defmodule MayonnaiOS.LauncherTest do
         {Launcher, device: "/nonexistent/event0", poweroff: fn -> send(test, :powered_off) end}
       )
 
-      # Into Settings -- the last category -- and down past Diagnostics and
+      # Into System -- the last category -- and down past Diagnostics and
       # Sleep onto the Power off row, which sits last on purpose.
       tap(:btn_dpad_up)
       tap(:btn_b)

--- a/test/panel_test.exs
+++ b/test/panel_test.exs
@@ -250,15 +250,16 @@ defmodule MayonnaiOS.PanelTest do
       assert Panel.owner() == {:program, "sleeper"}
       settle()
 
-      # X, which flips between the menu and diagnostics. During a game it
-      # must not re-root the viewport and paint a whole screen into a
-      # framebuffer the game owns.
-      press(:btn_y)
-      assert :sys.get_state(Launcher).scene == :diagnostics
-      refute_write("pressing X during a game")
+      # The pad is still the launcher's during a game, so a D-pad press walks
+      # the browser -- left closes the Games column. It must not re-root the
+      # viewport and paint the menu into a framebuffer the game owns.
+      assert MayonnaiOS.Browser.depth(Launcher.browser()) == 2
+      press(:btn_dpad_left)
+      assert MayonnaiOS.Browser.depth(Launcher.browser()) == 1
+      refute_write("pressing left during a game")
 
-      # And Menu out of the game: the hold is lifted and the screen X asked
-      # for is finally painted.
+      # And Menu out of the game: the hold is lifted and the menu the cursor
+      # moved on is finally painted.
       Launcher.stop_program()
       refute Panel.held?()
       assert_write("the repaint after the program was stopped")


### PR DESCRIPTION
## Summary

Four menu changes: Files gains a `/` root so the whole filesystem is browsable (not only `/root` and the shortcut roots), the Pickles category is renamed Apps and Settings is renamed System, the Bluetooth controller moves under Apps, and the X binding for diagnostics is removed — the row under System is now the way in, Menu the way out.

## Approach

The controller moves via a new optional `:category` key on config rows rather than a hardcoded module match, so config decides which column a row lands in and the browser's classification stays the fallback. `/` is added as an extra root rather than replacing `/root`, keeping the writable partition one press away; writes under the read-only squashfs fail with `:erofs`, which the panel already knows how to say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)