### PR TITLE
Center the browser's focus, preview on the right, full view on X

### DIFF
--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -1,8 +1,12 @@
 defmodule MayonnaiOS.Browser do
   @moduledoc """
-  The launcher's menu as a column browser: a stack of levels, NeXTSTEP-style,
-  where the first column is the categories and every descent opens another
-  column to the right. The panel draws the deepest three.
+  The launcher's menu as a column browser: a stack of levels, Miller-columns
+  style, and the focus is always the center of the panel. The left column is
+  the level above -- blank at the root -- and the right column is not a level
+  at all: it previews whatever the cursor is on. A directory previews as its
+  contents, a file as its metadata and its first bytes (text, an image, or a
+  hexdump, whichever the bytes are), a runnable row as what it is and that A
+  opens it, and a process monitor as a narrow slice of the readout itself.
 
   A pure data structure with no process. `MayonnaiOS.Launcher` holds one of
   these in its own state -- the same place the flat cursor used to live, and
@@ -46,12 +50,26 @@ defmodule MayonnaiOS.Browser do
   reopening the column -- or by the operation that just changed it, which
   re-reads the column it acted on.
 
+  ## The full view
+
+  X toggles the **full view**: the columns give way to one wide column about
+  the selected entry, built by `MayonnaiOS.Browser.View`. A directory becomes
+  a detailed listing with sizes, a text file a viewer, an image the picture,
+  any other file a hexdump, and a runnable row its metadata. While it is up,
+  B and X close it and the directions scroll it -- `full_input/2` is the only
+  input that belongs here, the way `overlay_input/2` is for the sheets. The
+  process monitors are the one exception, and it is the launcher's: their
+  detailed view is the `MayonnaiOS.Top` app itself, so X there starts it.
+
   ## The verbs, and the sheets they live behind
 
-  Inside a directory column, Y (and A on a file) opens the **actions sheet**:
+  Inside a directory column, Y -- and only Y -- opens the **actions sheet**:
   what can be done to the selected entry, plus pasting whatever the clipboard
-  holds. The sheet is drawn as one more column, because in this UI "a list to
-  pick from" and "a column" are the same thing.
+  holds. A never opens it: A is the button that *opens things* -- it enters a
+  directory, launches a program, views a file -- and a button that sometimes
+  opens and sometimes asks is two buttons wearing one cap. The sheet is drawn
+  as one more column, because in this UI "a list to pick from" and "a column"
+  are the same thing.
 
   Copy and move are a clipboard, because there is no keyboard: pick an entry
   up, walk anywhere in the tree, and the sheet there offers to put it down.
@@ -77,6 +95,7 @@ defmodule MayonnaiOS.Browser do
   """
 
   alias MayonnaiOS.{Files, Pickles, Programs}
