### PR TITLE
Add an online software update to the System menu

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -286,6 +286,12 @@ config :mayonnaios, :programs, [
   # the Bluetooth apps neither takes a device away from anything.
   %{name: "BEAM processes", app: {MayonnaiOS.Top, :beam}},
   %{name: "OS processes", app: {MayonnaiOS.Top, :os}},
+  # Checks kek/mayonnaios's GitHub releases for a newer version than the one
+  # running, and downloads and applies it with fwup if there is one -- the
+  # online half of what `mix upload` does from a dev machine. See
+  # `MayonnaiOS.Update`'s moduledoc for the download/apply/validate flow and
+  # why nothing here has to call `Nerves.Runtime.validate_firmware/0` itself.
+  %{name: "Software update", app: MayonnaiOS.Update.App},
   # Neither a program nor an app: a verb of the launcher's own. Selecting it
   # asks rather than acts -- Y answers, anything else cancels -- and it ends
   # in the same `Nerves.Runtime.poweroff/0` the Select+Menu chord reaches.

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -21,7 +21,7 @@ defmodule MayonnaiOS.Application do
       [status()] ++
         viewport() ++
         [controller_sessions(), pairing_sessions(), pickle_sessions()] ++
-        [top_sessions()] ++
+        [top_sessions(), update_sessions()] ++
         target_children()
 
     # See https://elixir.hexdocs.pm/Supervisor.html
@@ -94,6 +94,12 @@ defmodule MayonnaiOS.Application do
   # web API and the console should fail with "no such pickle" on a laptop,
   # not with "no such supervisor".
   defp pickle_sessions, do: MayonnaiOS.Pickles.sessions()
+
+  # The "Software update" app's DynamicSupervisor, empty until the row is
+  # opened -- same arrangement as the other apps, so `MayonnaiOS.Update.App`
+  # works on a laptop and fails with "no such supervisor" rather than an
+  # exception if it is ever started before this line runs.
+  defp update_sessions, do: MayonnaiOS.Update.App.sessions()
 
   # List all child processes to be supervised
   if Mix.target() == :host do

--- a/lib/mayonnaios/scene/update.ex
+++ b/lib/mayonnaios/scene/update.ex
@@ -1,0 +1,236 @@
+defmodule MayonnaiOS.Scene.Update do
+  @moduledoc """
+  What the panel shows while `MayonnaiOS.Update.App` has the buttons.
+
+  Draws `MayonnaiOS.Update.App.snapshot/0` and nothing else, told when to
+  redraw by `App.watch/1` -- the same arrangement as `MayonnaiOS.Scene.Top`,
+  for the same reason: `set_root/3` terminates this scene on every repaint
+  the launcher does, so nothing may be remembered here.
+  """
+
+  use Scenic.Scene
+
+  alias MayonnaiOS.Scene.StatusBar
+  alias MayonnaiOS.Update.App
+  alias Scenic.Graph
+
+  import Scenic.Primitives
+
+  @width 640
+  @height 480
+
+  @bg {12, 14, 22}
+  @title {235, 238, 245}
+  @label {150, 165, 195}
+  @good {110, 220, 150}
+  @fail {245, 110, 120}
+  @dim {110, 125, 155}
+
+  @status_bar StatusBar.height()
+
+  @title_y 50
+  @body_y 130
+  @detail_y 165
+  @bar_y 200
+  @bar_width @width - 40
+  @bar_height 18
+
+  @footer_rule 446
+  @footer_y 466
+
+  @impl Scenic.Scene
+  def init(scene, _param, _opts) do
+    {:ok, scene |> show(watch())}
+  end
+
+  @impl GenServer
+  def handle_info({:update_app, snapshot}, scene), do: {:noreply, show(scene, snapshot)}
+  def handle_info(_message, scene), do: {:noreply, scene}
+
+  # The app not running is a state to render rather than crash on, matching
+  # `MayonnaiOS.Scene.Top`.
+  defp watch do
+    App.watch(self())
+  rescue
+    _error -> :stopped
+  catch
+    :exit, _reason -> :stopped
+  end
+
+  defp show(scene, snapshot), do: push_graph(scene, graph(snapshot))
+
+  @doc """
+  The height of the strip this scene leaves for the shared top bar, public so
+  a test can assert that nothing is drawn above it.
+  """
+  @spec status_bar() :: pos_integer()
+  def status_bar, do: @status_bar
+
+  @doc """
+  Build the graph for a snapshot.
+
+  Public because it is the tested surface: no viewport, no driver and no
+  framebuffer, so a host test can assert what the panel says for every
+  state without a running app.
+  """
+  @spec graph(map() | :stopped) :: Scenic.Graph.t()
+  def graph(:stopped) do
+    base()
+    |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, @body_y})
+    |> footer("Menu goes back.")
+  end
+
+  def graph(%{status: :checking}) do
+    base()
+    |> text("Checking for an update...",
+      font_size: 22,
+      fill: {:color, @label},
+      translate: {20, @body_y}
+    )
+    |> footer("Menu goes back.")
+  end
+
+  def graph(%{status: :up_to_date, result: result}) do
+    base()
+    |> text("Up to date", font_size: 26, fill: {:color, @good}, translate: {20, @body_y})
+    |> text(version_line(result),
+      font_size: 16,
+      fill: {:color, @label},
+      translate: {20, @detail_y}
+    )
+    |> footer("A checks again. Menu goes back.")
+  end
+
+  def graph(%{status: :available, result: %{asset: nil} = result}) do
+    base()
+    |> text("Update available: #{result.latest}",
+      font_size: 22,
+      fill: {:color, @title},
+      translate: {20, @body_y}
+    )
+    |> text("No firmware file has been published for this device yet.",
+      font_size: 16,
+      fill: {:color, @fail},
+      translate: {20, @detail_y}
+    )
+    |> footer("Menu goes back.")
+  end
+
+  def graph(%{status: :available, result: result}) do
+    base()
+    |> text("Update available: #{result.latest}",
+      font_size: 22,
+      fill: {:color, @title},
+      translate: {20, @body_y}
+    )
+    |> text(version_line(result),
+      font_size: 16,
+      fill: {:color, @label},
+      translate: {20, @detail_y}
+    )
+    |> footer("A downloads and installs it. Menu goes back.")
+  end
+
+  def graph(%{status: :downloading, downloaded: downloaded, total: total}) do
+    base()
+    |> text("Downloading and installing...",
+      font_size: 22,
+      fill: {:color, @title},
+      translate: {20, @body_y}
+    )
+    |> progress_bar(downloaded, total)
+    |> footer("Menu cancels. The current firmware is untouched either way.")
+  end
+
+  def graph(%{status: :done}) do
+    base()
+    |> text("Installed", font_size: 26, fill: {:color, @good}, translate: {20, @body_y})
+    |> text("A restarts into it now.",
+      font_size: 16,
+      fill: {:color, @label},
+      translate: {20, @detail_y}
+    )
+    |> footer("A reboots. Menu goes back without rebooting.")
+  end
+
+  def graph(%{status: :error, error: reason}) do
+    base()
+    |> text("Update failed", font_size: 26, fill: {:color, @fail}, translate: {20, @body_y})
+    |> text(reason(reason), font_size: 15, fill: {:color, @label}, translate: {20, @detail_y})
+    |> footer("A tries again. Menu goes back.")
+  end
+
+  # :idle, or anything else not drawn above.
+  def graph(_snapshot) do
+    base()
+    |> text("Press A to check for an update.",
+      font_size: 20,
+      fill: {:color, @label},
+      translate: {20, @body_y}
+    )
+    |> footer("Menu goes back.")
+  end
+
+  defp base do
+    Graph.build(font: :roboto, font_size: 14)
+    |> rect({@width, @height}, fill: {:color, @bg})
+    |> StatusBar.mount()
+    |> text("Software update", font_size: 20, fill: {:color, @title}, translate: {20, @title_y})
+  end
+
+  defp version_line(%{current: current, latest: latest, comparable?: true}),
+    do: "Running #{current}, latest is #{latest}."
+
+  defp version_line(%{current: current, tag: tag}),
+    do: "Running #{current}; latest release is tagged #{tag} (not a comparable version)."
+
+  defp progress_bar(graph, _downloaded, nil) do
+    text(graph, "Size unknown", font_size: 16, fill: {:color, @label}, translate: {20, @bar_y})
+  end
+
+  defp progress_bar(graph, downloaded, total) when total > 0 do
+    fraction = downloaded |> min(total) |> Kernel./(total)
+    fill_width = round(@bar_width * fraction)
+
+    graph
+    |> rect({@bar_width, @bar_height}, fill: {:color, @dim}, translate: {20, @bar_y})
+    |> rect({max(fill_width, 1), @bar_height}, fill: {:color, @good}, translate: {20, @bar_y})
+    |> text("#{bytes(downloaded)} / #{bytes(total)} (#{round(fraction * 100)}%)",
+      font_size: 15,
+      fill: {:color, @label},
+      translate: {20, @bar_y + @bar_height + 20}
+    )
+  end
+
+  defp progress_bar(graph, downloaded, _total) do
+    text(graph, "#{bytes(downloaded)} downloaded",
+      font_size: 16,
+      fill: {:color, @label},
+      translate: {20, @bar_y}
+    )
+  end
+
+  defp footer(graph, words) do
+    graph
+    |> rect({@width - 40, 1}, fill: {:color, @dim}, translate: {20, @footer_rule})
+    |> text(words, font_size: 14, fill: {:color, @label}, translate: {20, @footer_y})
+  end
+
+  defp bytes(nil), do: "--"
+  defp bytes(b) when b >= 1024 * 1024, do: "#{Float.round(b / (1024 * 1024), 1)}M"
+  defp bytes(b) when b >= 1024, do: "#{div(b, 1024)}K"
+  defp bytes(b), do: "#{b}"
+
+  defp reason(:no_releases), do: "This repository has no published releases yet."
+  defp reason(:no_asset), do: "The release has no firmware file for this device."
+
+  defp reason({:insufficient_space, needed, path}),
+    do: "Not enough free space on #{path} (need #{bytes(needed)})."
+
+  defp reason({:http, _}), do: "Could not reach GitHub. Check the network connection."
+  defp reason({:http_status, status}), do: "GitHub returned an unexpected status (#{status})."
+  defp reason({:fwup_failed, status, _output}), do: "fwup exited with status #{status}."
+  defp reason(:fwup_not_found), do: "fwup is missing from this image."
+  defp reason(:no_devpath), do: "The firmware device path is unknown."
+  defp reason(other), do: inspect(other)
+end

