### PR TITLE
Add a Nintendo upload system

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -405,6 +405,17 @@ config :mayonnaios,
   ]
 
 config :mayonnaios, :systems, [
+  # Chronological, because that is the order these end up in the head and the
+  # upload page shows them in list order.
+  #
+  # No .fds here: fceumm plays Famicom Disk System images, but only with a
+  # BIOS this device does not ship, so accepting one would take an upload
+  # that cannot be played.
+  %{
+    key: "nes",
+    name: "Nintendo",
+    extensions: [".nes", ".unf", ".zip"]
+  },
   %{
     key: "snes",
     name: "Super Nintendo",


### PR DESCRIPTION
## Summary
Adds a `nes` upload system so the upload page offers a directory for NES ROMs, matching the fceumm core added in kek/mayonnaios_bundles.

The list is now in chronological console order rather than append order — nes, snes, gb, gbc, gba — since the upload page shows systems in list order.

## Follow-ups for reviewer
- `.fds` is deliberately absent: fceumm plays Famicom Disk System images but needs a BIOS this device doesn't ship, so accepting one would take an upload that can't be played. Agree, or would you rather accept it and let it fail loudly?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
