### PR TITLE
Show a system info panel in the root column's empty left slot

### DIFF
--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -2,7 +2,8 @@ defmodule MayonnaiOS.Browser do
   @moduledoc """
   The launcher's menu as a column browser: a stack of levels, Miller-columns
   style, and the focus is always the center of the panel. The left column is
-  the level above -- blank at the root -- and the right column is not a level
+  the level above -- `nil` at the root, where the scene draws the
+  `MayonnaiOS.SystemInfo` panel instead -- and the right column is not a level
   at all: it previews whatever the cursor is on. A directory previews as its
   contents, a file as its metadata and its first bytes (text, an image, or a
   hexdump, whichever the bytes are), a runnable row as what it is and that A
@@ -271,8 +272,9 @@ defmodule MayonnaiOS.Browser do
 
   @doc """
   The two levels the panel's left and center slots draw: the focused column,
-  where the cursor lives, and its parent -- `nil` at the root, where blank on
-  the left is the honest answer. The third slot is `preview/1`'s.
+  where the cursor lives, and its parent -- `nil` at the root, where there is
+  nothing above and the scene fills the slot with the system panel instead.
+  The third slot is `preview/1`'s.
   """
   @spec panes(t()) :: %{left: level() | nil, center: level()}
   def panes(%{levels: [only]}), do: %{left: nil, center: only}

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -16,9 +16,11 @@ defmodule MayonnaiOS.Scene.Home do
   The breadcrumb line names every open level, so the line still says where
   you are when the parents have scrolled off. Below it, a fixed grid of
   three slots: the focused column in the center -- the only cursor the D-pad
-  moves -- its parent on the left (blank at the root, where its highlighted
-  row is the one that is open, which is how a column browser shows where you
-  came from), and on the right the preview of whatever the cursor is on:
+  moves -- its parent on the left (its highlighted row is the one that is
+  open, which is how a column browser shows where you came from; at the
+  root, where there is no parent, the slot carries the
+  `MayonnaiOS.SystemInfo` panel), and on the right the preview of whatever
+  the cursor is on:
   the contents of a directory, the head of a file, the metadata of a
   program, a narrow slice of the process readout.
 
@@ -50,7 +52,7 @@ defmodule MayonnaiOS.Scene.Home do
 
   use Scenic.Scene
 
-  alias MayonnaiOS.{Browser, Files, Theme}
+  alias MayonnaiOS.{Browser, Files, SystemInfo, Theme}
   alias MayonnaiOS.Scene.StatusBar
   alias Scenic.Graph
   import Scenic.Primitives
@@ -233,18 +235,22 @@ defmodule MayonnaiOS.Scene.Home do
     |> slot(sheet, 2, true)
   end
 
-  # The main shape: parent, focus, preview. The parent slot stays blank at
-  # the root -- an empty column on the left is what "there is nothing above"
-  # looks like.
+  # The main shape: parent, focus, preview. At the root there is no parent,
+  # and the left slot carries the system panel instead of sitting empty.
   defp body(graph, browser) do
     panes = Browser.panes(browser)
 
     graph
     |> separators()
-    |> slot(panes.left, 0, false)
+    |> left_slot(panes.left)
     |> slot(panes.center, 1, true)
     |> preview_pane(Browser.preview(browser))
   end
+
+  # The system panel is the same `%{kind: :info, ...}` shape the preview's
+  # info panes carry, so the one line renderer draws both.
+  defp left_slot(graph, nil), do: info_pane(graph, SystemInfo.panel(), slot_x(0))
+  defp left_slot(graph, level), do: slot(graph, level, 0, false)
 
   defp slot(graph, nil, _index, _focused?), do: graph
   defp slot(graph, level, index, focused?), do: column(graph, level, slot_x(index), focused?)
@@ -390,13 +396,7 @@ defmodule MayonnaiOS.Scene.Home do
     |> preview_body(body, x, @rows_top + length(info) * 18 + 8)
   end
 
-  defp preview_pane(graph, %{kind: :info, title: title, lines: lines}) do
-    x = slot_x(2)
-
-    graph
-    |> preview_caption(title, x)
-    |> preview_lines(lines, x, @rows_top, label())
-  end
+  defp preview_pane(graph, %{kind: :info} = pane), do: info_pane(graph, pane, slot_x(2))
 
   defp preview_pane(graph, %{kind: :top, title: title, lines: lines}) do
     x = slot_x(2)
@@ -404,6 +404,14 @@ defmodule MayonnaiOS.Scene.Home do
     graph
     |> preview_caption(title, x)
     |> mono_lines(lines, x, @rows_top, 12)
+  end
+
+  # A generic line panel in any slot: a caption, then dim-labelled lines.
+  # The preview's info panes and the root's system panel are both this.
+  defp info_pane(graph, %{title: title, lines: lines}, x) do
+    graph
+    |> preview_caption(title, x)
+    |> preview_lines(lines, x, @rows_top, label())
   end
 
   defp preview_caption(graph, words, x) do

--- a/lib/mayonnaios/system_info.ex
+++ b/lib/mayonnaios/system_info.ex
@@ -1,0 +1,214 @@
+defmodule MayonnaiOS.SystemInfo do
+  @moduledoc """
+  The system panel: what the root column's left slot says about the device.
+
+  At the root of the column browser there is no parent column, so the left
+  slot carries the glanceable facts about the machine itself instead: what
+  firmware is running, how long it has been up, what address the network
+  gave it, and how much room the writable partitions have left. The shape it
+  returns is the same `%{kind: :info, title: ..., lines: ...}` the preview
+  pane already draws, so `MayonnaiOS.Scene.Home` renders it with the line
+  renderer it has rather than a second one.
+
+  ## Where each fact comes from
+
+    * the app version is the OTP release's own, via
+      `MayonnaiOS.Update.running_version/0`
+    * the firmware line is `Nerves.Runtime.KV`'s active-slot metadata: the
+      version fwup stamped and which slot (a or b) is running -- the fact
+      that says whether the last update actually took
+    * the build is the firmware's fwup UUID, shortened to its first eight
+      characters: two devices reading the same eight characters are running
+      byte-identical firmware, which no version number can promise
+    * uptime is the VM's wall clock -- on this appliance the VM starts
+      within seconds of power-on, and a clock the VM owns cannot block
+    * the address is the first useful IPv4 the kernel reports, WiFi first
+    * memory is what the BEAM has allocated, `:erlang.memory/1` -- the
+      number that grows when something in this VM leaks
+    * disk free is `MayonnaiOS.Files.space/1` on the writable mounts: the
+      data partition, and the games card when it is mounted
+
+  ## Every read is an argument
+
+  Each source is injectable and defaults to the real thing -- the same seam
+  `MayonnaiOS.Files`, `MayonnaiOS.Launcher` and `MayonnaiOS.Update` use --
+  because a host has no U-Boot environment, no `/root` partition and no
+  games card. A fact that cannot be read is a line the panel does not say,
+  never a crash: the panel degrades to whatever the machine can answer.
+  """
+
+  alias MayonnaiOS.{Files, GamesCard, Update}
+
+  @typedoc "The panel: the shape `MayonnaiOS.Scene.Home`'s info panes draw."
+  @type panel :: %{kind: :info, title: String.t(), lines: [String.t()]}
+
+  @doc """
+  Build the panel.
+
+  Options, all for tests -- the defaults are what the device uses:
+
+    * `:version` -- `fn -> String.t() end`, default
+      `MayonnaiOS.Update.running_version/0`
+    * `:kv` -- `fn -> map end` of active-slot firmware metadata plus
+      `"nerves_fw_active"`, default `Nerves.Runtime.KV`
+    * `:uptime_ms` -- `fn -> non_neg_integer end`, default the VM's wall
+      clock
+    * `:address` -- `fn -> {interface, address} | nil end`, default the
+      kernel's interface list
+    * `:memory_bytes` -- `fn -> non_neg_integer end`, default
+      `:erlang.memory(:total)`
+    * `:space` -- `fn path -> map | nil end`, default
+      `MayonnaiOS.Files.space/1`
+    * `:data_mount` -- the writable partition's mount point, default
+      `"/root"`
+    * `:games_mount` -- `fn -> String.t() | nil end`, default
+      `MayonnaiOS.GamesCard.mount_point/0`
+    * `:games_mounted?` -- `fn -> boolean end`, default
+      `MayonnaiOS.GamesCard.mounted?/0`
+  """
+  @spec panel(keyword()) :: panel()
+  def panel(opts \\ []) do
+    kv = Keyword.get(opts, :kv, &read_kv/0).()
+
+    lines =
+      [
+        "MayonnaiOS " <> Keyword.get(opts, :version, &Update.running_version/0).(),
+        firmware_line(kv),
+        build_line(kv),
+        uptime_line(Keyword.get(opts, :uptime_ms, &vm_uptime_ms/0).()),
+        address_line(Keyword.get(opts, :address, &first_address/0).()),
+        memory_line(Keyword.get(opts, :memory_bytes, &beam_memory/0).())
+      ] ++ disk_lines(opts)
+
+    %{kind: :info, title: "This device", lines: Enum.reject(lines, &is_nil/1)}
+  end
+
+  # -- firmware ---------------------------------------------------------------
+
+  # Active-slot metadata under its bare names, plus which slot is active.
+  # `Nerves.Runtime.KV` already answers with empties when it is not running;
+  # the rescue is for a host image without the module at all.
+  defp read_kv do
+    Nerves.Runtime.KV.get_all_active()
+    |> put_present("nerves_fw_active", Nerves.Runtime.KV.get("nerves_fw_active"))
+  rescue
+    _error -> %{}
+  catch
+    :exit, _reason -> %{}
+  end
+
+  defp put_present(map, _key, nil), do: map
+  defp put_present(map, key, value), do: Map.put(map, key, value)
+
+  defp firmware_line(%{"nerves_fw_version" => version} = kv) when version not in [nil, ""] do
+    "firmware #{version}#{slot_words(kv)}"
+  end
+
+  defp firmware_line(_kv), do: nil
+
+  defp slot_words(%{"nerves_fw_active" => slot}) when slot not in [nil, ""], do: ", slot #{slot}"
+  defp slot_words(_kv), do: ""
+
+  # The first eight characters of the fwup UUID: enough to tell two builds of
+  # the same version apart at a glance, short enough to fit the column.
+  defp build_line(%{"nerves_fw_uuid" => uuid}) when is_binary(uuid) and byte_size(uuid) >= 8 do
+    "build #{String.slice(uuid, 0, 8)}"
+  end
+
+  defp build_line(_kv), do: nil
+
+  # -- uptime -----------------------------------------------------------------
+
+  defp vm_uptime_ms do
+    {ms, _since_last} = :erlang.statistics(:wall_clock)
+    ms
+  end
+
+  defp uptime_line(ms) when is_integer(ms) and ms >= 0, do: "up " <> uptime_words(div(ms, 1000))
+  defp uptime_line(_reading), do: nil
+
+  # The two largest units that apply: seconds matter in the first minute and
+  # never after a day.
+  defp uptime_words(s) when s < 60, do: "#{s}s"
+  defp uptime_words(s) when s < 3600, do: "#{div(s, 60)}m #{rem(s, 60)}s"
+  defp uptime_words(s) when s < 86_400, do: "#{div(s, 3600)}h #{rem(s, 3600) |> div(60)}m"
+  defp uptime_words(s), do: "#{div(s, 86_400)}d #{rem(s, 86_400) |> div(3600)}h"
+
+  # -- network ----------------------------------------------------------------
+
+  # One interface and its IPv4, the radio first: on the device wlan0 is the
+  # address someone types into a browser to reach the upload page, and usb0
+  # only exists while a cable is in.
+  defp first_address do
+    case :inet.getifaddrs() do
+      {:ok, interfaces} ->
+        candidates =
+          for {name, props} <- interfaces,
+              {:addr, {a, _b, _c, _d} = addr} <- props,
+              a != 127 do
+            {List.to_string(name), addr |> :inet.ntoa() |> List.to_string()}
+          end
+
+        Enum.find(candidates, &match?({"wlan" <> _rest, _addr}, &1)) || List.first(candidates)
+
+      {:error, _reason} ->
+        nil
+    end
+  end
+
+  defp address_line(nil), do: "no network address"
+  defp address_line({interface, address}), do: "#{interface} #{address}"
+
+  # -- memory -----------------------------------------------------------------
+
+  defp beam_memory, do: :erlang.memory(:total)
+
+  defp memory_line(bytes) when is_integer(bytes), do: "beam memory #{bytes(bytes)}"
+  defp memory_line(_reading), do: nil
+
+  # -- disks ------------------------------------------------------------------
+
+  defp disk_lines(opts) do
+    space = Keyword.get(opts, :space, &Files.space/1)
+    data_mount = Keyword.get(opts, :data_mount, "/root")
+    games_mount = Keyword.get(opts, :games_mount, &GamesCard.mount_point/0)
+    games_mounted? = Keyword.get(opts, :games_mounted?, &GamesCard.mounted?/0)
+
+    [
+      space_line("internal", space.(data_mount)),
+      games_line(space, games_mount.(), games_mounted?.())
+    ]
+  end
+
+  # A mount that cannot be measured is a line the panel does not say.
+  defp space_line(_name, nil), do: nil
+
+  defp space_line(name, %{free: free, total: total}) do
+    "#{name}: #{bytes(free)} free of #{bytes(total)}"
+  end
+
+  # Only a mounted card gets measured: `df` on an unmounted mount point
+  # answers for whatever filesystem the empty directory sits on, and the
+  # internal partition's numbers under the card's name would be worse than
+  # no line at all.
+  defp games_line(_space, nil, _mounted?), do: nil
+  defp games_line(space, mount, true), do: space_line("games card", space.(mount))
+  defp games_line(_space, _mount, false), do: "games card: not in"
+
+  # -- words ------------------------------------------------------------------
+
+  # Powers of 1024 with df's one-letter units, the units every other number
+  # on this panel is quoted in.
+  defp bytes(b) when b < 1024, do: "#{b} B"
+
+  defp bytes(b) do
+    {value, unit} =
+      cond do
+        b >= 1024 * 1024 * 1024 -> {b / (1024 * 1024 * 1024), "G"}
+        b >= 1024 * 1024 -> {b / (1024 * 1024), "M"}
+        true -> {b / 1024, "K"}
+      end
+
+    "#{:erlang.float_to_binary(value, decimals: 1)}#{unit}"
+  end
+end

--- a/lib/mayonnaios/system_info.ex
+++ b/lib/mayonnaios/system_info.ex
@@ -183,8 +183,8 @@ defmodule MayonnaiOS.SystemInfo do
   # A mount that cannot be measured is a line the panel does not say.
   defp space_line(_name, nil), do: nil
 
-  defp space_line(name, %{free: free, total: total}) do
-    "#{name}: #{bytes(free)} free of #{bytes(total)}"
+  defp space_line(name, %{free: free}) do
+    "#{name}: #{bytes(free)} free"
   end
 
   # Only a mounted card gets measured: `df` on an unmounted mount point

--- a/test/system_info_test.exs
+++ b/test/system_info_test.exs
@@ -46,8 +46,8 @@ defmodule MayonnaiOS.SystemInfoTest do
                "up 3d 4h",
                "wlan0 192.168.4.17",
                "beam memory 182.2M",
-               "internal: 9.4G free of 12.9G",
-               "games card: 24.0G free of 57.9G"
+               "internal: 9.4G free",
+               "games card: 24.0G free"
              ]
     end
 
@@ -112,12 +112,12 @@ defmodule MayonnaiOS.SystemInfoTest do
     end
 
     test "every line fits the column it is drawn in" do
-      # The slot is 192 px wide (home.ex: (640 - 40 - 2 * 12) / 3) and the
+      # The slot is 200 px wide (home.ex: (640 - 24 - 2 * 8) / 3) and the
       # lines are set at 15 px in the theme's body font. Measured, not
       # counted: a character budget guessed against one font is wrong in the
       # next one.
       for line <- panel().lines do
-        assert Theme.width(line, 15) <= 192, "#{inspect(line)} overflows the slot"
+        assert Theme.width(line, 15) <= 200, "#{inspect(line)} overflows the slot"
       end
     end
   end

--- a/test/system_info_test.exs
+++ b/test/system_info_test.exs
@@ -1,0 +1,144 @@
+defmodule MayonnaiOS.SystemInfoTest do
+  use ExUnit.Case, async: true
+
+  alias MayonnaiOS.{Browser, SystemInfo, Theme}
+  alias MayonnaiOS.Scene.Home
+
+  # Every source injected, so nothing here reads the machine the tests run
+  # on: a host has no U-Boot environment and no games card, and a panel
+  # asserted against real readings would be a test of the laptop.
+
+  @kv %{
+    "nerves_fw_version" => "0.1.0",
+    "nerves_fw_uuid" => "3f8a2b1c-4d5e-6f70-8192-a3b4c5d6e7f8",
+    "nerves_fw_active" => "a"
+  }
+
+  defp panel(overrides \\ []) do
+    defaults = [
+      version: fn -> "0.1.0" end,
+      kv: fn -> @kv end,
+      uptime_ms: fn -> (3 * 86_400 + 4 * 3600 + 12 * 60) * 1000 end,
+      address: fn -> {"wlan0", "192.168.4.17"} end,
+      memory_bytes: fn -> 191_000_000 end,
+      space: fn
+        "/root" ->
+          %{device: "/dev/mmcblk0p4", free: 10_100_000_000, total: 13_900_000_000}
+
+        "/root/mnt/games" ->
+          %{device: "/dev/mmcblk2p1", free: 25_800_000_000, total: 62_200_000_000}
+      end,
+      games_mount: fn -> "/root/mnt/games" end,
+      games_mounted?: fn -> true end
+    ]
+
+    SystemInfo.panel(Keyword.merge(defaults, overrides))
+  end
+
+  describe "panel/1" do
+    test "says every fact when every source answers" do
+      assert %{kind: :info, title: "This device", lines: lines} = panel()
+
+      assert lines == [
+               "MayonnaiOS 0.1.0",
+               "firmware 0.1.0, slot a",
+               "build 3f8a2b1c",
+               "up 3d 4h",
+               "wlan0 192.168.4.17",
+               "beam memory 182.2M",
+               "internal: 9.4G free of 12.9G",
+               "games card: 24.0G free of 57.9G"
+             ]
+    end
+
+    test "an empty KV loses the firmware lines, nothing else" do
+      lines = panel(kv: fn -> %{} end).lines
+
+      assert "MayonnaiOS 0.1.0" in lines
+      refute Enum.any?(lines, &(&1 =~ "firmware"))
+      refute Enum.any?(lines, &(&1 =~ "build"))
+    end
+
+    test "a version without a slot is still said" do
+      lines = panel(kv: fn -> %{"nerves_fw_version" => "0.2.0"} end).lines
+      assert "firmware 0.2.0" in lines
+    end
+
+    test "no address is a statement, not a missing line" do
+      assert "no network address" in panel(address: fn -> nil end).lines
+    end
+
+    test "a mount that cannot be measured says nothing about itself" do
+      lines = panel(space: fn _path -> nil end).lines
+      refute Enum.any?(lines, &(&1 =~ "internal"))
+      refute Enum.any?(lines, &(&1 =~ "games card"))
+    end
+
+    test "an unmounted games card is reported as out, not measured" do
+      seen = :ets.new(:seen, [:public])
+
+      lines =
+        panel(
+          games_mounted?: fn -> false end,
+          space: fn path ->
+            :ets.insert(seen, {path})
+            %{device: "/dev/mmcblk0p4", free: 1024, total: 2048}
+          end
+        ).lines
+
+      assert "games card: not in" in lines
+      # The unmounted point is never measured: df on an empty directory
+      # answers for the filesystem underneath it, which is the wrong number
+      # under this name.
+      assert :ets.lookup(seen, "/root/mnt/games") == []
+    end
+
+    test "uptime takes the two largest units that apply" do
+      up = fn ms -> panel(uptime_ms: fn -> ms end).lines |> Enum.find(&(&1 =~ "up ")) end
+
+      assert up.(45 * 1000) == "up 45s"
+      assert up.((12 * 60 + 3) * 1000) == "up 12m 3s"
+      assert up.((5 * 3600 + 4 * 60) * 1000) == "up 5h 4m"
+      assert up.(2 * 86_400 * 1000 + 3600 * 1000) == "up 2d 1h"
+    end
+
+    test "the defaults survive a host with no device behind them" do
+      # No injection at all: the real KV, df, ifaddrs. The point is only that
+      # none of them crash and the always-answerable facts are there.
+      assert %{kind: :info, lines: lines} = SystemInfo.panel()
+      assert Enum.any?(lines, &(&1 =~ "MayonnaiOS"))
+      assert Enum.any?(lines, &(&1 =~ "up "))
+      assert Enum.any?(lines, &(&1 =~ "beam memory"))
+    end
+
+    test "every line fits the column it is drawn in" do
+      # The slot is 192 px wide (home.ex: (640 - 40 - 2 * 12) / 3) and the
+      # lines are set at 15 px in the theme's body font. Measured, not
+      # counted: a character budget guessed against one font is wrong in the
+      # next one.
+      for line <- panel().lines do
+        assert Theme.width(line, 15) <= 192, "#{inspect(line)} overflows the slot"
+      end
+    end
+  end
+
+  describe "the root column's left slot" do
+    test "carries the system panel" do
+      says = texts(Home.graph(Browser.new()))
+      assert "This device" in says
+      assert Enum.any?(says, &(&1 =~ "MayonnaiOS"))
+    end
+
+    test "gives the slot back to the parent below the root" do
+      says = texts(Home.graph(Browser.descend(Browser.new())))
+      refute "This device" in says
+    end
+  end
+
+  defp texts(graph) do
+    Scenic.Graph.reduce(graph, [], fn
+      %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+      _primitive, acc -> acc
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

At the root of the column browser the left slot sat blank. It now carries a system panel: firmware version and active slot, the fwup build UUID (first eight characters), uptime, the network address, BEAM memory, and disk free on the writable mounts -- the data partition, and the games card when it is in.

## Approach

The panel is a new `MayonnaiOS.SystemInfo` module returning the same `%{kind: :info, title:, lines:}` shape the preview pane already draws, so `Scene.Home` gains one `left_slot/2` dispatch and an `info_pane/3` shared with the existing `:info` preview clause rather than a second renderer -- kept deliberately small since #33 also touches this file. Every read (KV, uptime, ifaddrs, memory, df, games-card mount state) is an injectable argument defaulting to the real source, the seam the rest of the app uses, so the lines are asserted on the host with no device state.

Two facts stay off the panel because nothing records them: no build time exists in KV or the release spec, and no codename is set anywhere (`nerves_fw_misc` is unset in the BSP's fwup.conf) -- the short fwup UUID is the closest honest build identity. An unmounted games card is reported as "not in" rather than measured, because df on an empty mount point answers for the partition underneath it.

## Follow-ups for reviewer

- The uptime shown is the VM's wall clock, not /proc/uptime -- a few seconds short of power-on, but free of file I/O in the scene process. Fine, or would you rather read /proc/uptime?

🤖 Generated with [Claude Code](https://claude.com/claude-code)