+  alias MayonnaiOS.Browser.View
 
   @typedoc "One entry in a column."
   @type node_ :: %{
@@ -103,18 +122,23 @@ defmodule MayonnaiOS.Browser do
           | {:confirm, %{location: Files.location(), entry: map(), name: String.t()}}
           | {:rename, %{name: String.t(), chars: [String.t()], caret: non_neg_integer()}}
 
-  @typedoc "The whole browser: a stack of levels, a clipboard, and one overlay."
+  @typedoc """
+  The whole browser: a stack of levels, a clipboard, one overlay, and --
+  while X has it open -- the full view, a `MayonnaiOS.Browser.View.full/0`
+  plus the scroll offset this module moves.
+  """
   @type t :: %{
           levels: [level()],
           clipboard: %{mode: :copy | :move, location: Files.location(), name: String.t()} | nil,
           message: {:ok | :error, String.t()} | nil,
-          overlay: overlay()
+          overlay: overlay(),
+          full: map() | nil
         }
 
-  # How many of the deepest levels the panel draws. Fixed: three columns is
-  # the NeXT shape, and a view setting someone can lose is a view setting
-  # someone has to find again.
-  @columns 3
+  # How many lines the full view shows at once. The scene draws exactly this
+  # many, read through `full_rows/0`, so paging and the panel cannot disagree
+  # about what a screenful is.
+  @full_rows 16
 
   # One screen. The scene shows ten rows; paging by ten keeps the shoulder
   # buttons and the scene in step without either reading the other.
@@ -137,7 +161,7 @@ defmodule MayonnaiOS.Browser do
   """
   @spec new() :: t()
   def new do
-    %{levels: [root_level()], clipboard: nil, message: nil, overlay: nil}
+    %{levels: [root_level()], clipboard: nil, message: nil, overlay: nil, full: nil}
   end
 
   @doc "How many levels are open."
@@ -236,22 +260,115 @@ defmodule MayonnaiOS.Browser do
 
   @doc """
   Back to the root column. The clipboard survives -- carrying a file across
-  the tree is what it is for -- and any overlay does not.
+  the tree is what it is for -- and any overlay or full view does not.
   """
   @spec reset(t()) :: t()
   def reset(browser) do
-    %{browser | levels: [root_level()], message: nil, overlay: nil}
+    %{browser | levels: [root_level()], message: nil, overlay: nil, full: nil}
   end
 
   @doc """
-  The levels the panel should draw: the deepest ones, at most three.
-
-  The head of the result is the leftmost column and the last is the focused
-  one -- the only one whose cursor the D-pad moves.
+  The two levels the panel's left and center slots draw: the focused column,
+  where the cursor lives, and its parent -- `nil` at the root, where blank on
+  the left is the honest answer. The third slot is `preview/1`'s.
   """
-  @spec visible(t()) :: [level()]
-  def visible(%{levels: levels}) do
-    Enum.take(levels, -min(@columns, length(levels)))
+  @spec panes(t()) :: %{left: level() | nil, center: level()}
+  def panes(%{levels: [only]}), do: %{left: nil, center: only}
+  def panes(%{levels: levels}), do: %{left: Enum.at(levels, -2), center: List.last(levels)}
+
+  @doc """
+  What the right pane says about the current selection, or `nil` with nothing
+  selected.
+
+  An expandable node -- a category, a root, a directory -- previews as the
+  column a descend would open, through the same expansion, so the preview and
+  the descent cannot disagree about what is inside. Leaves are
+  `MayonnaiOS.Browser.View`'s: file contents, program metadata, the narrow
+  process list.
+
+  Built fresh on every call rather than stored, because it is derived from
+  the selection and the disk -- the scene asks when it draws, and holding a
+  copy here would only be one more thing to go stale.
+  """
+  @spec preview(t()) :: map() | nil
+  def preview(browser) do
+    node = selected(browser)
+
+    cond do
+      node == nil -> nil
+      expandable?(node) -> %{kind: :level, level: expand(node)}
+      true -> View.preview(node, focused(browser).location)
+    end
+  end
+
+  # -- the full view --------------------------------------------------------------
+
+  @doc """
+  Whether the full view -- one wide column -- has the panel. While this is
+  true, `full_input/2` is the only input that belongs here.
+  """
+  @spec full?(t()) :: boolean()
+  def full?(%{full: full}), do: full != nil
+
+  @doc """
+  Open the full view of the selected entry: X's half of the toggle, and A's
+  way of opening a file that cannot be entered or run.
+
+  An entry with no full view -- a category, an empty column -- leaves the
+  browser unchanged, so the caller can compare and skip the repaint. The
+  process monitors never arrive here from a button: the launcher starts the
+  `MayonnaiOS.Top` app instead, because the app is their detailed view.
+  """
+  @spec open_full(t()) :: t()
+  def open_full(browser) do
+    node = selected(browser)
+
+    case node && View.full(node, focused(browser).location) do
+      nil -> browser
+      full -> %{browser | full: Map.put(full, :offset, 0), message: nil}
+    end
+  end
+
+  @doc "Close the full view. Back to the columns, exactly as they were."
+  @spec close_full(t()) :: t()
+  def close_full(browser), do: %{browser | full: nil}
+
+  @doc "How many lines the full view shows at once; the scene draws this many."
+  @spec full_rows() :: pos_integer()
+  def full_rows, do: @full_rows
+
+  @doc """
+  One button, while the full view is up.
+
+  B closes it -- in the full view, back always goes back -- and so does X,
+  because a toggle that only toggles one way is a door with no handle on the
+  inside. The directions and the shoulders scroll anything with lines, and
+  everything else is swallowed: a press meant for this view must not also
+  move a cursor in a column that is not on the panel.
+  """
+  @spec full_input(t(), atom()) :: t()
+  def full_input(%{full: nil} = browser, _button), do: browser
+
+  def full_input(browser, button) do
+    case button do
+      :b -> close_full(browser)
+      :x -> close_full(browser)
+      :up -> scroll_full(browser, -1)
+      :down -> scroll_full(browser, +1)
+      :left -> scroll_full(browser, -@full_rows)
+      :right -> scroll_full(browser, +@full_rows)
+      :l1 -> scroll_full(browser, -@full_rows)
+      :r1 -> scroll_full(browser, +@full_rows)
+      _other -> browser
+    end
+  end
+
+  # Clamped like `page/2` and for the same reason; a view with no lines -- an
+  # image -- has nowhere to scroll to and stays put.
+  defp scroll_full(%{full: full} = browser, delta) do
+    ceiling = max(length(Map.get(full, :lines, [])) - @full_rows, 0)
+    offset = (full.offset + delta) |> max(0) |> min(ceiling)
+    %{browser | full: %{full | offset: offset}}
   end
 
   @doc """

--- a/lib/mayonnaios/browser/view.ex
+++ b/lib/mayonnaios/browser/view.ex
@@ -1,0 +1,464 @@
+defmodule MayonnaiOS.Browser.View do
+  @moduledoc """
+  What the panel says *about* an entry: the preview pane on the browser's
+  right, and the one-wide-column full view that X opens.
+
+  Pure functions from a column entry to a description the scene can draw.
+  `MayonnaiOS.Browser` calls them -- the preview on every repaint, the full
+  view once when X opens it -- and holds what they return; the scene renders
+  the result and owns nothing, the same division the rest of the browser
+  lives by. Directories and the other expandable nodes are previewed by the
+  browser itself, as the column a descend would open, so this module only
+  describes leaves: files, programs, and the launcher's own verbs.
+
+  ## What a file looks like from here
+
+  The first bytes decide. A head that a decoder recognises as an image is an
+  image; a head that is UTF-8 with no null bytes is text; everything else is
+  bytes, shown as a hexdump -- which is not a fallback so much as the honest
+  answer for a save file or a ROM.
+
+  Every read is capped. The classifying peek is 64 KB, which is enough for a
+  JPEG that buries its dimensions behind EXIF blocks; the text view loads a
+  quarter megabyte; the image view refuses anything past 8 MB, because the
+  decode happens in the display driver on this SoC's CPU. A cap that is hit
+  goes on the panel as "the first N of M" rather than being passed off as
+  the whole file.
+
+  ## The process monitors are entries with a pulse
+
+  A row that opens `MayonnaiOS.Top` is previewed as a narrow slice of the
+  readout itself: the top of the list by memory, sampled when the preview is
+  built. One sample, no deltas -- the activity column needs a previous
+  sample and a preview has none, so memory is the honest column to show.
+  """
+
+  alias MayonnaiOS.{Browser, Files, Pickles, Top}
+
+  @typedoc """
+  A preview pane: what the browser's right column shows for a leaf.
+  """
+  @type preview ::
+          %{kind: :file, title: String.t(), info: [String.t()], body: body()}
+          | %{kind: :info, title: String.t(), lines: [String.t()]}
+          | %{kind: :top, title: String.t(), lines: [String.t()]}
+
+  @typedoc "The contents half of a file preview."
+  @type body ::
+          nil
+          | {:text, [String.t()]}
+          | {:hex, [String.t()]}
+          | {:image, image()}
+          | {:note, String.t()}
+
+  @typedoc """
+  A decoded-enough image: dimensions and format from the header, and the
+  bytes when the file is small enough to hand to the display driver.
+  """
+  @type image :: %{
+          format: String.t(),
+          width: pos_integer(),
+          height: pos_integer(),
+          bytes: binary() | nil
+        }
+
+  @typedoc "A full view: one wide column, scrolled by the browser."
+  @type full ::
+          %{kind: :listing, title: String.t(), lines: [String.t()], note: String.t() | nil}
+          | %{kind: :text, title: String.t(), lines: [String.t()], note: String.t() | nil}
+          | %{kind: :hex, title: String.t(), lines: [String.t()], note: String.t() | nil}
+          | %{kind: :image, title: String.t(), image: image(), note: String.t() | nil}
+          | %{kind: :info, title: String.t(), lines: [String.t()]}
+
+  # One read for a preview: enough to classify honestly, enough text to fill
+  # the pane many times over, and bounded whatever the file's size is.
+  @peek 65_536
+
+  # The most a text view loads. A quarter megabyte is hundreds of screens of
+  # config file; anything bigger is being read for its head anyway.
+  @text_cap 262_144
+
+  # The most a hex view loads: 4 KB is 256 dump lines, and the point of a
+  # hexdump on this panel is the header of the thing, not all of it.
+  @hex_cap 4_096
+
+  # The most an image view hands to the display driver, whose decoder runs on
+  # the CPU that also runs everything else. Bigger files keep their metadata
+  # and lose only the picture.
+  @image_cap 8 * 1024 * 1024
+
+  # How many entries the preview of anything list-shaped shows, and how many
+  # lines of a file's contents. Sized to the pane, not to the data.
+  @preview_body 8
+
+  # -- the preview pane ---------------------------------------------------------
+
+  @doc """
+  The preview for a leaf entry, or `nil` for one with nothing to say.
+
+  `column` is the location of the column the entry sits in -- how a file's
+  bytes are reached -- and is `nil` outside the file tree.
+  """
+  @spec preview(Browser.node_(), Files.location() | nil) :: preview() | nil
+  def preview(%{kind: :file, name: name, entry: entry}, column) do
+    %{kind: :file, title: name, info: file_info(entry), body: preview_body(column, name, entry)}
+  end
+
+  def preview(%{kind: :program, name: name, program: %{app: {Top, which}}}, _column) do
+    %{kind: :top, title: name, lines: top_lines(which)}
+  end
+
+  def preview(%{kind: :program, name: name, program: program}, _column) do
+    %{kind: :info, title: name, lines: program_lines(program)}
+  end
+
+  def preview(_node, _column), do: nil
+
+  # What the entry *is*, before what it contains: its links, its size, its
+  # type. These are the lines above the contents in the preview pane.
+  defp file_info(%{broken?: true, link: link}), do: ["a broken link to #{link || "?"}"]
+
+  defp file_info(%{link: link} = entry) when is_binary(link) do
+    ["a link to #{link}" | file_info(%{entry | link: nil})]
+  end
+
+  defp file_info(%{type: :regular, size: size}) when is_integer(size) and size >= 1024 do
+    ["a file of #{bytes(size)} (#{size} bytes)"]
+  end
+
+  defp file_info(%{type: :regular, size: size}), do: ["a file of #{size} bytes"]
+  defp file_info(%{type: type}), do: ["a #{type}"]
+
+  defp preview_body(nil, _name, _entry), do: nil
+
+  defp preview_body(column, name, %{type: :regular}) do
+    with {:ok, target} <- Files.descend(column, name),
+         {:ok, head} <- Files.peek(target, @peek) do
+      cond do
+        head == <<>> ->
+          {:note, "empty"}
+
+        image = image_meta(head) ->
+          {:image, load_image(target, image)}
+
+        text?(head) ->
+          {:text, head |> text_lines() |> Enum.take(@preview_body)}
+
+        true ->
+          {:hex, head |> take_bytes(8 * @preview_body) |> narrow_hex()}
+      end
+    else
+      {:error, reason} -> {:note, "cannot be read: #{Browser.why(reason)}"}
+    end
+  end
+
+  # A device node, a socket, a directory that lost its location: nothing to
+  # read, and the info lines above have already said what it is.
+  defp preview_body(_column, _name, _entry), do: nil
+
+  # -- the full view ------------------------------------------------------------
+
+  @doc """
+  The full view X opens for an entry: one wide column, described whole.
+
+  `nil` for an entry with nothing more to show than its row -- the root
+  categories. The process monitors never reach here from a button: the
+  launcher opens the `MayonnaiOS.Top` app itself, because the app *is* their
+  detailed view.
+  """
+  @spec full(Browser.node_(), Files.location() | nil) :: full() | nil
+  def full(%{kind: :dir, name: name, location: location}, _column), do: listing(name, location)
+
+  def full(%{kind: :place, name: name, key: key}, _column) do
+    case Files.at(key) do
+      {:ok, location} -> listing(name, location)
+      {:error, reason} -> info(name, ["cannot be opened: #{Browser.why(reason)}"])
+    end
+  end
+
+  def full(%{kind: :file, name: name, entry: entry}, column) do
+    file_full(name, entry, column)
+  end
+
+  def full(%{kind: :program, name: name, program: program}, _column) do
+    info(name, program_lines(program))
+  end
+
+  def full(_node, _column), do: nil
+
+  # The detailed listing: every entry with its size, one line each, in the
+  # order `Files.list/1` already sorts them.
+  defp listing(name, location) do
+    case Files.list(location) do
+      {:ok, entries} ->
+        %{
+          kind: :listing,
+          title: name,
+          lines: Enum.map(entries, &listing_line/1),
+          note: if(entries == [], do: "Empty.")
+        }
+
+      {:error, reason} ->
+        info(name, ["cannot be read: #{Browser.why(reason)}"])
+    end
+  end
+
+  defp listing_line(entry) do
+    String.pad_trailing(shorten(entry.name, 40), 42) <>
+      String.pad_leading(entry_size(entry), 10) <>
+      link_words(entry)
+  end
+
+  defp entry_size(%{broken?: true}), do: "broken"
+  defp entry_size(%{type: :directory}), do: "directory"
+  defp entry_size(%{type: :regular, size: size}), do: bytes(size)
+  defp entry_size(%{type: type}), do: to_string(type)
+
+  defp link_words(%{link: nil}), do: ""
+  defp link_words(%{link: target}), do: "  -> " <> shorten_left(target, 24)
+
+  defp file_full(name, %{type: :regular} = entry, column) when column != nil do
+    with {:ok, target} <- Files.descend(column, name),
+         {:ok, head} <- Files.peek(target, @peek) do
+      cond do
+        head == <<>> -> info(name, file_info(entry) ++ ["empty"])
+        image = image_meta(head) -> image_full(name, target, image, entry)
+        text?(head) -> text_full(name, target, entry)
+        true -> hex_full(name, target, entry)
+      end
+    else
+      {:error, reason} -> unreadable(name, entry, reason)
+    end
+  end
+
+  defp file_full(name, entry, _column), do: info(name, file_info(entry))
+
+  defp text_full(name, target, entry) do
+    case Files.peek(target, @text_cap) do
+      {:ok, data} ->
+        %{kind: :text, title: name, lines: text_lines(data), note: cap_note(entry, data)}
+
+      {:error, reason} ->
+        unreadable(name, entry, reason)
+    end
+  end
+
+  defp hex_full(name, target, entry) do
+    case Files.peek(target, @hex_cap) do
+      {:ok, data} ->
+        %{kind: :hex, title: name, lines: hexdump(data), note: cap_note(entry, data)}
+
+      {:error, reason} ->
+        unreadable(name, entry, reason)
+    end
+  end
+
+  defp image_full(name, target, meta, entry) do
+    image = load_image(target, meta)
+
+    %{
+      kind: :image,
+      title: name,
+      image: image,
+      note: if(image.bytes == nil, do: "too big to decode (#{bytes(entry.size)})")
+    }
+  end
+
+  defp unreadable(name, entry, reason) do
+    info(name, file_info(entry) ++ ["cannot be read: #{Browser.why(reason)}"])
+  end
+
+  defp info(title, lines), do: %{kind: :info, title: title, lines: lines}
+
+  # Said on the panel when the cap was hit: "the first 256.0K of 1.2G" is a
+  # different claim from silently showing a head as though it were the whole.
+  defp cap_note(%{size: size}, data) when is_integer(size) and size > byte_size(data) do
+    "the first #{bytes(byte_size(data))} of #{bytes(size)}"
+  end
+
+  defp cap_note(_entry, _data), do: nil
+
+  # -- classifying --------------------------------------------------------------
+
+  # The header parse the display driver's decoder also agrees with:
+  # ExImageInfo is what `Scenic.Assets.Stream.Image.from_binary/1` uses, so a
+  # file called an image here is one the stream will accept.
+  defp image_meta(head) do
+    case ExImageInfo.info(head) do
+      {format, width, height, _variant} -> %{format: format, width: width, height: height}
+      nil -> nil
+    end
+  end
+
+  # The whole file, when it is small enough to hand to the decoder. Past the
+  # cap the dimensions still get shown -- they came off the header -- and
+  # only the picture is declined.
+  defp load_image(target, meta) do
+    case Files.peek(target, @image_cap + 1) do
+      {:ok, data} when byte_size(data) <= @image_cap -> Map.put(meta, :bytes, data)
+      _too_big_or_unreadable -> Map.put(meta, :bytes, nil)
+    end
+  end
+
+  defp text?(head) do
+    not String.contains?(head, <<0>>) and utf8?(head, 3)
+  end
+
+  # The peek can cut a multi-byte character at its boundary, so up to three
+  # trailing bytes are allowed to be the front of one before the head stops
+  # counting as text.
+  defp utf8?(head, 0), do: String.valid?(head)
+
+  defp utf8?(head, spare) do
+    String.valid?(head) or
+      (byte_size(head) > 0 and utf8?(binary_part(head, 0, byte_size(head) - 1), spare - 1))
+  end
+
+  defp text_lines(data) do
+    data
+    |> String.replace("\r", "")
+    |> String.replace("\t", "  ")
+    |> String.split("\n")
+  end
+
+  # -- hex ------------------------------------------------------------------------
+
+  @doc """
+  Classic hexdump lines: offset, sixteen bytes, the printable characters.
+
+  Public because the format is a contract with the panel's monospace column
+  -- 75 characters, which is what fits -- and a test should be able to pin
+  it without building a file tree.
+  """
+  @spec hexdump(binary()) :: [String.t()]
+  def hexdump(data) do
+    data
+    |> chunks(16)
+    |> Enum.with_index()
+    |> Enum.map(fn {chunk, index} ->
+      hex_offset(index * 16) <>
+        "  " <> String.pad_trailing(hex_pairs(chunk), 47) <> "  |#{ascii(chunk)}|"
+    end)
+  end
+
+  # The preview pane's narrow cousin: eight bytes a line, no offset and no
+  # ascii, because the pane is a third of the panel wide.
+  defp narrow_hex(data) do
+    for chunk <- chunks(data, 8), do: hex_pairs(chunk)
+  end
+
+  defp hex_offset(offset) do
+    offset |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(6, "0")
+  end
+
+  defp hex_pairs(chunk) do
+    chunk
+    |> :binary.bin_to_list()
+    |> Enum.map_join(" ", fn byte ->
+      byte |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(2, "0")
+    end)
+  end
+
+  defp ascii(chunk) do
+    for <<byte <- chunk>>, into: "", do: if(byte in 32..126, do: <<byte>>, else: ".")
+  end
+
+  defp chunks(<<>>, _size), do: []
+  defp chunks(data, size) when byte_size(data) <= size, do: [data]
+
+  defp chunks(data, size) do
+    <<head::binary-size(^size), rest::binary>> = data
+    [head | chunks(rest, size)]
+  end
+
+  defp take_bytes(data, count), do: binary_part(data, 0, min(byte_size(data), count))
+
+  # -- the runnable rows -----------------------------------------------------------
+
+  # What a program row is and what the buttons do to it. The words name the
+  # launcher's own bindings, so they live next to the other button prose and
+  # change when it does.
+  defp program_lines(%{action: :poweroff}) do
+    [
+      "A verb of the launcher's own.",
+      "A puts the question on the panel;",
+      "Y -- and only Y -- switches off."
+    ]
+  end
+
+  defp program_lines(%{action: action}) when action != nil do
+    ["A verb of the launcher's own.", "A runs it."]
+  end
+
+  defp program_lines(%{app: {Pickles.App, _name}}) do
+    ["A pickle: a sandboxed Lua app.", "A opens it. Menu leaves it."]
+  end
+
+  defp program_lines(%{app: app}) when app != nil do
+    ["An app in this firmware.", "A opens it. Menu leaves it."]
+  end
+
+  defp program_lines(%{installed?: false} = program) do
+    ["A program.", program.path || "", "Not installed: nothing is at that path."]
+  end
+
+  defp program_lines(program) do
+    ["A program on this device.", program.path || ""] ++
+      args_lines(program) ++ ["A runs it. Menu stops it."]
+  end
+
+  defp args_lines(%{args: []}), do: []
+  defp args_lines(%{args: args}), do: ["args: " <> Enum.join(args, " ")]
+
+  # The narrow process list: the top of the readout by memory, one sample.
+  defp top_lines(:beam) do
+    Top.Beam.sample() |> Top.Beam.rows(nil) |> top_rows()
+  end
+
+  defp top_lines(:os) do
+    case Top.Os.sample() do
+      {:ok, sample} -> sample |> Top.Os.rows(nil) |> top_rows()
+      {:error, reason} -> ["no reading: #{inspect(reason)}"]
+    end
+  end
+
+  defp top_rows(rows) do
+    rows
+    |> Enum.sort_by(& &1.mem, :desc)
+    |> Enum.take(@preview_body)
+    |> Enum.map(fn row ->
+      String.pad_leading(bytes(row.mem), 6) <> "  " <> shorten(row_name(row), 18)
+    end)
+  end
+
+  defp row_name(%{name: name}) when is_binary(name), do: name
+  defp row_name(%{name: name}), do: inspect(name)
+
+  # -- words -----------------------------------------------------------------------
+
+  defp bytes(nil), do: "--"
+  defp bytes(b) when b < 1024, do: "#{b} B"
+
+  defp bytes(b) do
+    {value, unit} =
+      cond do
+        b >= 1024 * 1024 * 1024 -> {b / (1024 * 1024 * 1024), "G"}
+        b >= 1024 * 1024 -> {b / (1024 * 1024), "M"}
+        true -> {b / 1024, "K"}
+      end
+
+    "#{:erlang.float_to_binary(value, decimals: 1)}#{unit}"
+  end
+
+  defp shorten(words, max) do
+    if String.length(words) <= max, do: words, else: String.slice(words, 0, max - 1) <> "…"
+  end
+
+  defp shorten_left(words, max) do
+    if String.length(words) <= max do
+      words
+    else
+      "…" <> String.slice(words, String.length(words) - max + 1, max)
+    end
+  end
+end

--- a/lib/mayonnaios/controller.ex
+++ b/lib/mayonnaios/controller.ex
@@ -91,6 +91,16 @@ defmodule MayonnaiOS.Controller do
   def active?, do: Process.whereis(__MODULE__) != nil
 
   @doc """
+  B belongs to this app, not to the launcher.
+
+  Every button here is the controller's product -- B is a gamepad button the
+  host is waiting for -- so the launcher must not spend it on leaving. Menu
+  is the way out, as the screen says.
+  """
+  @spec claims_back?() :: true
+  def claims_back?, do: true
+
+  @doc """
   Forward an evdev report to the pad.
 
   Called by `MayonnaiOS.Launcher` while controller mode is on. Safe to call

--- a/lib/mayonnaios/files.ex
+++ b/lib/mayonnaios/files.ex
@@ -343,6 +343,39 @@ defmodule MayonnaiOS.Files do
   end
 
   @doc """
+  The first `count` bytes of a file, or fewer if the file is shorter.
+
+  This is the read behind the browser's previews, and the cap is the caller's
+  contract: whatever the file's size, at most `count` bytes come off the disk,
+  so a cursor resting on a 200 MB ROM costs one bounded read and not a load
+  of the whole thing into a VM with the panel to run.
+
+  Follows a symlink, like every other read here -- the symlink caveat in the
+  moduledoc applies. A directory answers `{:error, :eisdir}`.
+  """
+  @spec peek(location(), pos_integer()) :: {:ok, binary()} | {:error, reason()}
+  def peek(location, count) do
+    with {:ok, path} <- resolve(location),
+         {:ok, _name} <- basename(location) do
+      case File.open(path, [:read, :binary, :raw]) do
+        {:ok, io} ->
+          result =
+            case :file.read(io, count) do
+              {:ok, data} -> {:ok, data}
+              :eof -> {:ok, <<>>}
+              {:error, reason} -> {:error, reason}
+            end
+
+          File.close(io)
+          result
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @doc """
   Free space on the filesystem holding a location, or `nil`.
 
   Per location, not per device, and that is the point. The roots span more

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -85,13 +85,24 @@ defmodule MayonnaiOS.Launcher do
       D-pad right     open the selected entry as another column
       D-pad left      close a column
       L1 / R1         page the focused column a screenful at a time
-      A               open the selected entry, launch it, or -- on a file --
-                      show what can be done with it
-      B               close a column or sheet; first, clear an obituary
+      A               open the selected entry: enter a directory, launch a
+                      program, or -- on a file -- open its full view, which
+                      is what "open" means for the one thing that cannot be
+                      entered or run
+      B               go back: close the full view, a sheet or a column;
+                      first, clear an obituary. B also leaves the apps that
+                      are readouts and the diagnostics screen -- but never
+                      an app that needs B for itself, the controller and
+                      the pickles; see `claims_back?/1`
+      X               toggle the full view: one wide column about the
+                      selected entry -- a detailed listing, a text viewer,
+                      the image, a hexdump. On a process monitor it opens
+                      the readout app, which is that row's detailed view
       Y               the second verb, and the panel says what it is: the
-                      actions sheet in a directory, the delete on its
-                      confirmation, remove-a-character in the rename editor,
-                      and the answer to the Power off row's question
+                      actions sheet in a directory -- Y and only Y, A never
+                      opens it -- the delete on its confirmation,
+                      remove-a-character in the rename editor, and the
+                      answer to the Power off row's question
       Menu            go back to the home screen, at its root column
       Power           sleep -- backlight off, and any press wakes it
       Select+Menu     power off
@@ -99,9 +110,11 @@ defmodule MayonnaiOS.Launcher do
   While the browser has a sheet up -- actions, a delete confirmation, the
   rename editor -- `MayonnaiOS.Browser.busy?/1` is true and every pad button
   is routed to `Browser.overlay_input/2` instead of the bindings above, so a
-  D-pad press cannot both move a caret and a cursor. Menu and the power-off
-  chord stay the launcher's even then, because "put me back where I started"
-  must not depend on what is on the panel.
+  D-pad press cannot both move a caret and a cursor. The full view is the
+  same arrangement through `Browser.full_input/2`: the directions scroll it
+  and B closes it. Menu and the power-off chord stay the launcher's in both
+  cases, because "put me back where I started" must not depend on what is on
+  the panel.
 
   These are the buttons as printed on the shell. Two of the atoms above name
   the opposite button; see the note on the attributes below.
@@ -229,6 +242,10 @@ defmodule MayonnaiOS.Launcher do
   @confirm_button :btn_x
   @actions_button :btn_x
 
+  # Physical X, which the device tree's swap makes :btn_y -- the note above.
+  # X toggles the full view: the wide column about the selected entry.
+  @full_button :btn_y
+
   # Menu, doing double duty: alone it is the way back to the home screen,
   # and held with Select it powers off. The chord is tested first.
   @poweroff_modifier :btn_select
@@ -258,9 +275,9 @@ defmodule MayonnaiOS.Launcher do
   @page_down_button :btn_tr
 
   # Physical B, which is BTN_SOUTH and therefore InputEvent's :btn_a -- the
-  # table at the top of this module is the authority. Bound only to clear the
-  # obituary line, which is also every other screen's "back" gesture, so the
-  # button does what the hand expects.
+  # table at the top of this module is the authority. The "back" gesture
+  # everywhere: it clears an obituary, closes the full view, a sheet or a
+  # column, and leaves the readout apps and diagnostics.
   @back_button :btn_a
 
   # How many of a program's last lines the obituary keeps. Three is what the
@@ -581,7 +598,16 @@ defmodule MayonnaiOS.Launcher do
   def handle_info({:input_event, _device, events}, %{app: app} = state) when app != nil do
     {state, slept?} = Enum.reduce(events, {state, false}, &app_event/2)
 
-    if not slept?, do: app_module(app).input(events)
+    # B leaves the apps that do not claim it -- the readouts, where back
+    # should go back -- and is then held out of the report the way the sleep
+    # key is from everything: the press that closes a screen must not also
+    # act inside it. The apps that need B for themselves keep it whole; see
+    # claims_back?/1.
+    leaving? = not slept? and back_press?(events) and not claims_back?(app)
+
+    if not slept? and not leaving?, do: app_module(app).input(events)
+
+    state = if leaving?, do: state |> stop_app() |> go_home(), else: state
 
     {:noreply, leave_app(state, events)}
   end
@@ -727,6 +753,22 @@ defmodule MayonnaiOS.Launcher do
     end
   end
 
+  defp back_press?(events) do
+    Enum.any?(events, &match?({:ev_key, @back_button, 1}, &1))
+  end
+
+  # Whether the app keeps B for itself. The controller forwards it to the
+  # host as a gamepad button and a pickle's script reads it as "b"; for
+  # those, a launcher that eats B is a controller with a dead button. An app
+  # says so by exporting `claims_back?/0` returning true; the readouts do
+  # not, so for them B is the way back. RetroArch and the other external
+  # programs are not in question here at all -- they read evdev themselves,
+  # and nothing in this clause sees their buttons.
+  defp claims_back?(app) do
+    module = app_module(app)
+    function_exported?(module, :claims_back?, 0) and module.claims_back?()
+  end
+
   defp stop_app(%{app: nil} = state), do: state
 
   defp stop_app(%{app: app} = state) do
@@ -764,6 +806,9 @@ defmodule MayonnaiOS.Launcher do
       Browser.busy?(state.browser) ->
         overlay(state, key)
 
+      Browser.full?(state.browser) ->
+        full_view(state, key)
+
       true ->
         bound(state, key)
     end
@@ -785,6 +830,21 @@ defmodule MayonnaiOS.Launcher do
     browse(state, Browser.overlay_input(state.browser, semantic(key)))
   end
 
+  # The full view has the buttons: scrolling to the browser, and the same two
+  # exceptions as the sheets -- the power-off chord, and Menu as the way
+  # home. The sleep key was already tested above.
+  defp full_view(state, @home_button) do
+    if MapSet.member?(state.held, @poweroff_modifier) do
+      poweroff(state, "Select+Menu")
+    else
+      go_home(state)
+    end
+  end
+
+  defp full_view(state, key) do
+    browse(state, Browser.full_input(state.browser, semantic(key)))
+  end
+
   # The browser speaks verbs, not scan codes: it should not have to know that
   # this board's device tree swaps A/B and X/Y, and `:other` still matters --
   # on the delete confirmation any unnamed button cancels.
@@ -792,9 +852,12 @@ defmodule MayonnaiOS.Launcher do
   defp semantic(@down_button), do: :down
   defp semantic(@left_button), do: :left
   defp semantic(@right_button), do: :right
+  defp semantic(@page_up_button), do: :l1
+  defp semantic(@page_down_button), do: :r1
   defp semantic(@launch_button), do: :a
   defp semantic(@back_button), do: :b
   defp semantic(@confirm_button), do: :y
+  defp semantic(@full_button), do: :x
   defp semantic(_key), do: :other
 
   # The Power off row's question, answered the way `MayonnaiOS.Files` answers
@@ -852,6 +915,20 @@ defmodule MayonnaiOS.Launcher do
   defp bound(state, @page_up_button), do: browse(state, Browser.page(state.browser, :up))
   defp bound(state, @page_down_button), do: browse(state, Browser.page(state.browser, :down))
   defp bound(state, @actions_button), do: browse(state, Browser.open_actions(state.browser))
+
+  # X: the full view of the selected entry -- except the process monitors,
+  # whose detailed view is the readout app itself, so X opens it the way A
+  # does. `MayonnaiOS.Browser` owns every other shape of the full view.
+  defp bound(state, @full_button) do
+    case Browser.selected(state.browser) do
+      %{kind: :program, program: %{app: {MayonnaiOS.Top, _which}} = program} ->
+        start_program(program, state)
+
+      _node ->
+        browse(state, Browser.open_full(state.browser))
+    end
+  end
+
   defp bound(state, @back_button), do: back(state)
 
   # Menu: back to the home screen, or -- with Select held -- power off.
@@ -876,7 +953,13 @@ defmodule MayonnaiOS.Launcher do
     state
   end
 
-  # B: the obituary goes first -- it is the thing most recently put on the
+  # B: on the diagnostics screen there is no column to close, so back is the
+  # way out -- the same press that leaves the readout apps. Only with nothing
+  # running: while a program has the display, its buttons are its own and a
+  # stop stays Menu's.
+  defp back(%{scene: scene, port: nil} = state) when scene != :home, do: go_home(state)
+
+  # The obituary goes next -- it is the thing most recently put on the
   # panel, and "back" should take back the last thing shown. With nothing to
   # clear, B closes a column, which is what B means on every other screen.
   defp back(%{obituary: nil} = state), do: browse(state, Browser.ascend(state.browser))
@@ -982,20 +1065,22 @@ defmodule MayonnaiOS.Launcher do
   end
 
   # A on the browser: a category, a root or a directory opens as another
-  # column; a program, a pickle or a verb starts; a file opens its actions
-  # sheet, because "open" on the one kind of thing that cannot be entered or
-  # run means "what can be done with it".
+  # column; a program, a pickle or a verb starts; a file opens its full
+  # view, because "open" on the one kind of thing that cannot be entered or
+  # run means "show me it". A never opens the actions sheet -- that is Y's,
+  # and only Y's.
   #
-  # The busy clause is for `launch/0` from a console -- a pad press with a
-  # sheet up never reaches here, `press/2` routes it first.
+  # The busy and full clauses are for `launch/0` from a console -- a pad
+  # press never reaches here in those states, `press/2` routes it first.
   defp do_launch(%{port: nil, app: nil} = state) do
     node = Browser.selected(state.browser)
 
     cond do
       Browser.busy?(state.browser) -> browse(state, Browser.overlay_input(state.browser, :a))
+      Browser.full?(state.browser) -> state
       Browser.expandable?(node) -> browse(state, Browser.descend(state.browser))
       match?(%{kind: :program}, node) -> start_program(node.program, state)
-      match?(%{kind: :file}, node) -> browse(state, Browser.open_actions(state.browser))
+      match?(%{kind: :file}, node) -> browse(state, Browser.open_full(state.browser))
       true -> state
     end
   end

--- a/lib/mayonnaios/pickles/app.ex
+++ b/lib/mayonnaios/pickles/app.ex
@@ -63,6 +63,15 @@ defmodule MayonnaiOS.Pickles.App do
   def scene, do: MayonnaiOS.Scene.Pickle
 
   @doc """
+  Launcher contract: B belongs to the pickle, not to the launcher.
+
+  A script reads it as the plastic-name "b" through `on_button`, so the
+  launcher must not spend it on leaving. Menu is the way out, as everywhere.
+  """
+  @spec claims_back?() :: true
+  def claims_back?, do: true
+
+  @doc """
   The pickle currently on the panel, or `nil`.
   """
   def current, do: GenServer.call(__MODULE__, :current)

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -13,18 +13,30 @@ defmodule MayonnaiOS.Scene.Home do
 
   ## What the panel shows
 
-  The breadcrumb line names every open level even when only the deepest
-  three fit, so the line still says where you are when the root has scrolled
-  off. Below it, a fixed grid of three columns -- the deepest levels fill it
-  from the left, and the cursor lives in the rightmost occupied one; in the
-  columns left of it the highlighted row is the one that is open, which is
-  how a column browser shows where you came from.
+  The breadcrumb line names every open level, so the line still says where
+  you are when the parents have scrolled off. Below it, a fixed grid of
+  three slots: the focused column in the center -- the only cursor the D-pad
+  moves -- its parent on the left (blank at the root, where its highlighted
+  row is the one that is open, which is how a column browser shows where you
+  came from), and on the right the preview of whatever the cursor is on:
+  the contents of a directory, the head of a file, the metadata of a
+  program, a narrow slice of the process readout.
 
-  The actions sheet is drawn as one more column, because in this UI "a list
-  to pick from" and "a column" are the same thing. The delete confirmation
-  and the rename editor take the whole column area instead: one is a
-  question that deserves the room, and the other is a character grid that
-  needs it.
+  The actions sheet rides in the preview's slot, because in this UI "a list
+  to pick from" and "a column" are the same thing. The full view that X
+  opens, the delete confirmation and the rename editor take the whole column
+  area instead: one wide column is the full view's point, a question
+  deserves the room, and a character grid needs it.
+
+  ## Images
+
+  An image -- a preview thumbnail or the full view -- reaches the driver as
+  a streamed texture: the compressed bytes go into `Scenic.Assets.Stream`
+  under a fixed id and a rect is filled from it, scaled to fit its box. The
+  driver decodes them itself (stb_image in scenic_driver_local), which is
+  why no decoder lives in this VM. Staging can fail -- bytes past the view's
+  cap, no Scenic running, a file the decoder refuses -- and the box then
+  says so instead of drawing nothing.
 
   ## Why the footer says what the buttons do, on every screen
 
@@ -96,6 +108,18 @@ defmodule MayonnaiOS.Scene.Home do
   @cell 15
   @cells 36
 
+  # The full view's table: monospace, because listings and hexdumps are
+  # columns of figures, and one line per text primitive. 13 px Roboto Mono
+  # runs about 7.8 px per glyph, so 76 characters fill the span.
+  @mono :roboto_mono
+  @full_pitch 19
+  @full_chars 76
+
+  # Where streamed textures go, one fixed id per box. Fixed, so a new image
+  # replaces the old one instead of leaking a texture per file browsed.
+  @preview_stream "browser_preview"
+  @full_stream "browser_full"
+
   @impl Scenic.Scene
   def init(scene, param, _opts) do
     # The boot root comes from `default_scene:` in config, which Scenic starts
@@ -147,7 +171,7 @@ defmodule MayonnaiOS.Scene.Home do
   # kept when it runs long: where you are matters more than where you began,
   # and the root is always one Menu press away.
   defp breadcrumb(graph, browser) do
-    trail = browser |> Browser.trail() |> Enum.join(" > ")
+    trail = (Browser.trail(browser) ++ full_crumb(browser)) |> Enum.join(" > ")
 
     text(graph, truncate_left(trail, 48),
       font_size: 18,
@@ -155,6 +179,11 @@ defmodule MayonnaiOS.Scene.Home do
       translate: {@left, @title_y}
     )
   end
+
+  # The full view is one deeper than the deepest column, and the line should
+  # say so: it is the current place the way every level above it is.
+  defp full_crumb(%{full: %{title: title}}), do: [title]
+  defp full_crumb(_browser), do: []
 
   # What is on the clipboard, top right, because a held file that is not
   # shown is a file someone pastes into the wrong place a minute later.
@@ -173,7 +202,9 @@ defmodule MayonnaiOS.Scene.Home do
   defp body(graph, %{overlay: {:confirm, pending}}), do: confirm_view(graph, pending)
   defp body(graph, %{overlay: {:rename, rename}}), do: rename_view(graph, rename)
 
-  # The actions sheet rides in as one more column, titled by the entry it is
+  defp body(graph, %{full: full}) when full != nil, do: full_view(graph, full)
+
+  # The actions sheet rides in the preview's slot, titled by the entry it is
   # about, so opening it reads as descending into the question.
   defp body(graph, %{overlay: {:actions, actions, cursor}} = browser) do
     sheet = %{
@@ -183,24 +214,32 @@ defmodule MayonnaiOS.Scene.Home do
       note: nil
     }
 
-    columns(graph, Enum.take(Browser.visible(browser) ++ [sheet], -@slots))
-  end
-
-  defp body(graph, browser), do: columns(graph, Browser.visible(browser))
-
-  defp columns(graph, levels) do
-    count = length(levels)
+    panes = Browser.panes(browser)
 
     graph
     |> separators()
-    |> then(fn g ->
-      levels
-      |> Enum.with_index()
-      |> Enum.reduce(g, fn {level, index}, acc ->
-        column(acc, level, @left + index * (@slot + @gutter), index == count - 1)
-      end)
-    end)
+    |> slot(panes.left, 0, false)
+    |> slot(panes.center, 1, false)
+    |> slot(sheet, 2, true)
   end
+
+  # The main shape: parent, focus, preview. The parent slot stays blank at
+  # the root -- an empty column on the left is what "there is nothing above"
+  # looks like.
+  defp body(graph, browser) do
+    panes = Browser.panes(browser)
+
+    graph
+    |> separators()
+    |> slot(panes.left, 0, false)
+    |> slot(panes.center, 1, true)
+    |> preview_pane(Browser.preview(browser))
+  end
+
+  defp slot(graph, nil, _index, _focused?), do: graph
+  defp slot(graph, level, index, focused?), do: column(graph, level, slot_x(index), focused?)
+
+  defp slot_x(index), do: @left + index * (@slot + @gutter)
 
   # The grid is fixed at three slots, so the hairlines are too: they say the
   # empty slots are empty, not absent.
@@ -312,6 +351,287 @@ defmodule MayonnaiOS.Scene.Home do
     start = min(max(0, cursor - visible + 1), max(0, count - visible))
 
     %{rows: items |> Enum.slice(start, visible) |> Enum.with_index(start), cursor: cursor}
+  end
+
+  # -- the preview pane -------------------------------------------------------------
+
+  # The third slot: not a column with a cursor but a statement about the
+  # selected entry -- what it contains, what it is, what the buttons do to
+  # it. `nil` -- an empty column -- draws nothing, which is the honest pane
+  # for no selection.
+  defp preview_pane(graph, nil), do: graph
+
+  # An expandable entry previews as the column it would open: same rows,
+  # no cursor, because the cursor is still one A press away.
+  defp preview_pane(graph, %{kind: :level, level: level}) do
+    x = slot_x(2)
+
+    graph
+    |> preview_caption(level.title, x)
+    |> preview_listing(level, x)
+  end
+
+  defp preview_pane(graph, %{kind: :file, title: title, info: info, body: body}) do
+    x = slot_x(2)
+
+    graph
+    |> preview_caption(title, x)
+    |> preview_lines(info, x, @rows_top, @label)
+    |> preview_body(body, x, @rows_top + length(info) * 18 + 8)
+  end
+
+  defp preview_pane(graph, %{kind: :info, title: title, lines: lines}) do
+    x = slot_x(2)
+
+    graph
+    |> preview_caption(title, x)
+    |> preview_lines(lines, x, @rows_top, @label)
+  end
+
+  defp preview_pane(graph, %{kind: :top, title: title, lines: lines}) do
+    x = slot_x(2)
+
+    graph
+    |> preview_caption(title, x)
+    |> mono_lines(lines, x, @rows_top, 12)
+  end
+
+  defp preview_caption(graph, words, x) do
+    text(graph, truncate(words, name_chars()),
+      font_size: 12,
+      fill: {:color, @dim},
+      translate: {x, @caption_y}
+    )
+  end
+
+  defp preview_listing(graph, %{entries: [], note: note}, x) do
+    text(graph, truncate(note || "Empty.", name_chars() + 6),
+      font_size: 13,
+      fill: {:color, @dim},
+      translate: {x, @rows_top + 16}
+    )
+  end
+
+  defp preview_listing(graph, %{entries: entries}, x) do
+    shown = Enum.take(entries, @visible - 1)
+
+    {graph, y} =
+      Enum.reduce(shown, {graph, @rows_top}, fn node, {acc, y} ->
+        acc =
+          text(acc, truncate(node.name, name_chars()),
+            font_size: 14,
+            fill: {:color, name_colour(node, false)},
+            translate: {x + 4, y + 16}
+          )
+
+        {acc, y + 22}
+      end)
+
+    case length(entries) - length(shown) do
+      0 ->
+        graph
+
+      more ->
+        text(graph, "… and #{more} more",
+          font_size: 12,
+          fill: {:color, @dim},
+          translate: {x + 4, y + 14}
+        )
+    end
+  end
+
+  defp preview_lines(graph, lines, x, top, colour) do
+    {graph, _y} =
+      Enum.reduce(lines, {graph, top}, fn line, {acc, y} ->
+        acc =
+          text(acc, truncate(line, 30),
+            font_size: 13,
+            fill: {:color, colour},
+            translate: {x, y + 14}
+          )
+
+        {acc, y + 18}
+      end)
+
+    graph
+  end
+
+  defp mono_lines(graph, lines, x, top, size) do
+    {graph, _y} =
+      Enum.reduce(lines, {graph, top}, fn line, {acc, y} ->
+        acc =
+          text(acc, line,
+            font: @mono,
+            font_size: size,
+            fill: {:color, @title},
+            translate: {x, y + 14}
+          )
+
+        {acc, y + size + 4}
+      end)
+
+    graph
+  end
+
+  defp preview_body(graph, nil, _x, _y), do: graph
+
+  defp preview_body(graph, {:note, words}, x, y) do
+    text(graph, truncate(words, 30), font_size: 13, fill: {:color, @dim}, translate: {x, y + 14})
+  end
+
+  defp preview_body(graph, {:text, lines}, x, y) do
+    mono_lines(graph, Enum.map(lines, &truncate(&1, 27)), x, y, 12)
+  end
+
+  defp preview_body(graph, {:hex, lines}, x, y) do
+    mono_lines(graph, lines, x, y, 12)
+  end
+
+  defp preview_body(graph, {:image, image}, x, y) do
+    bottom = @rows_top + @visible * @pitch
+    image_box(graph, @preview_stream, image, {x, y + 6, @slot - 8, bottom - y - 12})
+  end
+
+  # -- the full view ------------------------------------------------------------------
+
+  # One wide column: what X opened. The heading carries the name and, on the
+  # right, where the window sits in the whole -- the two facts the lines
+  # themselves cannot show.
+  defp full_view(graph, %{kind: :image, title: title, image: image} = full) do
+    facts =
+      Enum.join(
+        ["#{image.width} x #{image.height}", image.format] ++ List.wrap(full.note),
+        "  "
+      )
+
+    graph
+    |> full_heading(title, facts)
+    |> image_box(@full_stream, image, {@left, @rows_top, @span, @message_y - @rows_top - 10})
+  end
+
+  defp full_view(graph, %{kind: :info, title: title, lines: lines}) do
+    graph = full_heading(graph, title, "")
+
+    {graph, _y} =
+      Enum.reduce(lines, {graph, @rows_top}, fn line, {acc, y} ->
+        acc =
+          text(acc, truncate(line, @full_chars),
+            font_size: 15,
+            fill: {:color, @label},
+            translate: {@left, y + 14}
+          )
+
+        {acc, y + 22}
+      end)
+
+    graph
+  end
+
+  defp full_view(graph, %{kind: kind, lines: lines} = full)
+       when kind in [:listing, :text, :hex] do
+    window = Enum.slice(lines, full.offset, Browser.full_rows())
+
+    {graph, _y} =
+      Enum.reduce(window, {graph, @rows_top}, fn line, {acc, y} ->
+        acc =
+          text(acc, truncate(line, @full_chars),
+            font: @mono,
+            font_size: 13,
+            fill: {:color, @title},
+            translate: {@left, y + 14}
+          )
+
+        {acc, y + @full_pitch}
+      end)
+
+    full_heading(graph, full.title, range_words(full))
+  end
+
+  defp full_heading(graph, title, words) do
+    graph
+    |> text(truncate(title, 42),
+      font_size: 16,
+      fill: {:color, @title},
+      translate: {@left, @caption_y + 2}
+    )
+    |> text(truncate(words, 34),
+      font_size: 12,
+      fill: {:color, @dim},
+      translate: {@left + 372, @caption_y + 2}
+    )
+  end
+
+  # Where the window sits, what the cap kept out, and -- for an empty
+  # listing -- why there are no lines at all.
+  defp range_words(%{lines: [], note: note}), do: note || "Empty."
+
+  defp range_words(%{kind: kind, lines: lines, offset: offset} = full) do
+    total = length(lines)
+    window = Browser.full_rows()
+
+    range =
+      if total > window do
+        "#{offset + 1}–#{min(offset + window, total)} of #{total} #{unit(kind)}"
+      else
+        "#{total} #{unit(kind)}"
+      end
+
+    case full.note do
+      nil -> range
+      note -> "#{note}  --  #{range}"
+    end
+  end
+
+  defp unit(:listing), do: "entries"
+  defp unit(_kind), do: "lines"
+
+  # -- streamed images ------------------------------------------------------------
+
+  # The picture, scaled to fit its box and centered in it. The texture is
+  # staged first, because a rect filled from a stream nobody fed is a blank
+  # hole shaped like a bug; when staging fails, the box says so.
+  defp image_box(graph, id, %{bytes: bytes, width: w, height: h}, {x, y, box_w, box_h}) do
+    case stage_image(id, bytes) do
+      :ok ->
+        scale = min(box_w / w, box_h / h)
+
+        rect(graph, {w, h},
+          fill: {:stream, id},
+          scale: scale,
+          pin: {0, 0},
+          translate: {x + (box_w - w * scale) / 2, y + (box_h - h * scale) / 2}
+        )
+
+      :error ->
+        text(graph, "cannot be shown here",
+          font_size: 13,
+          fill: {:color, @dim},
+          translate: {x, y + 16}
+        )
+    end
+  end
+
+  defp stage_image(_id, nil), do: :error
+
+  defp stage_image(id, bytes) do
+    case Scenic.Assets.Stream.Image.from_binary(bytes) do
+      {:ok, image} -> put_stream(id, image)
+      {:error, _reason} -> :error
+    end
+  end
+
+  # Stream.put talks to Scenic's asset table, which is only there while
+  # Scenic runs -- and these graphs are also built by host tests with no
+  # viewport at all. :error then, and the box explains itself.
+  defp put_stream(id, image) do
+    case Scenic.Assets.Stream.put(id, image) do
+      :ok -> :ok
+      _other -> :error
+    end
+  rescue
+    _error -> :error
+  catch
+    :exit, _reason -> :error
   end
 
   # -- the delete confirmation ----------------------------------------------------
@@ -540,15 +860,18 @@ defmodule MayonnaiOS.Scene.Home do
     |> text(headline, font_size: 16, fill: {:color, @wait}, translate: {@left, @footer_y})
   end
 
+  defp hint(%{full: full}) when full != nil,
+    do: "B goes back. Up/Down scroll, L1/R1 page. X also closes."
+
   defp hint(%{overlay: {:actions, _actions, _cursor}}), do: "A does it. B goes back."
   defp hint(%{overlay: {:confirm, _pending}}), do: "Y deletes. Anything else cancels."
   defp hint(%{overlay: {:rename, _rename}}), do: "A saves. B cancels. Y removes a character."
 
   defp hint(browser) do
     if Browser.focused(browser).location == nil do
-      "A opens. B closes a column. L1/R1 page. Menu goes to the top."
+      "A opens. B closes a column. X inspects. L1/R1 page. Menu goes to the top."
     else
-      "A opens. B closes. Y for what can be done here. L1/R1 page. Menu goes to the top."
+      "A opens. B closes. X inspects. Y for file actions. Menu goes to the top."
     end
   end
 

--- a/lib/mayonnaios/scene/pairing.ex
+++ b/lib/mayonnaios/scene/pairing.ex
@@ -123,7 +123,7 @@ defmodule MayonnaiOS.Scene.Pairing do
     |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, 90})
     |> text(reason(error), font_size: 16, fill: {:color, @label}, translate: {20, 120})
     |> column(20, 160, explain(error))