--- a/lib/mayonnaios/update.ex
+++ b/lib/mayonnaios/update.ex
@@ -1,0 +1,356 @@
+defmodule MayonnaiOS.Update do
+  @moduledoc """
+  Checks GitHub for a newer release, downloads its firmware asset, and
+  applies it with `fwup` -- the online half of what `mix upload` does from a
+  dev machine.
+
+  This is the logic; `MayonnaiOS.Update.App` is the menu app that drives it
+  from a button and `MayonnaiOS.Scene.Update` is what the panel shows. Split
+  the same way `MayonnaiOS.Bundle` is split from the program rows that
+  install one: the network and the disk are the thin, hard-to-test part, so
+  every step here takes its I/O through an injectable argument and defaults
+  to the real thing, the way `MayonnaiOS.Files.space/1` and
+  `MayonnaiOS.Launcher.Signals` do.
+
+  ## The three steps, and what each trusts
+
+      check/1     GitHub's releases API, parsed into "is there a newer
+                   tag, and does it have a firmware asset for this target"
+      download/2  streamed straight to a file, like `MayonnaiOS.Bundle` --
+                   this device has 1 GB of RAM and a firmware image is
+                   tens of megabytes
+      apply/2     `fwup -t upgrade`, the same task `mix upload` invokes over
+                   SSH, against whichever slot is not currently running
+
+  There is no checksum gate here the way there is in `MayonnaiOS.Bundle`.
+  `fwup` already has one: every Nerves `.fw` is itself signed/framed and
+  `fwup` refuses a corrupt or truncated one before it touches the inactive
+  partition, so the trust anchor for firmware is `fwup`'s own validation
+  rather than a hash carried alongside the download the way a bundle's is.
+  TLS on the download is still checked -- see `MayonnaiOS.Bundle` for why
+  that is defence in depth rather than the whole story.
+
+  ## Why this device needs `Nerves.Runtime.validate_firmware/0` and does not call it
+
+  `nerves_fw_autovalidate=0` on this board (see `uboot/uboot.env` in
+  `nerves_system_rg40xxv`): a freshly applied slot is **not** trusted by
+  U-Boot until something marks it validated, and if nothing does before the
+  next reboot, U-Boot reverts to the slot that was already running. That is
+  deliberate -- the alternative is a kernel that fails to boot leaving the
+  device stuck, unrecoverable without reflashing the card -- but it means
+  *something* in the image has to call `validate_firmware/0` after the new
+  firmware has actually come up.
+
+  This project already has that something, system-wide:
+
+      config :nerves_runtime, startup_guard_enabled: true
+
+  in `config/target.exs`. `Nerves.Runtime.StartupGuard` validates the
+  running slot once every OTP application in this release has started, on
+  *every* boot -- not only the one after an update. So the flow this module
+  drives is: apply the new firmware, offer a reboot, and let the boot that
+  follows validate itself the same way every other boot on this device
+  does. Nothing here calls `validate_firmware/0` a second time, because a
+  second, update-specific validator racing the StartupGuard is exactly the
+  latch bug documented in `fwup-ops.conf`'s `task validate` -- one validator
+  is the point.
+
+  What that leaves as a real risk, and one this module cannot remove: if the
+  device is powered off during the *first* boot of the new firmware, before
+  every application has started, U-Boot reverts on the next boot. That is
+  the same risk `mix upload` already carries and is not new here -- it is
+  the reason `nerves_fw_booted`/`nerves_fw_validated` exist at all.
+
+  ## What is not handled
+
+  `apply/2` only ever writes the inactive slot, so a download or apply that
+  is interrupted -- including by leaving the app's menu screen, which stops
+  its process -- never touches the firmware that is currently running.
+  Retrying is always safe: the worst case is a half-written inactive slot
+  that the next attempt overwrites.
+  """
+
+  require Logger
+
+  @default_repo "kek/mayonnaios"
+
+  @type asset :: %{name: String.t(), url: String.t(), size: non_neg_integer() | nil}
+
+  @type check_result :: %{
+          current: String.t(),
+          latest: String.t(),
+          tag: String.t(),
+          comparable?: boolean(),
+          available?: boolean(),
+          notes: String.t() | nil,
+          published_at: String.t() | nil,
+          asset: asset() | nil
+        }
+
+  @doc """
+  The version of the firmware actually running, from the OTP release's own
+  `.app` file -- the same number `mix.exs`'s `@version` compiles in.
+
+  `"0.0.0"` if the application spec has not loaded, which cannot happen
+  outside of a test that has gone out of its way to unload it, but a
+  version string is more useful there than a crash.
+  """
+  @spec running_version() :: String.t()
+  def running_version do
+    case Application.spec(:mayonnaios, :vsn) do
+      nil -> "0.0.0"
+      vsn -> List.to_string(vsn)
+    end
+  end
+
+  @doc """
+  Ask GitHub whether a newer release than `current_version` exists, and
+  whether it carries a firmware asset for `target`.
+
+  Options, all for tests -- the defaults are what the device actually uses:
+
+    * `:repo` -- `"owner/name"`, default `"kek/mayonnaios"`
+    * `:target` -- the Nerves target to find an asset for, default
+      `Nerves.Runtime.mix_target/0`
+    * `:current_version` -- default `running_version/0`
+    * `:fetch` -- `(url -> {:ok, %{status: integer, body: binary}} |
+      {:error, term}})`, default an HTTPS GET through `:httpc`
+
+  Never raises. `:no_releases` is returned for a repo with no releases at
+  all -- GitHub's `/releases/latest` is a 404 in that case, not an empty
+  list -- which is where this project is today.
+  """
+  @spec check(keyword()) :: {:ok, check_result()} | {:error, term()}
+  def check(opts \\ []) do
+    repo = Keyword.get(opts, :repo, Application.get_env(:mayonnaios, :update_repo, @default_repo))
+    target = Keyword.get(opts, :target, Nerves.Runtime.mix_target())
+    current = Keyword.get(opts, :current_version, running_version())
+    fetch = Keyword.get(opts, :fetch, &http_get/1)
+
+    url = "https://api.github.com/repos/#{repo}/releases/latest"
+
+    with {:ok, %{status: 200, body: body}} <- fetch.(url),
+         {:ok, release} <- decode(body) do
+      {:ok, build_result(release, target, current)}
+    else
+      {:ok, %{status: 404}} -> {:error, :no_releases}
+      {:ok, %{status: status}} -> {:error, {:http_status, status}}
+      {:error, reason} -> {:error, {:http, reason}}
+      :error -> {:error, :invalid_response}
+    end
+  end
+
+  @doc """
+  How `current` compares to `latest`, both plain version strings.
+
+  Uses `Version.compare/2`, which is stricter than a tag name: a release
+  tagged `v1.2` rather than `v1.2.0` is not a version this can compare, and
+  `{:error, :unparseable}` says so rather than guessing. `check/1` still
+  reports the raw strings either way -- `comparable?` is what a screen uses
+  to decide whether to trust `available?` at all.
+  """
+  @spec compare_versions(String.t(), String.t()) ::
+          {:ok, :lt | :eq | :gt} | {:error, :unparseable}
+  def compare_versions(current, latest) do
+    {:ok, Version.compare(current, latest)}
+  rescue
+    Version.InvalidVersionError -> {:error, :unparseable}
+  end
+
+  @doc """
+  A release tag as a bare version string: `"v1.2.0"` and `"1.2.0"` both
+  become `"1.2.0"`. Only the leading `v`/`V` is stripped -- anything else
+  odd about the tag is left in, for `compare_versions/2` to reject.
+  """
+  @spec normalize_tag(String.t()) :: String.t()
+  def normalize_tag(tag) when is_binary(tag) do
+    case tag do
+      <<v, rest::binary>> when v in [?v, ?V] -> rest
+      other -> other
+    end
+  end
+
+  @doc """
+  Whether `dest_dir`'s filesystem has room for `needed_bytes`, with a 5%
+  margin on top -- `fwup` writes progressively rather than staging a whole
+  second copy, but a download that lands exactly at the last free byte and
+  a filesystem that is never quite as free as `df` says are both real, and
+  a margin is cheaper than explaining either.
+
+  `nil` for `needed_bytes` -- an asset with no reported size -- passes, since
+  there is nothing to check against; the download itself still fails cleanly
+  if the disk fills up.
+  """
+  @spec enough_space?(String.t(), non_neg_integer() | nil) :: boolean()
+  def enough_space?(_dest_dir, nil), do: true
+
+  def enough_space?(dest_dir, needed_bytes) do
+    case MayonnaiOS.Files.space(dest_dir) do
+      %{free: free} -> free >= needed_bytes + div(needed_bytes, 20)
+      nil -> false
+    end
+  end
+
+  @doc """
+  Download `asset` to `dest`, streamed straight to disk.
+
+  Refuses before it starts if `enough_space?/2` says there is not room, so a
+  download that would fail with the disk full instead fails immediately with
+  the number that explains why. Injectable `:get` is `(url, dest -> :ok |
+  {:error, term})`, for tests; the default streams through `:httpc` the same
+  way `MayonnaiOS.Bundle.install/2` does.
+  """
+  @spec download(asset(), String.t(), keyword()) :: :ok | {:error, term()}
+  def download(asset, dest, opts \\ []) do
+    get = Keyword.get(opts, :get, &http_get_to_file/2)
+
+    if enough_space?(Path.dirname(dest), asset[:size]) do
+      File.rm(dest)
+      get.(asset.url, dest)
+    else
+      {:error, {:insufficient_space, asset[:size], Path.dirname(dest)}}
+    end
+  end
+
+  @doc """
+  Apply a downloaded `.fw` file to the inactive firmware slot with `fwup`'s
+  `upgrade` task -- the same task `ssh_subsystem_fwup` runs for `mix upload`,
+  the only difference being that the bytes are already a local file instead
+  of arriving over a port's stdin.
+
+  Options, for tests and for the one thing that varies on a real device:
+
+    * `:devpath` -- default `Nerves.Runtime.KV.get("nerves_fw_devpath")`
+    * `:fwup_path` -- default `System.find_executable("fwup")`
+    * `:cmd` -- `(path, args, opts -> {output, status})`, default
+      `System.cmd/3`
+
+  Never touches the currently running slot: `fwup upgrade` always targets
+  whichever one is not active, which is what makes retrying after any
+  failure here safe.
+  """
+  @spec apply(String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def apply(fw_path, opts \\ []) do
+    devpath = Keyword.get(opts, :devpath, Nerves.Runtime.KV.get("nerves_fw_devpath"))
+    fwup_path = Keyword.get(opts, :fwup_path, System.find_executable("fwup"))
+    cmd = Keyword.get(opts, :cmd, &System.cmd/3)
+
+    cond do
+      is_nil(devpath) ->
+        {:error, :no_devpath}
+
+      is_nil(fwup_path) ->
+        {:error, :fwup_not_found}
+
+      true ->
+        args = ["--apply", "--no-unmount", "-i", fw_path, "-t", "upgrade", "-d", devpath]
+
+        case cmd.(fwup_path, args, stderr_to_stdout: true) do
+          {output, 0} ->
+            Logger.info("[update] fwup applied #{fw_path}")
+            {:ok, output}
+
+          {output, status} ->
+            Logger.warning("[update] fwup exited #{status}: #{String.trim(output)}")
+            {:error, {:fwup_failed, status, output}}
+        end
+    end
+  end
+
+  # -- release parsing ---------------------------------------------------------
+
+  defp build_result(release, target, current) do
+    tag = Map.get(release, "tag_name", "")
+    latest = normalize_tag(tag)
+    assets = Map.get(release, "assets", [])
+
+    {comparable?, available?} =
+      case compare_versions(current, latest) do
+        {:ok, :lt} -> {true, true}
+        {:ok, _eq_or_gt} -> {true, false}
+        {:error, :unparseable} -> {false, false}
+      end
+
+    %{
+      current: current,
+      latest: latest,
+      tag: tag,
+      comparable?: comparable?,
+      available?: available?,
+      notes: Map.get(release, "body"),
+      published_at: Map.get(release, "published_at"),
+      asset: find_asset(assets, target)
+    }
+  end
+
+  # An asset is this target's if it ends in ".fw" and names the target
+  # somewhere in its filename -- "mayonnaios_rg40xxv.fw" -- rather than by a
+  # fixed name, since nothing has published one yet to pin the convention
+  # down further. `nil` when nothing matches: a release can exist with no
+  # firmware asset for this device at all, and that is a state worth
+  # showing rather than treating as "no update".
+  defp find_asset(assets, target) do
+    target_str = to_string(target)
+
+    Enum.find_value(assets, fn asset ->
+      name = Map.get(asset, "name", "")
+
+      if String.ends_with?(name, ".fw") and String.contains?(name, target_str) do
+        %{name: name, url: Map.get(asset, "browser_download_url"), size: Map.get(asset, "size")}
+      end
+    end)
+  end
+
+  defp decode(body) do
+    {:ok, :json.decode(body)}
+  rescue
+    _ -> :error
+  end
+
+  # -- the real transport -------------------------------------------------------
+  #
+  # Both follow MayonnaiOS.Bundle's lead: :httpc and :ssl from OTP, verified
+  # TLS as defence in depth. See that module's moduledoc for the "why not a
+  # dependency" account -- it applies here unchanged.
+
+  defp http_get(url) do
+    {:ok, _} = Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+
+    request = {String.to_charlist(url), user_agent()}
+    http_opts = [timeout: 15_000, connect_timeout: 10_000, ssl: ssl_opts()]
+
+    case :httpc.request(:get, request, http_opts, body_format: :binary) do
+      {:ok, {{_line, status, _reason}, _headers, body}} -> {:ok, %{status: status, body: body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp http_get_to_file(url, dest) do
+    {:ok, _} = Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+
+    request = {String.to_charlist(url), user_agent()}
+    http_opts = [timeout: :infinity, connect_timeout: 30_000, ssl: ssl_opts()]
+
+    case :httpc.request(:get, request, http_opts, stream: String.to_charlist(dest)) do
+      {:ok, :saved_to_file} -> :ok
+      {:ok, {{_, status, _}, _, _}} -> {:error, {:http_status, status}}
+      {:error, reason} -> {:error, {:http, reason}}
+    end
+  end
+
+  # GitHub's API 403s a request with no User-Agent at all.
+  defp user_agent, do: [{~c"User-Agent", ~c"mayonnaios-update"}]
+
+  defp ssl_opts do
+    [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      depth: 3,
+      customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
+    ]
+  rescue
+    _ -> [verify: :verify_peer, cacerts: []]
+  end
+end

--- a/lib/mayonnaios/update/app.ex
+++ b/lib/mayonnaios/update/app.ex
@@ -1,0 +1,339 @@
+defmodule MayonnaiOS.Update.App do
+  @moduledoc """
+  The System menu's "Software update" row: checks GitHub for a newer
+  release the moment it is opened, and drives `MayonnaiOS.Update` through
+  download, apply and reboot on the confirm button.
+
+  An app rather than a program, on the same terms as `MayonnaiOS.Top`: a
+  module in this firmware, started in this VM, with a scene of its own and
+  no external process handed the screen. Unlike Top it needs no hardware at
+  all, so nothing stops two changes at once the way the Bluetooth apps stop
+  each other -- there is simply one process, because there is one screen.
+
+  ## The state machine
+
+      :idle        not checked yet, or the user asked to check again
+      :checking    the GitHub request is in flight
+      :up_to_date  checked; nothing newer
+      :available   checked; a newer release exists, with a firmware asset
+      :downloading fetching the asset to a tmpfs path, `:downloaded`/`:total`
+                   updated a couple of times a second by polling the file's
+                   size -- no callback from `:httpc`'s streamed download, but
+                   a stat cheap enough to run twice a second
+      :done        `fwup` accepted it; a reboot is what makes it count
+      :error       whatever went wrong, at whichever step
+
+  A on `:idle`/`:up_to_date`/`:error` (re)checks. A on `:available` starts
+  the download-and-apply. A on `:done` reboots. Every other state ignores A,
+  and Menu is the launcher's own -- neither this module nor its scene has to
+  do anything with it beyond dropping it, matching `MayonnaiOS.Top`.
+
+  ## Download and apply run off this process, deliberately
+
+  Both are seconds-long I/O and neither belongs on a GenServer that also has
+  to answer `snapshot/0` for a redrawing scene. `spawn_monitor/1` rather than
+  `Task.async/1`: a `Task` links the caller, and a transfer that raised would
+  take this process down mid-update with nothing on the panel to say why.
+  The worker function catches everything of its own and always sends a
+  result; the monitor is a backstop for what should therefore never happen.
+
+  ## Leaving mid-update
+
+  Pressing Menu stops this app like any other, which kills this process and
+  the download-or-apply worker with it. That is safe for the reason
+  `MayonnaiOS.Update`'s moduledoc gives: `fwup upgrade` only ever writes the
+  slot that is not running, so an interrupted apply leaves a half-written
+  inactive partition and nothing else -- reopening this screen and trying
+  again overwrites it. Nothing is lost but the time spent.
+  """
+
+  use GenServer
+
+  alias MayonnaiOS.Update
+
+  @sessions MayonnaiOS.Update.App.Sessions
+
+  # Physical A and Menu, in the launcher's own vocabulary -- see
+  # MayonnaiOS.Launcher's moduledoc for why the atom named "b" is the button
+  # printed "A" on this board's shell.
+  @advance :btn_b
+  @menu :btn_mode
+
+  @default_tmp_path "/tmp/mayonnaios_update.fw"
+  @poll_ms 500
+
+  # -- the app protocol the Launcher uses --------------------------------------
+
+  @doc """
+  Start the app. Idempotent: pressing the menu row again while it is already
+  running shows the same process rather than starting a second one.
+  """
+  @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(opts \\ []) do
+    case DynamicSupervisor.start_child(@sessions, {__MODULE__, opts}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Stop the app."
+  @spec stop() :: :ok
+  def stop do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(@sessions, pid)
+    end
+  end
+
+  @doc """
+  Forward an evdev report from the Launcher.
+
+  A cast, for the same reason `MayonnaiOS.Top.input/1` is: nothing here may
+  make a button press wait on this process.
+  """
+  @spec input([tuple()]) :: :ok
+  def input(events) do
+    if Process.whereis(__MODULE__), do: GenServer.cast(__MODULE__, {:input, events}), else: :ok
+  end
+
+  @doc "The scene the launcher shows while this app has the buttons."
+  @spec scene() :: module()
+  def scene, do: MayonnaiOS.Scene.Update
+
+  @doc """
+  Be told when the state changes, as `{:update_app, snapshot}`.
+
+  Same arrangement as `MayonnaiOS.Top.watch/1`: the scene calls this instead
+  of polling, and the watcher is monitored so a scene torn down by
+  `set_root/3` drops itself.
+  """
+  @spec watch(pid()) :: map() | :stopped
+  def watch(pid) do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, {:watch, pid}), else: :stopped
+  end
+
+  @doc "Everything the panel needs, as one map. `:stopped` if the app is not running."
+  @spec snapshot() :: map() | :stopped
+  def snapshot do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, :snapshot), else: :stopped
+  end
+
+  @doc "The DynamicSupervisor the app runs under, for the application tree."
+  @spec sessions() :: Supervisor.child_spec()
+  def sessions do
+    %{
+      id: @sessions,
+      start: {DynamicSupervisor, :start_link, [[name: @sessions, strategy: :one_for_one]]},
+      type: :supervisor
+    }
+  end
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      # Temporary, like the other app sessions: whatever went wrong is in the
+      # log, and a restart would land on a screen the user already left.
+      restart: :temporary
+    }
+  end
+
+  @doc false
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  # -- state --------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    state = %{
+      status: :idle,
+      result: nil,
+      error: nil,
+      downloaded: 0,
+      total: nil,
+      worker: nil,
+      tmp_path: Keyword.get(opts, :tmp_path, @default_tmp_path),
+      poll_ms: Keyword.get(opts, :poll_ms, @poll_ms),
+      check_opts: Keyword.get(opts, :check_opts, []),
+      download_opts: Keyword.get(opts, :download_opts, []),
+      apply_opts: Keyword.get(opts, :apply_opts, []),
+      # Injectable for the tests, the same way `MayonnaiOS.Launcher`'s
+      # `:poweroff` is: the real thing is `no_return()` and cannot run on a
+      # laptop, or in a test, without ending the process running it.
+      reboot: Keyword.get(opts, :reboot, &Nerves.Runtime.reboot/0),
+      watchers: []
+    }
+
+    {:ok, run_check(state)}
+  end
+
+  @impl GenServer
+  def handle_call(:snapshot, _from, state), do: {:reply, snapshot_of(state), state}
+
+  def handle_call({:watch, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, snapshot_of(state), %{state | watchers: [pid | state.watchers]}}
+  end
+
+  @impl GenServer
+  def handle_cast({:input, events}, state) do
+    {:noreply, state |> apply_events(events) |> notify(state)}
+  end
+
+  @impl GenServer
+  def handle_info({:update_check_done, result}, state) do
+    state = apply_check_result(result, state)
+    {:noreply, notify(state, nil)}
+  end
+
+  def handle_info({:update_transfer_done, result}, state) do
+    state = apply_transfer_result(result, state)
+    {:noreply, notify(state, nil)}
+  end
+
+  def handle_info(:poll_progress, %{status: :downloading} = state) do
+    state = %{state | downloaded: file_size(state.tmp_path)}
+    schedule_progress(state)
+    {:noreply, notify(state, nil)}
+  end
+
+  # Arrives once more after the transfer has already finished; downloading
+  # is over by then, and there is nothing left to poll for.
+  def handle_info(:poll_progress, state), do: {:noreply, state}
+
+  # The worker died without sending a result at all -- not the outcome its
+  # own rescue clause is supposed to guarantee, so this is a bug rather than
+  # a reported failure. Still becomes a visible error instead of a screen
+  # that says "downloading..." forever.
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{worker: {worker_pid, ref}} = state)
+      when is_pid(worker_pid) do
+    state = %{state | status: :error, error: {:worker_crashed, reason}, worker: nil}
+    {:noreply, notify(state, nil)}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | watchers: List.delete(state.watchers, pid)}}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # -- transitions ----------------------------------------------------------
+
+  defp run_check(state) do
+    parent = self()
+    check_opts = state.check_opts
+
+    {pid, ref} =
+      spawn_monitor(fn -> send(parent, {:update_check_done, Update.check(check_opts)}) end)
+
+    %{state | status: :checking, error: nil, worker: {pid, ref}}
+  end
+
+  defp apply_check_result({:ok, %{available?: true} = result}, state),
+    do: %{state | status: :available, result: result, error: nil, worker: nil}
+
+  defp apply_check_result({:ok, result}, state),
+    do: %{state | status: :up_to_date, result: result, error: nil, worker: nil}
+
+  defp apply_check_result({:error, reason}, state),
+    do: %{state | status: :error, result: nil, error: reason, worker: nil}
+
+  defp start_transfer(%{result: %{asset: nil}} = state) do
+    %{state | status: :error, error: :no_asset}
+  end
+
+  defp start_transfer(state) do
+    parent = self()
+    asset = state.result.asset
+    tmp_path = state.tmp_path
+    download_opts = state.download_opts
+    apply_opts = state.apply_opts
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        result = transfer(asset, tmp_path, download_opts, apply_opts)
+        send(parent, {:update_transfer_done, result})
+      end)
+
+    schedule_progress(state)
+    %{state | status: :downloading, downloaded: 0, total: asset.size, worker: {pid, ref}}
+  end
+
+  # Runs off the GenServer; see the moduledoc for why. Always returns rather
+  # than raising, so the caller always gets a result to show.
+  defp transfer(asset, tmp_path, download_opts, apply_opts) do
+    with :ok <- Update.download(asset, tmp_path, download_opts),
+         {:ok, _output} <- Update.apply(tmp_path, apply_opts) do
+      :ok
+    end
+  rescue
+    e -> {:error, {:exception, Exception.message(e)}}
+  after
+    # Tmpfs is RAM on this device; the file has done its job whether fwup
+    # accepted it or not, and there is no reason to hold onto ~1GB's worth
+    # of it either way.
+    File.rm(tmp_path)
+  end
+
+  defp apply_transfer_result(:ok, state),
+    do: %{state | status: :done, error: nil, worker: nil}
+
+  defp apply_transfer_result({:error, reason}, state),
+    do: %{state | status: :error, error: reason, worker: nil}
+
+  defp schedule_progress(state), do: Process.send_after(self(), :poll_progress, state.poll_ms)
+
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} -> size
+      _error -> 0
+    end
+  end
+
+  # -- input ------------------------------------------------------------------
+
+  defp apply_events(state, events) do
+    Enum.reduce(events, state, fn
+      {:ev_key, key, 1}, acc -> press(acc, key)
+      _event, acc -> acc
+    end)
+  end
+
+  defp press(state, @menu), do: state
+
+  defp press(%{status: status} = state, @advance) when status in [:idle, :up_to_date, :error],
+    do: run_check(state)
+
+  defp press(%{status: :available} = state, @advance), do: start_transfer(state)
+  defp press(%{status: :done} = state, @advance), do: reboot(state)
+  defp press(state, _key), do: state
+
+  defp reboot(state) do
+    state.reboot.()
+    state
+  end
+
+  # -- snapshot -----------------------------------------------------------------
+
+  defp snapshot_of(state) do
+    %{
+      status: state.status,
+      result: state.result,
+      error: state.error,
+      downloaded: state.downloaded,
+      total: state.total
+    }
+  end
+
+  defp notify(state, previous) do
+    if previous != nil and snapshot_of(state) == snapshot_of(previous) do
+      state
+    else
+      snapshot = snapshot_of(state)
+      Enum.each(state.watchers, &send(&1, {:update_app, snapshot}))
+      state
+    end
+  end
+end

