### PR TITLE
Add Game Boy, Game Boy Color and Game Boy Advance upload systems

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -409,6 +409,21 @@ config :mayonnaios, :systems, [
     key: "snes",
     name: "Super Nintendo",
     extensions: [".sfc", ".smc", ".zip"]
+  },
+  %{
+    key: "gb",
+    name: "Game Boy",
+    extensions: [".gb", ".zip"]
+  },
+  %{
+    key: "gbc",
+    name: "Game Boy Color",
+    extensions: [".gbc", ".zip"]
+  },
+  %{
+    key: "gba",
+    name: "Game Boy Advance",
+    extensions: [".gba", ".zip"]
   }
 ]
 


### PR DESCRIPTION
## Summary
Adds `gb`, `gbc` and `gba` to `:systems` so the upload page offers directories for the three Game Boy systems. The matching cores land via kek/mayonnaios_bundles#3; the `:cores` catalogue entries follow once that release exists and its published tarballs have sha256s to pin here.

## Follow-ups for reviewer
- One directory per system (`.gb` in gb/, `.gbc` in gbc/) even though gambatte runs both — mirror the card's stock layout, or would a single gb dir be preferable?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