-    |> footer("Menu goes back.")
+    |> footer("B or Menu goes back.")
   end
 
   def graph(status, _error) do
@@ -334,9 +334,12 @@ defmodule MayonnaiOS.Scene.Pairing do
     )
   end
 
-  defp bindings(%{bonds: []}), do: "Menu goes back."
-  defp bindings(%{armed: true}), do: "A forgets this pairing. Any direction cancels. Menu leaves."
-  defp bindings(_status), do: "D-pad picks a pairing, A forgets it. Menu goes back."
+  defp bindings(%{bonds: []}), do: "B or Menu goes back."
+
+  defp bindings(%{armed: true}),
+    do: "A forgets this pairing. Any direction cancels. B or Menu leaves."
+
+  defp bindings(_status), do: "D-pad picks a pairing, A forgets it. B or Menu goes back."
 
   defp footer(graph, message) do
     graph

--- a/lib/mayonnaios/scene/top.ex
+++ b/lib/mayonnaios/scene/top.ex
@@ -97,7 +97,7 @@ defmodule MayonnaiOS.Scene.Top do
     base("Processes")
     |> text("Not running", font_size: 26, fill: {:color, @fail}, translate: {20, 120})
     |> text(reason(error), font_size: 16, fill: {:color, @label}, translate: {20, 150})
