### PR TITLE
Stop blocking the boot on the first diagnostics reading

### DIFF
--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -18,7 +18,8 @@ defmodule MayonnaiOS.Application do
     #
     # Set `config :mayonnaios, autostart_ui: true` once it is known good.
     children =
-      [status()] ++
+      signs_of_life() ++
+        [status()] ++
         viewport() ++
         [controller_sessions(), pairing_sessions(), pickle_sessions()] ++
         [top_sessions(), update_sessions()] ++
@@ -103,6 +104,8 @@ defmodule MayonnaiOS.Application do
 
   # List all child processes to be supervised
   if Mix.target() == :host do
+    defp signs_of_life(), do: []
+
     defp target_children() do
       [
         # Children that only run on the host during development or test.
@@ -113,10 +116,20 @@ defmodule MayonnaiOS.Application do
       ]
     end
   else
-    defp target_children() do
-      # Order is deliberate, and it is about diagnosing a boot that fails.
-      # Each of these is a way of finding out what happened when the one after
-      # it never runs, so the cheapest and most reliable goes first.
+    # The two children that say the software is alive, at the very front of
+    # the tree -- ahead of Scenic and ahead of every poller.
+    #
+    # Both are free to start: the LED is one sysfs write, and the splash is a
+    # Task that polls for /dev/fb0 in its own process. Neither can hold up
+    # what follows, so there is nothing to weigh against being first.
+    #
+    # Being first is worth something twice over. The amber LED is the only
+    # signal that survives a UI which fails to start, and the earlier it is
+    # set the more of the boot it covers. And the splash and Scenic are both
+    # waiting for the same framebuffer, so whichever starts second is the one
+    # that draws second -- with the splash behind Scenic, a slow first frame
+    # could put the wordmark on top of the home screen rather than before it.
+    defp signs_of_life() do
       [
         # Earliest possible sign of life, and the only one that survives a UI
         # that fails to start. Needs nothing but sysfs.
@@ -125,19 +138,26 @@ defmodule MayonnaiOS.Application do
         # Something on the panel as soon as there is a panel to put it on. It
         # polls for /dev/fb0 in its own process rather than blocking the
         # supervisor, because the framebuffer does not exist until the panel
-        # module binds -- about two and a half seconds after the BEAM starts.
-        # So placing it early costs nothing, and waiting for it would cost
-        # everything after it.
-        MayonnaiOS.Splash,
+        # driver probes.
+        MayonnaiOS.Splash
+      ]
+    end
 