--- a/test/update/app_test.exs
+++ b/test/update/app_test.exs
@@ -1,0 +1,293 @@
+defmodule MayonnaiOS.Update.AppTest do
+  # Not async: the app is a named process.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Update.App
+  alias MayonnaiOS.Scene.Update, as: Scene
+
+  @advance :btn_b
+  @menu :btn_mode
+
+  defp release(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "tag_name" => "v0.2.0",
+        "assets" => [
+          %{
+            "name" => "mayonnaios_rg40xxv.fw",
+            "browser_download_url" => "https://example.test/x.fw",
+            "size" => 8
+          }
+        ]
+      },
+      overrides
+    )
+  end
+
+  defp ok_json(term), do: {:ok, %{status: 200, body: :json.encode(term) |> IO.iodata_to_binary()}}
+
+  defp press(key, value \\ 1), do: App.input([{:ev_key, key, value}])
+
+  defp tmp_path do
+    Path.join(System.tmp_dir!(), "update-app-test-#{System.unique_integer([:positive])}.fw")
+  end
+
+  # The check that runs on init is asynchronous, so it may already have
+  # finished by the time a test could register a watcher for it -- the
+  # tests below poll the snapshot for that first transition instead of
+  # asserting on a pushed message, and only start watching once the app is
+  # already sitting in a known state, which removes the race for every
+  # transition after that.
+  defp await_status(statuses, tries \\ 200) do
+    snapshot = App.snapshot()
+
+    cond do
+      snapshot.status in statuses ->
+        snapshot
+
+      tries > 0 ->
+        Process.sleep(2)
+        await_status(statuses, tries - 1)
+
+      true ->
+        flunk("timed out waiting for status in #{inspect(statuses)}, got #{inspect(snapshot)}")
+    end
+  end
+
+  describe "checking on start" do
+    test "an available update is reported" do
+      fetch = fn _url -> ok_json(release()) end
+
+      start_supervised!(
+        {App, check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"]}
+      )
+
+      snapshot = await_status([:available])
+      assert snapshot.result.latest == "0.2.0"
+      assert snapshot.result.asset.name == "mayonnaios_rg40xxv.fw"
+    end
+
+    test "no newer release is up to date" do
+      fetch = fn _url -> ok_json(release(%{"tag_name" => "v0.1.0"})) end
+
+      start_supervised!(
+        {App, check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"]}
+      )
+
+      assert await_status([:up_to_date])
+    end
+
+    test "a check failure is shown rather than raised" do
+      fetch = fn _url -> {:error, :timeout} end
+      start_supervised!({App, check_opts: [fetch: fetch]})
+
+      snapshot = await_status([:error])
+      assert snapshot.error == {:http, :timeout}
+    end
+
+    test "a release with no matching firmware asset is still available" do
+      fetch = fn _url -> ok_json(release(%{"assets" => []})) end
+
+      start_supervised!(
+        {App, check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"]}
+      )
+
+      snapshot = await_status([:available])
+      assert snapshot.result.asset == nil
+    end
+  end
+
+  describe "the buttons" do
+    setup do
+      fetch = fn _url -> ok_json(release()) end
+
+      start_supervised!(
+        {App, check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"]}
+      )
+
+      await_status([:available])
+      :ok
+    end
+
+    test "Menu changes nothing" do
+      before = App.snapshot()
+      press(@menu)
+      assert App.snapshot() == before
+    end
+  end
+
+  describe "downloading and applying" do
+    test "A on :available runs download and apply, and lands on :done" do
+      fetch = fn _url -> ok_json(release()) end
+      path = tmp_path()
+      get = fn _url, dest -> File.write!(dest, "firmware-bytes") end
+      cmd = fn _path, _args, _opts -> {"Success", 0} end
+
+      start_supervised!(
+        {App,
+         check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"],
+         download_opts: [get: get],
+         apply_opts: [devpath: "/dev/mmcblk0", fwup_path: "/usr/bin/true", cmd: cmd],
+         tmp_path: path}
+      )
+
+      await_status([:available])
+
+      App.watch(self())
+      press(@advance)
+
+      assert_receive {:update_app, %{status: :downloading}}, 1_000
+      assert_receive {:update_app, %{status: :done}}, 1_000
+
+      # Tmpfs is freed once the transfer is over, either way.
+      refute File.exists?(path)
+    end
+
+    test "a download failure becomes :error, and A retries the check" do
+      fetch = fn _url -> ok_json(release()) end
+      path = tmp_path()
+      get = fn _url, _dest -> {:error, {:http_status, 500}} end
+
+      start_supervised!(
+        {App,
+         check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"],
+         download_opts: [get: get],
+         tmp_path: path}
+      )
+
+      await_status([:available])
+
+      App.watch(self())
+      press(@advance)
+      assert_receive {:update_app, %{status: :error, error: {:http_status, 500}}}, 1_000
+
+      press(@advance)
+      assert_receive {:update_app, %{status: :available}}, 1_000
+    end
+
+    test "an available update with no firmware asset is an immediate, local error" do
+      fetch = fn _url -> ok_json(release(%{"assets" => []})) end
+
+      start_supervised!(
+        {App, check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"]}
+      )
+
+      await_status([:available])
+
+      App.watch(self())
+      press(@advance)
+      assert_receive {:update_app, %{status: :error, error: :no_asset}}, 1_000
+    end
+  end
+
+  describe "reboot" do
+    test "A on :done calls the injected reboot function" do
+      fetch = fn _url -> ok_json(release()) end
+      path = tmp_path()
+      get = fn _url, dest -> File.write!(dest, "firmware-bytes") end
+      cmd = fn _path, _args, _opts -> {"Success", 0} end
+      test_pid = self()
+
+      start_supervised!(
+        {App,
+         check_opts: [fetch: fetch, target: :rg40xxv, current_version: "0.1.0"],
+         download_opts: [get: get],
+         apply_opts: [devpath: "/dev/mmcblk0", fwup_path: "/usr/bin/true", cmd: cmd],
+         tmp_path: path,
+         reboot: fn -> send(test_pid, :rebooted) end}
+      )
+
+      await_status([:available])
+
+      App.watch(self())
+      press(@advance)
+      assert_receive {:update_app, %{status: :downloading}}, 1_000
+      assert_receive {:update_app, %{status: :done}}, 1_000
+
+      press(@advance)
+      assert_receive :rebooted, 1_000
+    end
+  end
+
+  describe "the scene" do
+    # graph/1 is the tested surface: no viewport, no driver, no framebuffer.
+    # Same helper the other scene tests use.
+    defp texts(graph) do
+      Scenic.Graph.reduce(graph, [], fn
+        %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+        _primitive, acc -> acc
+      end)
+    end
+
+    test "not running" do
+      assert Enum.member?(texts(Scene.graph(:stopped)), "Not running")
+    end
+
+    test "checking" do
+      assert Enum.any?(
+               texts(Scene.graph(%{status: :checking})),
+               &String.contains?(&1, "Checking")
+             )
+    end
+
+    test "idle invites a check" do
+      assert Enum.any?(texts(Scene.graph(%{status: :idle})), &String.contains?(&1, "Press A"))
+    end
+
+    test "up to date names both versions" do
+      result = %{current: "0.1.0", latest: "0.1.0", comparable?: true, tag: "v0.1.0"}
+      texts = texts(Scene.graph(%{status: :up_to_date, result: result}))
+
+      assert Enum.member?(texts, "Up to date")
+      assert Enum.any?(texts, &(&1 =~ "0.1.0"))
+    end
+
+    test "available with an asset invites installing it" do
+      result = %{
+        current: "0.1.0",
+        latest: "0.2.0",
+        comparable?: true,
+        tag: "v0.2.0",
+        asset: %{name: "mayonnaios_rg40xxv.fw", url: "https://x/y.fw", size: 10}
+      }
+
+      texts = texts(Scene.graph(%{status: :available, result: result}))
+
+      assert Enum.any?(texts, &(&1 =~ "0.2.0"))
+      assert Enum.any?(texts, &String.contains?(&1, "downloads and installs"))
+    end
+
+    test "available with no asset says so instead of offering to install" do
+      result = %{current: "0.1.0", latest: "0.2.0", tag: "v0.2.0", asset: nil}
+      texts = texts(Scene.graph(%{status: :available, result: result}))
+
+      assert Enum.any?(texts, &String.contains?(&1, "No firmware file"))
+      refute Enum.any?(texts, &String.contains?(&1, "downloads and installs"))
+    end
+
+    test "downloading with a known size shows a percentage" do
+      texts = texts(Scene.graph(%{status: :downloading, downloaded: 50, total: 100}))
+      assert Enum.any?(texts, &String.contains?(&1, "50%"))
+    end
+
+    test "downloading with an unknown size does not divide by it" do
+      texts = texts(Scene.graph(%{status: :downloading, downloaded: 50, total: nil}))
+      assert Enum.member?(texts, "Size unknown")
+    end
+
+    test "done offers a reboot" do
+      texts = texts(Scene.graph(%{status: :done}))
+      assert Enum.member?(texts, "Installed")
+      assert Enum.any?(texts, &String.contains?(&1, "reboots"))
+    end
+
+    test "an error names what went wrong" do
+      texts = texts(Scene.graph(%{status: :error, error: :no_releases}))
+      assert Enum.any?(texts, &String.contains?(&1, "no published releases"))
+    end
+
+    test "nothing is drawn above the shared status bar" do
+      assert Scene.status_bar() > 0
+    end
+  end
+end

--- a/test/update_test.exs
+++ b/test/update_test.exs
@@ -1,0 +1,269 @@
+defmodule MayonnaiOS.UpdateTest do
+  use ExUnit.Case, async: true
+
+  alias MayonnaiOS.Update
+
+  # Everything here is the part that decides what the panel says without
+  # touching the network -- `check/1`'s `:fetch` and `download/2`'s `:get`
+  # are the seams, the same way `MayonnaiOS.Files.space/1`'s `:run` and
+  # `MayonnaiOS.Launcher.Signals` are elsewhere in this codebase. `apply/2`'s
+  # `:cmd` is the same idea for `fwup` itself.
+
+  defp ok_json(term), do: {:ok, %{status: 200, body: :json.encode(term) |> IO.iodata_to_binary()}}
+
+  defp release(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "tag_name" => "v0.2.0",
+        "body" => "Notes.",
+        "published_at" => "2026-01-01T00:00:00Z",
+        "assets" => [
+          %{
+            "name" => "mayonnaios_rg40xxv.fw",
+            "browser_download_url" => "https://example.test/mayonnaios_rg40xxv.fw",
+            "size" => 12_345
+          }
+        ]
+      },
+      overrides
+    )
+  end
+
+  describe "check/1" do
+    test "a newer tag with a matching asset is available" do
+      fetch = fn _url -> ok_json(release()) end
+
+      assert {:ok, result} =
+               Update.check(fetch: fetch, target: :rg40xxv, current_version: "0.1.0")
+
+      assert result.available?
+      assert result.comparable?
+      assert result.current == "0.1.0"
+      assert result.latest == "0.2.0"
+      assert result.tag == "v0.2.0"
+      assert result.notes == "Notes."
+
+      assert result.asset == %{
+               name: "mayonnaios_rg40xxv.fw",
+               url: "https://example.test/mayonnaios_rg40xxv.fw",
+               size: 12_345
+             }
+    end
+
+    test "the same version is not an update" do
+      fetch = fn _url -> ok_json(release(%{"tag_name" => "v0.1.0"})) end
+
+      assert {:ok, result} =
+               Update.check(fetch: fetch, target: :rg40xxv, current_version: "0.1.0")
+
+      refute result.available?
+      assert result.comparable?
+    end
+
+    test "a tag older than what is running is not an update" do
+      fetch = fn _url -> ok_json(release(%{"tag_name" => "v0.1.0"})) end
+
+      assert {:ok, result} =
+               Update.check(fetch: fetch, target: :rg40xxv, current_version: "0.2.0")
+
+      refute result.available?
+    end
+
+    test "a release with no matching asset still reports the version" do
+      fetch = fn _url ->
+        ok_json(release(%{"assets" => [%{"name" => "mayonnaios_rpi0.fw", "size" => 1}]}))
+      end
+
+      assert {:ok, result} =
+               Update.check(fetch: fetch, target: :rg40xxv, current_version: "0.1.0")
+
+      assert result.available?
+      assert result.asset == nil
+    end
+
+    test "a release with no assets at all" do
+      fetch = fn _url -> ok_json(release(%{"assets" => []})) end
+
+      assert {:ok, result} =
+               Update.check(fetch: fetch, target: :rg40xxv, current_version: "0.1.0")
+
+      assert result.asset == nil
+    end
+
+    test "an unparseable tag is reported without crashing" do
+      fetch = fn _url -> ok_json(release(%{"tag_name" => "not-a-version"})) end
+
+      assert {:ok, result} =
+               Update.check(fetch: fetch, target: :rg40xxv, current_version: "0.1.0")
+
+      refute result.comparable?
+      refute result.available?
+      assert result.latest == "not-a-version"
+    end
+
+    test "a repository with no releases at all is a 404" do
+      fetch = fn _url -> {:ok, %{status: 404, body: ""}} end
+      assert {:error, :no_releases} = Update.check(fetch: fetch)
+    end
+
+    test "an unexpected HTTP status is reported" do
+      fetch = fn _url -> {:ok, %{status: 500, body: ""}} end
+      assert {:error, {:http_status, 500}} = Update.check(fetch: fetch)
+    end
+
+    test "no network is reported rather than raising" do
+      fetch = fn _url -> {:error, :timeout} end
+      assert {:error, {:http, :timeout}} = Update.check(fetch: fetch)
+    end
+
+    test "a body that is not JSON is reported rather than raising" do
+      fetch = fn _url -> {:ok, %{status: 200, body: "not json"}} end
+      assert {:error, :invalid_response} = Update.check(fetch: fetch)
+    end
+  end
+
+  describe "compare_versions/2" do
+    test "lt, eq and gt" do
+      assert Update.compare_versions("0.1.0", "0.2.0") == {:ok, :lt}
+      assert Update.compare_versions("0.2.0", "0.2.0") == {:ok, :eq}
+      assert Update.compare_versions("0.2.0", "0.1.0") == {:ok, :gt}
+    end
+
+    test "an unparseable version on either side" do
+      assert Update.compare_versions("garbage", "0.2.0") == {:error, :unparseable}
+      assert Update.compare_versions("0.1.0", "garbage") == {:error, :unparseable}
+    end
+  end
+
+  describe "normalize_tag/1" do
+    test "strips a leading v or V" do
+      assert Update.normalize_tag("v1.2.3") == "1.2.3"
+      assert Update.normalize_tag("V1.2.3") == "1.2.3"
+    end
+
+    test "leaves an already-bare version alone" do
+      assert Update.normalize_tag("1.2.3") == "1.2.3"
+    end
+
+    test "leaves anything else in place for compare_versions/2 to reject" do
+      assert Update.normalize_tag("release-42") == "release-42"
+    end
+  end
+
+  describe "running_version/0" do
+    test "reads the running OTP release's own version" do
+      assert Update.running_version() == "0.1.0"
+    end
+  end
+
+  describe "enough_space?/2" do
+    test "nil needed bytes always passes" do
+      assert Update.enough_space?(System.tmp_dir!(), nil)
+    end
+
+    test "an absurd requirement does not fit" do
+      refute Update.enough_space?(System.tmp_dir!(), 1_000_000_000_000_000)
+    end
+
+    test "a small requirement fits" do
+      assert Update.enough_space?(System.tmp_dir!(), 1)
+    end
+
+    test "a location with no filesystem to measure fails closed" do
+      refute Update.enough_space?("/definitely/not/a/real/path/at/all", 1)
+    end
+  end
+
+  describe "download/2" do
+    setup do
+      dir = Path.join(System.tmp_dir!(), "update-test-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+      %{dest: Path.join(dir, "firmware.fw")}
+    end
+
+    test "writes what the injected getter is given", %{dest: dest} do
+      asset = %{name: "x.fw", url: "https://example.test/x.fw", size: 4}
+      get = fn _url, path -> File.write!(path, "data") end
+
+      assert :ok = Update.download(asset, dest, get: get)
+      assert File.read!(dest) == "data"
+    end
+
+    test "a getter's error is returned", %{dest: dest} do
+      asset = %{name: "x.fw", url: "https://example.test/x.fw", size: 4}
+      get = fn _url, _path -> {:error, {:http_status, 404}} end
+
+      assert {:error, {:http_status, 404}} = Update.download(asset, dest, get: get)
+    end
+
+    test "refuses before starting when there is not enough space", %{dest: dest} do
+      asset = %{name: "x.fw", url: "https://example.test/x.fw", size: 1_000_000_000_000_000}
+      get = fn _url, _path -> flunk("must not be called when there is no room") end
+
+      assert {:error, {:insufficient_space, _needed, _dir}} =
+               Update.download(asset, dest, get: get)
+
+      refute File.exists?(dest)
+    end
+
+    test "an asset with no reported size is not blocked by the space check", %{dest: dest} do
+      asset = %{name: "x.fw", url: "https://example.test/x.fw", size: nil}
+
+      get = fn _url, path ->
+        File.write!(path, "ok")
+        :ok
+      end
+
+      assert :ok = Update.download(asset, dest, get: get)
+    end
+  end
+
+  describe "apply/2" do
+    test "runs fwup's upgrade task against the given device" do
+      cmd = fn path, args, _opts ->
+        send(self(), {:cmd, path, args})
+        {"Success", 0}
+      end
+
+      assert {:ok, "Success"} =
+               Update.apply("/tmp/x.fw",
+                 devpath: "/dev/mmcblk0",
+                 fwup_path: "/usr/bin/fwup",
+                 cmd: cmd
+               )
+
+      assert_received {:cmd, "/usr/bin/fwup", args}
+      assert "--apply" in args
+      assert "--no-unmount" in args
+      assert Enum.at(args, Enum.find_index(args, &(&1 == "-i")) + 1) == "/tmp/x.fw"
+      assert Enum.at(args, Enum.find_index(args, &(&1 == "-t")) + 1) == "upgrade"
+      assert Enum.at(args, Enum.find_index(args, &(&1 == "-d")) + 1) == "/dev/mmcblk0"
+    end
+
+    test "a nonzero exit is reported with fwup's own output" do
+      cmd = fn _path, _args, _opts -> {"Error: bad archive", 1} end
+
+      assert {:error, {:fwup_failed, 1, "Error: bad archive"}} =
+               Update.apply("/tmp/x.fw",
+                 devpath: "/dev/mmcblk0",
+                 fwup_path: "/usr/bin/fwup",
+                 cmd: cmd
+               )
+    end
+
+    test "a missing device path is reported without shelling out" do
+      cmd = fn _path, _args, _opts -> flunk("must not run fwup with no devpath") end
+
+      assert {:error, :no_devpath} =
+               Update.apply("/tmp/x.fw", devpath: nil, fwup_path: "/usr/bin/fwup", cmd: cmd)
+    end
+
+    test "a missing fwup binary is reported without shelling out" do
+      cmd = fn _path, _args, _opts -> flunk("must not run a nil executable") end
+
+      assert {:error, :fwup_not_found} =
+               Update.apply("/tmp/x.fw", devpath: "/dev/mmcblk0", fwup_path: nil, cmd: cmd)
+    end
+  end
+end


### PR DESCRIPTION
## What this adds

A **Software update** row in the System menu that checks `kek/mayonnaios`'s GitHub releases for a version newer than the one running, and, if one exists with a firmware asset for this device, downloads and applies it.

## Investigation

- **Distribution today**: manual only. `mix upload nerves.local` from a dev machine, over SSH, via `ssh_subsystem_fwup`. `gh release list -R kek/mayonnaios` and `gh api repos/kek/mayonnaios/releases` both return nothing — **the repo has no releases and no `.github/` workflows at all**, so there is no CI pattern to extend. Per the task brief, I did not add a release-publishing workflow; see "What still needs to exist" below for what a release needs to carry.
- **A/B + `nerves_fw_autovalidate=0`**: confirmed in `nerves_system_rg40xxv/uboot/uboot.env`. A freshly applied slot is not trusted until something validates it, or U-Boot reverts on the next boot. This project already has that something, **system-wide**: `config :nerves_runtime, startup_guard_enabled: true` in `config/target.exs`. `Nerves.Runtime.StartupGuard` validates the running slot once every OTP application has started, on every boot. So this feature does **not** call `Nerves.Runtime.validate_firmware/0` itself — a second, update-specific validator racing the StartupGuard is exactly the latch bug documented in `nerves_system_rg40xxv/fwup-ops.conf`'s `task validate` (one validation call permanently masking the next).
- **HTTP/JSON**: no `req`/`Jason` usage anywhere in `lib/` despite being transitive deps — `MayonnaiOS.Bundle` already fetches over `:httpc` and encodes/decodes with the OTP `:json` module ("no other reason to carry a JSON library"). This follows the same convention.

## The flow

- `MayonnaiOS.Update.check/1` — GET `https://api.github.com/repos/kek/mayonnaios/releases/latest`, parse the tag against the running OTP release version (`Application.spec(:mayonnaios, :vsn)`) with `Version.compare/2`, and look for a release asset ending in `.fw` whose name contains the target (`rg40xxv`). Returns the comparison, notes, and asset (or `nil` if the release has none — a release can exist with no firmware asset yet, which is shown rather than treated as "no update").
- `MayonnaiOS.Update.download/2` — streams the asset to a tmpfs path via `:httpc`, after `enough_space?/2` checks free space (via `MayonnaiOS.Files.space/1`, with a 5% margin) and refuses up front rather than filling the disk.
- `MayonnaiOS.Update.apply/2` — runs `fwup --apply --no-unmount -i <path> -t upgrade -d <devpath>`, the same `upgrade` task `ssh_subsystem_fwup` invokes for `mix upload`, just against a local file instead of stdin. Always targets the *inactive* slot, so an interrupted download or apply — including leaving the menu mid-update, which stops the app process — never touches the firmware that is currently running; retrying just overwrites the half-written inactive slot.
- `MayonnaiOS.Update.App` is the System menu app (state machine: idle → checking → up_to_date/available → downloading → done/error), `MayonnaiOS.Scene.Update` is the screen. A checks/advances/reboots; Menu leaves, same as the other apps.

Every I/O boundary (`:fetch`, `:get`, `:cmd`) is an injectable argument defaulting to the real thing, the same pattern `MayonnaiOS.Files.space/1` and `MayonnaiOS.Launcher.Signals` already use — that's what makes the version-comparison and release-parsing logic fully unit-testable without a network.

## What's untested on hardware

Everything: no release has ever been published, so the download/apply path has only run against injected fakes and `/bin/true` in tests. Specifically unverified on the device:
- That a real GitHub release asset downloads correctly through this device's `:httpc`/TLS setup at real firmware size (tens of MB) over WiFi.
- That `fwup --apply --no-unmount -t upgrade` against `nerves_fw_devpath` behaves as expected when invoked this way (locally, from a file) rather than via `ssh_subsystem_fwup`'s stdin-based port.
- Free space on the real tmpfs at real firmware size.
- That StartupGuard actually validates the new slot on the first boot after an app-triggered apply, the same as it does after `mix upload` — expected from reading `fwup-ops.conf`/`uboot.env`, not observed for this path.

## What still needs to exist for this to light up

A release pipeline that tags a version and publishes a `.fw` asset per release, named so it contains `rg40xxv` (e.g. `mayonnaios_rg40xxv.fw`) — `MayonnaiOS.Update.check/1`'s asset matching only requires that substring and a `.fw` suffix, deliberately, since no convention exists yet to pin down further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)