-    |> footer("Menu goes back.")
+    |> footer("B or Menu goes back.")
   end
 
   # A machine whose sample failed -- a host with no /proc is the ordinary way
@@ -110,7 +110,7 @@ defmodule MayonnaiOS.Scene.Top do
       fill: {:color, @label},
       translate: {20, 150}
     )
-    |> footer("Menu goes back.")
+    |> footer("B or Menu goes back.")
   end
 
   def graph(snapshot, _error) do
@@ -121,7 +121,7 @@ defmodule MayonnaiOS.Scene.Top do
     |> table(snapshot)
     |> range(snapshot)
     |> footer(
-      "Up/Down scroll, Left/Right page. Y sorts by #{other_sort(snapshot)}. Menu goes back."
+      "Up/Down scroll, Left/Right page. Y sorts by #{other_sort(snapshot)}. B or Menu goes back."
     )
   end
 

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -164,12 +164,103 @@ defmodule MayonnaiOS.BrowserTest do
                0
     end
 
-    test "visible/1 is the deepest three levels" do
+    test "panes/1: the focus is the center, the parent is the left" do
       browser = Browser.new() |> into_root() |> select("snes") |> Browser.descend()
 
-      assert Browser.depth(browser) == 4
-      assert Enum.map(Browser.visible(browser), & &1.title) |> length() == 3
-      assert List.last(Browser.visible(browser)).title == "snes"
+      assert %{left: left, center: center} = Browser.panes(browser)
+      assert center.title == "snes"
+      assert Enum.map(left.entries, & &1.name) == ["backup", "snes", "readme.txt"]
+    end
+
+    test "panes/1 at the root: nothing above, so the left is blank" do
+      assert %{left: nil, center: %{title: "RG40XXV"}} = Browser.panes(Browser.new())
+    end
+  end
+
+  describe "the preview pane" do
+    setup :tmp_tree
+
+    test "a directory previews as its contents, through the same expansion" do
+      browser = Browser.new() |> into_root() |> select("snes")
+
+      assert %{kind: :level, level: level} = Browser.preview(browser)
+      assert Enum.map(level.entries, & &1.name) == ["chrono.sfc"]
+    end
+
+    test "a category previews as its rows" do
+      assert %{kind: :level, level: %{title: "Games"}} = Browser.preview(Browser.new())
+    end
+
+    test "a file previews as its metadata and its head" do
+      browser = Browser.new() |> into_root() |> select("readme.txt")
+
+      assert %{kind: :file, title: "readme.txt", body: {:text, ["hi"]}} =
+               Browser.preview(browser)
+    end
+
+    test "an empty column previews nothing", %{root: root} do
+      File.mkdir_p!(Path.join(root, "hollow"))
+      browser = Browser.new() |> into_root() |> select("hollow") |> Browser.descend()
+
+      assert Browser.selected(browser) == nil
+      assert Browser.preview(browser) == nil
+    end
+  end
+
+  describe "the full view" do
+    setup :tmp_tree
+
+    test "X on a directory is a detailed listing, and B puts the columns back" do
+      browser = Browser.new() |> into_root() |> select("snes") |> Browser.open_full()
+
+      assert Browser.full?(browser)
+      assert %{kind: :listing, title: "snes", lines: [line], offset: 0} = browser.full
+      assert line =~ "chrono.sfc"
+
+      back = Browser.full_input(browser, :b)
+      refute Browser.full?(back)
+      assert names(back) == ["backup", "snes", "readme.txt"]
+    end
+
+    test "X is a toggle: it closes what it opened" do
+      browser = Browser.new() |> into_root() |> select("readme.txt") |> Browser.open_full()
+
+      assert %{kind: :text, lines: ["hi"]} = browser.full
+      refute Browser.full_input(browser, :x) |> Browser.full?()
+    end
+
+    test "a category has no full view, so the caller can skip the repaint" do
+      browser = Browser.new()
+      assert Browser.open_full(browser) == browser
+    end
+
+    test "scrolling clamps at both ends", %{root: root} do
+      File.write!(
+        Path.join(root, "long.txt"),
+        Enum.map_join(1..40, "\n", &"line #{&1}")
+      )
+
+      browser =
+        Browser.new() |> into_root() |> select("long.txt") |> Browser.open_full()
+
+      assert browser.full.offset == 0
+      assert Browser.full_input(browser, :up).full.offset == 0
+
+      down = Browser.full_input(browser, :down)
+      assert down.full.offset == 1
+
+      paged = Browser.full_input(down, :r1)
+      assert paged.full.offset == 17
+
+      floor = Enum.reduce(1..9, paged, fn _press, acc -> Browser.full_input(acc, :r1) end)
+      assert floor.full.offset == 40 - Browser.full_rows()
+    end
+
+    test "reset drops the full view with everything else" do
+      browser =
+        Browser.new() |> into_root() |> select("readme.txt") |> Browser.open_full()
+
+      refute Browser.reset(browser) |> Browser.full?()
     end
   end
 