+    defp target_children() do
+      # Order is deliberate, and it is about diagnosing a boot that fails.
+      # Each of these is a way of finding out what happened when the one after
+      # it never runs, so the cheapest and most reliable goes first. The LED
+      # and the splash come before all of it, in `signs_of_life/0`.
+      [
         # The way back in when WiFi does not come up. Nothing populates USB
         # configfs at boot, so without this usb0 never appears.
         MayonnaiOS.USBGadget,
 
         # Takes /root out of discard mode. Ahead of everything that writes to
         # it, because the discards this stops are what the writes trigger --
-        # but behind the three above, which are there to make a failing boot
-        # diagnosable and should not be displaced by a repair.
+        # but behind the LED, the splash and the gadget, which are there to
+        # make a failing boot diagnosable and should not be displaced by a
+        # repair.
         MayonnaiOS.AppPartition.Startup,
 
         # Takes the mixer to 0% with the output path switched on, so the

--- a/lib/mayonnaios/diagnostics.ex
+++ b/lib/mayonnaios/diagnostics.ex
@@ -140,14 +140,36 @@ defmodule MayonnaiOS.Diagnostics do
     # exactly like a GPU doing nothing.
     File.write("#{@gpu}/profiling", "1")
 
+    :timer.send_interval(@poll_ms, :poll)
+    {:ok, %__MODULE__{}, {:continue, :first_reading}}
+  end
+
+  # The first reading is taken here rather than in `init/1` because of where
+  # this process sits in the boot: the application supervisor starts its
+  # children one at a time and waits for each `start_link` to return, so
+  # anything done in `init/1` is time the games card, the cores, the web
+  # server and the launcher spend not existing.
+  #
+  # And the first reading is the expensive one. It spawns four programs off a
+  # read-only squashfs that has none of them in the page cache yet -- `evtest`
+  # for the jack, `dmesg` for the Realtek firmware line (whose whole output is
+  # then scanned), `amixer` for the mixer, `hwclock` where it exists -- which
+  # is several hundred milliseconds of fork/exec in front of every child below
+  # this one.
+  #
+  # `handle_continue` runs before this process handles any other message, so
+  # `snapshot/0` still cannot observe the empty struct: a caller that asks
+  # immediately waits for the reading rather than being told nothing. What
+  # moves is only when the *rest of the supervision tree* is allowed to start.
+  @impl GenServer
+  def handle_continue(:first_reading, state) do
     state =
-      %__MODULE__{}
+      state
       |> Map.put(:jack, %{inserted: query_jack(), changes: 0})
       |> Map.put(:rtl, rtl_status())
       |> poll()
 
-    :timer.send_interval(@poll_ms, :poll)
-    {:ok, state}
+    {:noreply, state}
   end
 
   @impl GenServer

--- a/lib/mayonnaios/splash.ex
+++ b/lib/mayonnaios/splash.ex
@@ -2,38 +2,25 @@ defmodule MayonnaiOS.Splash do
   @moduledoc """
   Puts something on the panel as soon as there is a panel to put it on.
 
-  ## Why this is drawn here rather than earlier
+  ## Why this waits rather than assuming
 
-  It looks like a splash screen belongs in the bootloader, or in the kernel as
-  `CONFIG_LOGO`. On this board neither is earlier in practice, because the
-  panel is the constraint and not the software. Measured on hardware:
+  The panel is the constraint, not the software. `/dev/fb0` does not exist
+  until the DRM stack has bound every component of sun4i's display engine and
+  fbdev emulation has registered a device for it, and that happens during
+  kernel initcalls -- so it can be either side of the moment this process
+  starts, depending on how long the f2fs mount and the BEAM's own startup take
+  on the day.
 
-      2.32s   init starts
-      2.78s   f2fs starts mounting /root
-      5.73s   /root mounted
-      7.10s   the BEAM starts
-      9.47s   panel-mipi binds
-      10.27s  console switches to the framebuffer
-
-  The panel driver is a module (`CONFIG_DRM_PANEL_MIPI=m`) whose panel
-  description is a firmware file, and erlinit loads it from `--pre-run-exec`
-  *after* mounting `/root` -- so the display waits about three seconds behind
-  an f2fs mount that has nothing to do with it. The BEAM is already running
-  two and a half seconds before the panel exists.
-
-  So Elixir is not the late part. Drawing from here lands within a few
-  hundred milliseconds of the first moment the hardware can show anything, and
-  if the panel is later made to come up early -- built in, with its firmware
-  linked into the kernel image -- this same code starts appearing at around
-  two seconds with no change.
+  So `run/0` polls rather than opening the device once. It is first in the
+  supervision tree (see `MayonnaiOS.Application`) and it polls in its own
+  process, which together mean it draws at the first moment the hardware can
+  show anything without holding up anything that follows.
 
   ## Kernel messages will scribble over it
 
-  The kernel command line carries `console=tty0` and deliberately omits
-  `quiet`, because during bring-up a silent screen could not be told apart
-  from a screen that never came up. That decision was right and it is why boot
-  messages scroll past. It also means fbcon owns this framebuffer and will
-  print over anything drawn here.
+  The kernel command line carries `console=tty0`, which is what makes a boot
+  failure visible on a board whose only UART is on internal test pads. It also
+  means fbcon owns this framebuffer and prints over anything drawn here.
 
   `quiesce_console/0` unbinds fbcon from the framebuffer before drawing, which
   stops that without touching the kernel command line, without a rebuild, and


### PR DESCRIPTION
Two startup changes, both about what the application supervisor is made to wait for.

`MayonnaiOS.Diagnostics` took its first reading in `init/1`. The supervisor starts children one at a time and waits for each `start_link` to return, so that reading sat in front of the games card, the cores, the pickles, the web server and the launcher — and it is the reading that spawns `evtest`, `dmesg`, `amixer` and `hwclock` off a squashfs with none of them in the page cache. It moves to `handle_continue`, which runs before this process handles any other message, so `snapshot/0` still cannot observe the empty struct.

The LED and the splash move to the front of the tree, ahead of Scenic. Neither can hold anything up, and the splash and Scenic are both waiting for the same `/dev/fb0` — whichever starts second draws second, and with the splash behind Scenic a slow first frame could put the wordmark on top of the home screen.

`MayonnaiOS.Splash`'s moduledoc still described the panel as a module that erlinit loads from `--pre-run-exec` after mounting `/root`. It is built in now, with its description linked into the kernel image, and it probes during initcalls.

## Where this sits

The measurement that prompted this came off the running device, and it says the application is not the expensive part of this boot:

```
0.465394  printk: legacy console [ttyS0] enabled
2.001858  5000400.serial: ttyS1 ...          <- 1.54 s of ring buffer draining to a 115200 UART
2.503870  Console: switching to colour frame buffer device 80x30
2.879808  sunxi-mmc 4022000.mmc: fatal err update clk timeout
3.667822  sunxi-mmc 4022000.mmc: initialized
3.682426  VFS: Mounted root (squashfs) readonly on device 179:3
3.703632  Run /sbin/init as init process
7.866889  nerves_heart: Received init handshake
```

The two large kernel-side costs — the printk backlog and `rootwait` waiting out an empty second card slot — are BSP changes and are tracked separately. This PR is the part that lives here.

## Verification

`mix compile --warnings-as-errors` and `mix test` (724 passing) on `MIX_TARGET=host`. Not booted on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