--- a/test/browser_view_test.exs
+++ b/test/browser_view_test.exs
@@ -1,0 +1,210 @@
+defmodule MayonnaiOS.Browser.ViewTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Browser.View
+  alias MayonnaiOS.Files
+
+  # These run against a real temporary directory for the reason the browser
+  # tests do: what is being asserted is what a set of bytes on a disk looks
+  # like from the panel, and a mock would only agree with itself.
+
+  # A complete 1x1 PNG, byte for byte: signature, IHDR, one IDAT, IEND. Small
+  # enough to write out and real enough that the same parser the display
+  # driver trusts recognises it.
+  @png <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0x0D, ?I, ?H, ?D, ?R, 0, 0, 0,
+         1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 0x1F, 0x15, 0xC4, 0x89, 0, 0, 0, 0x0D, ?I, ?D, ?A, ?T,
+         0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0, 0,
+         0, 0, ?I, ?E, ?N, ?D, 0xAE, 0x42, 0x60, 0x82>>
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "view-test-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(Path.join(root, "sub"))
+    File.write!(Path.join(root, "notes.txt"), "one\ttab\r\ntwo\nthree\nfour")
+    File.write!(Path.join(root, "save.bin"), <<0, 1, 2, 254, 255, ?H, ?I>>)
+    File.write!(Path.join(root, "pixel.png"), @png)
+    File.write!(Path.join(root, "empty"), "")
+    File.write!(Path.join(root, "sub/rom.sfc"), "123456789")
+
+    Application.put_env(:mayonnaios, :file_roots, [%{key: "r", path: root, note: ""}])
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      Application.delete_env(:mayonnaios, :file_roots)
+    end)
+
+    {:ok, column} = Files.at("r")
+    %{root: root, column: column}
+  end
+
+  defp file_node(column, name) do
+    {:ok, location} = Files.descend(column, name)
+    {:ok, entry} = Files.stat(location)
+    %{kind: :file, name: name, entry: entry}
+  end
+
+  describe "Files.peek/2" do
+    test "reads at most the asked-for bytes", %{column: column} do
+      {:ok, location} = Files.descend(column, "notes.txt")
+
+      assert {:ok, "one"} = Files.peek(location, 3)
+      assert {:ok, "one\ttab\r\ntwo\nthree\nfour"} = Files.peek(location, 1_000_000)
+    end
+
+    test "an empty file is empty, not an error", %{column: column} do
+      {:ok, location} = Files.descend(column, "empty")
+      assert {:ok, <<>>} = Files.peek(location, 16)
+    end
+
+    test "a missing file says why", %{column: column} do
+      {:ok, location} = Files.descend(column, "not-there")
+      assert {:error, :enoent} = Files.peek(location, 16)
+    end
+  end
+
+  describe "previewing a file" do
+    test "a text file previews its first lines", %{column: column} do
+      preview = View.preview(file_node(column, "notes.txt"), column)
+
+      assert %{kind: :file, title: "notes.txt", info: [info], body: {:text, lines}} = preview
+      assert info =~ "a file of"
+      # Tabs become spaces and carriage returns go, so the panel never draws
+      # a control character.
+      assert ["one  tab", "two", "three", "four"] = lines
+    end
+
+    test "bytes that are not text preview as a narrow hexdump", %{column: column} do
+      preview = View.preview(file_node(column, "save.bin"), column)
+
+      assert %{body: {:hex, [line]}} = preview
+      assert line == "00 01 02 fe ff 48 49"
+    end
+
+    test "an image previews as its pixels and its header facts", %{column: column} do
+      preview = View.preview(file_node(column, "pixel.png"), column)
+
+      assert %{body: {:image, image}} = preview
+      assert %{format: "image/png", width: 1, height: 1, bytes: @png} = image
+    end
+
+    test "an empty file says so", %{column: column} do
+      assert %{body: {:note, "empty"}} = View.preview(file_node(column, "empty"), column)
+    end
+
+    test "a file with no column location keeps its info and loses the read" do
+      node = %{
+        kind: :file,
+        name: "x",
+        entry: %{type: :regular, size: 3, link: nil, broken?: false}
+      }
+
+      assert %{info: _lines, body: nil} = View.preview(node, nil)
+    end
+  end
+
+  describe "previewing a runnable row" do
+    test "a program shows its path and that A runs it" do
+      [program] = MayonnaiOS.Programs.list([%{path: System.find_executable("sh")}])
+      preview = View.preview(%{kind: :program, name: "sh", program: program}, nil)
+
+      assert %{kind: :info, lines: lines} = preview
+      assert Enum.any?(lines, &(&1 =~ "A runs it"))
+      assert program.path in lines
+    end
+
+    test "a missing program says not installed" do
+      [program] = MayonnaiOS.Programs.list([%{path: "/nonexistent/prog"}])
+      preview = View.preview(%{kind: :program, name: "prog", program: program}, nil)
+
+      assert Enum.any?(preview.lines, &(&1 =~ "Not installed"))
+    end
+
+    test "the power-off verb says Y answers" do
+      [program] = MayonnaiOS.Programs.list([%{name: "Power off", action: :poweroff}])
+      preview = View.preview(%{kind: :program, name: "Power off", program: program}, nil)
+
+      assert Enum.any?(preview.lines, &(&1 =~ "only Y"))
+    end
+
+    test "a process monitor previews as a narrow list by memory" do
+      [program] = MayonnaiOS.Programs.list([%{name: "BEAM", app: {MayonnaiOS.Top, :beam}}])
+      preview = View.preview(%{kind: :program, name: "BEAM", program: program}, nil)
+
+      assert %{kind: :top, lines: [_ | _] = lines} = preview
+      # Widest first: the list is the readout's head, by memory.
+      mems = for line <- lines, do: line |> String.split() |> hd()
+      assert length(mems) <= 10
+    end
+  end
+
+  describe "the full view" do
+    test "a directory is a detailed listing with sizes", %{column: column} do
+      {:ok, location} = Files.descend(column, "sub")
+      node = %{kind: :dir, name: "sub", location: location, entry: %{type: :directory}}
+
+      assert %{kind: :listing, title: "sub", lines: [line], note: nil} =
+               View.full(node, column)
+
+      assert line =~ "rom.sfc"
+      assert line =~ "9 B"
+    end
+
+    test "an empty directory says Empty", %{root: root, column: column} do
+      File.mkdir_p!(Path.join(root, "hollow"))
+      {:ok, location} = Files.descend(column, "hollow")
+      node = %{kind: :dir, name: "hollow", location: location, entry: %{type: :directory}}
+
+      assert %{kind: :listing, lines: [], note: "Empty."} = View.full(node, column)
+    end
+
+    test "a place opens as a listing of its root" do
+      node = %{kind: :place, name: "r", key: "r", note: ""}
+
+      assert %{kind: :listing, lines: lines} = View.full(node, nil)
+      assert Enum.any?(lines, &(&1 =~ "notes.txt"))
+    end
+
+    test "a text file is a text viewer", %{column: column} do
+      assert %{kind: :text, lines: lines, note: nil} =
+               View.full(file_node(column, "notes.txt"), column)
+
+      assert "three" in lines
+    end
+
+    test "other bytes are a hexdump with offsets and printables", %{column: column} do
+      assert %{kind: :hex, lines: [line]} = View.full(file_node(column, "save.bin"), column)
+      assert line == "000000  00 01 02 fe ff 48 49                             |.....HI|"
+    end
+
+    test "an image carries its bytes for the panel to draw", %{column: column} do
+      assert %{kind: :image, image: %{width: 1, height: 1, bytes: @png}, note: nil} =
+               View.full(file_node(column, "pixel.png"), column)
+    end
+
+    test "a runnable row is its metadata" do
+      [program] = MayonnaiOS.Programs.list([%{path: "/nonexistent/prog"}])
+      node = %{kind: :program, name: "prog", program: program}
+
+      assert %{kind: :info, lines: lines} = View.full(node, nil)
+      assert Enum.any?(lines, &(&1 =~ "Not installed"))
+    end
+
+    test "a category has no full view" do
+      assert View.full(%{kind: :category, id: :games, name: "Games"}, nil) == nil
+    end
+  end
+
+  describe "hexdump/1" do
+    test "sixteen bytes a line, offset first, printables last" do
+      lines = View.hexdump(:binary.copy(<<0>>, 16) <> "ABCDEFGH")
+
+      assert [
+               "000000  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  |................|",
+               "000010  41 42 43 44 45 46 47 48                          |ABCDEFGH|"
+             ] = lines
+    end
+
+    test "nothing dumps to nothing" do
+      assert View.hexdump(<<>>) == []
+    end
+  end
+end

--- a/test/controller/app_test.exs
+++ b/test/controller/app_test.exs
@@ -107,13 +107,26 @@ defmodule MayonnaiOS.Controller.AppTest do
     test "a whole evdev report is forwarded in one piece" do
       press(:btn_b)
 
-      send_events([{:ev_key, :btn_dpad_down, 1}, {:ev_key, :btn_a, 1}])
+      # Not :btn_a -- physical B -- in this report: FakeApp does not claim B,
+      # so for it that press is the way out, not input.
+      send_events([{:ev_key, :btn_dpad_down, 1}, {:ev_key, :btn_x, 1}])
 
       # One entry, not two: the A press that started the app belongs to the
       # launcher and is not forwarded. Only what happens after it is the
       # app's.
       assert [report] = FakeApp.log().events
-      assert report == [{:ev_key, :btn_dpad_down, 1}, {:ev_key, :btn_a, 1}]
+      assert report == [{:ev_key, :btn_dpad_down, 1}, {:ev_key, :btn_x, 1}]
+    end
+
+    test "B stops an app that does not claim it" do
+      press(:btn_b)
+      assert FakeApp.log().started == 1
+
+      # Physical B: FakeApp exports no claims_back?/0, so back goes back.
+      press(:btn_a)
+
+      assert FakeApp.log().stopped == 1
+      assert FakeApp.log().events == []
     end
 
     test "the D-pad does not move the menu cursor" do

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -153,6 +153,25 @@ defmodule MayonnaiOS.LauncherTest do
       refute Enum.any?(says, &(&1 =~ "exited"))
     end
 
+    test "the right pane previews the selection" do
+      Application.put_env(:mayonnaios, :programs, [%{path: "/a"}])
+
+      # The cursor is on Games, so the preview pane lists what Games holds.
+      assert "a" in texts(Home.graph(Browser.new()))
+    end
+
+    test "the full view is one wide column about the selection" do
+      Application.put_env(:mayonnaios, :programs, [%{path: "/a"}])
+
+      browser = Browser.new() |> Browser.descend() |> Browser.open_full()
+      says = texts(Home.graph(browser))
+
+      assert Enum.any?(says, &(&1 =~ "/a"))
+      assert Enum.any?(says, &(&1 =~ "B goes back"))
+      # The columns give way to the one wide view.
+      refute "Games" in says
+    end
+
     test "the footer labels the buttons for the state on screen" do
       idle = texts(Home.graph(Browser.new()))
       assert Enum.any?(idle, &(&1 =~ "A opens."))

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -331,6 +331,52 @@ defmodule MayonnaiOS.LauncherTest do
       assert Launcher.selected() == 1
     end
 
+    test "A on a file opens the full view, never the actions sheet" do
+      # Down onto Files, into the first root, cursor on its first file.
+      press(:btn_dpad_down)
+      press(:btn_b)
+      press(:btn_b)
+
+      press(:btn_b)
+      browser = Launcher.browser()
+      assert Browser.full?(browser)
+      refute Browser.busy?(browser)
+
+      # Physical B closes it, and the columns are back where they were.
+      press(:btn_a)
+      refute Browser.full?(Launcher.browser())
+      assert Browser.depth(Launcher.browser()) == 3
+    end
+
+    test "X toggles the full view, and the view has the D-pad while it is up" do
+      press(:btn_dpad_down)
+      press(:btn_b)
+      press(:btn_b)
+
+      # :btn_y is the button silkscreened X; see the Launcher moduledoc.
+      press(:btn_y)
+      assert Browser.full?(Launcher.browser())
+
+      before = Launcher.selected()
+      press(:btn_dpad_down)
+      assert Launcher.selected() == before
+
+      press(:btn_y)
+      refute Browser.full?(Launcher.browser())
+    end
+
+    test "Menu leaves the full view for the root column" do
+      press(:btn_dpad_down)
+      press(:btn_b)
+      press(:btn_b)
+      press(:btn_y)
+      assert Browser.full?(Launcher.browser())
+
+      press(:btn_mode)
+      refute Browser.full?(Launcher.browser())
+      assert Browser.depth(Launcher.browser()) == 1
+    end
+
     test "Menu goes back to the root column from deep in the tree" do
       press(:btn_b)
       press(:btn_dpad_down)
@@ -345,6 +391,80 @@ defmodule MayonnaiOS.LauncherTest do
       send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 0}]})
       # selected/0 is a call, so it is ordered behind the casts above.
       Launcher.selected()
+    end
+  end
+
+  # B leaving the readout apps and diagnostics, and staying with the apps
+  # that need it. The fake apps at the bottom of this file stand in for the
+  # real ones because the real ones want hci0 or a viewport; the contract
+  # exercised -- start, stop, input, claims_back? -- is the launcher's whole
+  # view of an app either way.
+  describe "B as the way back out" do
+    setup do
+      Process.register(self(), :launcher_test_sink)
+
+      Application.put_env(:mayonnaios, :programs, [
+        %{name: "Readout", app: FakeReadout, category: :apps},
+        %{name: "Game", app: FakeGame, category: :apps},
+        %{name: "BEAM processes", app: {MayonnaiOS.Top, :beam}, category: :apps}
+      ])
+
+      on_exit(fn -> Application.delete_env(:mayonnaios, :programs) end)
+
+      start_supervised!({Launcher, device: "/nonexistent/event0"})
+
+      # Into the Apps column: third category from the top.
+      tap(:btn_dpad_down)
+      tap(:btn_dpad_down)
+      tap(:btn_b)
+      :ok
+    end
+
+    test "B leaves an app that does not claim it, and the press is swallowed" do
+      tap(:btn_b)
+      assert :sys.get_state(Launcher).app == FakeReadout
+
+      tap(:btn_a)
+      assert_receive {FakeReadout, :stopped}
+      assert :sys.get_state(Launcher).app == nil
+      assert :sys.get_state(Launcher).scene == :home
+
+      # The press that left never reached the app as input.
+      refute_received {FakeReadout, {:input, [{:ev_key, :btn_a, 1}]}}
+    end
+
+    test "B stays with an app that claims it" do
+      tap(:btn_dpad_down)
+      tap(:btn_b)
+      assert :sys.get_state(Launcher).app == FakeGame
+
+      tap(:btn_a)
+      assert_receive {FakeGame, {:input, [{:ev_key, :btn_a, 1}]}}
+      assert :sys.get_state(Launcher).app == FakeGame
+      refute_received {FakeGame, :stopped}
+    end
+
+    test "X on a process monitor opens the readout itself, and B backs out" do
+      tap(:btn_dpad_down)
+      tap(:btn_dpad_down)
+
+      tap(:btn_y)
+      assert :sys.get_state(Launcher).app == {MayonnaiOS.Top, :beam}
+
+      tap(:btn_a)
+      assert :sys.get_state(Launcher).app == nil
+    end
+
+    test "B leaves diagnostics for the home screen" do
+      # System is one wrap up from Apps' row; simplest is Menu home, then up.
+      tap(:btn_mode)
+      tap(:btn_dpad_up)
+      tap(:btn_b)
+      tap(:btn_b)
+      assert :sys.get_state(Launcher).scene == :diagnostics
+
+      tap(:btn_a)
+      assert :sys.get_state(Launcher).scene == :home
     end
   end
 
@@ -761,6 +881,35 @@ defmodule MayonnaiOS.LauncherTest do
       refute_received :flushed
       assert alive?(os_pid)
     end
+  end
+end
+
+# The launcher's app contract with nothing behind it: starts a process that
+# idles, reports its stops and its inputs to whichever test registered itself
+# as the sink. One does not claim B and one does, which is the difference
+# under test.
+defmodule FakeReadout do
+  def start, do: {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+  def stop, do: notify(:stopped)
+  def input(events), do: notify({:input, events})
+  def scene, do: nil
+
+  defp notify(message) do
+    if pid = Process.whereis(:launcher_test_sink), do: send(pid, {__MODULE__, message})
+    :ok
+  end
+end
+
+defmodule FakeGame do
+  def start, do: {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+  def stop, do: notify(:stopped)
+  def input(events), do: notify({:input, events})
+  def scene, do: nil
+  def claims_back?, do: true
+
+  defp notify(message) do
+    if pid = Process.whereis(:launcher_test_sink), do: send(pid, {__MODULE__, message})
+    :ok
   end
 end
 

--- a/test/pairing_test.exs
+++ b/test/pairing_test.exs
@@ -242,7 +242,7 @@ defmodule MayonnaiOS.PairingTest do
       texts = texts(Scene.graph(Pairing.status()))
 
       assert "Nothing paired." in texts
-      assert "Menu goes back." in texts
+      assert "B or Menu goes back." in texts
       refute Enum.any?(texts, &String.contains?(&1, "A forgets"))
     end
 
@@ -275,7 +275,7 @@ defmodule MayonnaiOS.PairingTest do
       texts = texts(Scene.graph(Pairing.status()))
 
       assert "press A again to forget" in texts
-      assert "A forgets this pairing. Any direction cancels. Menu leaves." in texts
+      assert "A forgets this pairing. Any direction cancels. B or Menu leaves." in texts
     end
 
     test "an unarmed row says what the buttons do" do
@@ -286,7 +286,7 @@ defmodule MayonnaiOS.PairingTest do
 
       assert "A1:A2:A3:A4:A5:A6" in texts
       assert "public address, 128-bit key" in texts
-      assert "D-pad picks a pairing, A forgets it. Menu goes back." in texts
+      assert "D-pad picks a pairing, A forgets it. B or Menu goes back." in texts
     end
 
     test "a scan that never started says so instead of showing an empty room" do


### PR DESCRIPTION
## Summary
The column browser becomes proper Miller columns: the focused column is always the center slot, the parent sits on the left (blank at the root), and the right slot previews the selection — a directory as its contents, a file as its metadata plus its head (text, image, or hexdump, decided by the first bytes), a runnable row as its metadata, a process monitor as a narrow one-sample slice of the readout. X toggles a full view: one wide column with a detailed listing, a text viewer, the image full-screen (streamed to the driver, which decodes it itself), or an offset+ascii hexdump. Reads are bounded everywhere and the panel says when a cap was hit.

## Buttons

| Button | In the columns | In the full view | In apps/screens |
|--------|----------------|------------------|-----------------|
| A | opens: enters a directory, launches a program, opens a file's full view. Never the actions sheet | — | — |
| B | closes a column; clears an obituary first | closes the full view | leaves the readout apps (Top, Bluetooth devices) and diagnostics; never the controller or pickles, which claim B via `claims_back?/0`; external programs (RetroArch) are untouched |
| X | opens the full view; on a process monitor, opens the Top app (that *is* its detailed view) | closes it (toggle) | — |
| Y | the actions sheet — the only way to it | swallowed | — |

## Decisions where the spec conflicted
- "A enters a directory or in the case of a file … X should trigger the full mode" is ambiguous about what A does on a non-executable file. Consistency rule applied: A always *opens* — so A on a file opens the same full view X does, and only Y ever opens the actions sheet.
- Categories (Games/Files/Apps/System) get a contents preview but no full view; X there is a no-op.
- Bluetooth *devices* (pairing) is a readout that doesn't use B, so B leaves it; only the controller and the pickles keep B, per the "consistency wins" clause.
- The confirm-delete rule is untouched: only Y deletes, everything else cancels.

## Follow-ups for reviewer
- Image rendering rides on `Scenic.Assets.Stream` + the driver's stb_image decode; fine on host tests, but is cairo-fb's texture path proven on the panel, or should the image full view land behind a try on the device first?

**Untested on hardware** — verified with `mix compile --warnings-as-errors` and the full test suite (766 passing) on the host only; the host UI renders blank, so column layout, image streaming, and button feel need a check on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)