### PR TITLE
Add a Moonlight settings screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,20 +194,34 @@ RetroArch uses. It installs the same way RetroArch does, as a bundle:
 
     iex> MayonnaiOS.Bundle.install(MayonnaiOS.Bundle.spec(:moonlight))
 
-First run is a one-time SSH session, because two things exist only on the
-player's side of the fence. Pairing prints a PIN that must be typed into the
-host, and the stream cannot start without the host's address — which no
-bundle can know, so the launcher passes a config file the player creates:
+**Moonlight settings**, in the System column, is where the stream is set up:
+the host's address, the resolution, the frame rate, the bitrate, the codec,
+and which app to launch. Saving writes
+`/root/.config/moonlight/moonlight.conf`, which is the file the launcher
+passes Moonlight on its command line — so what the screen says and what the
+stream does cannot drift apart.
+
+- **The first save seeds from the bundle's own template**, so the
+  hardware-dictated defaults and the comments explaining them are what a new
+  file starts as: 720p30, h264, SDL, a modest bitrate.
+- **It edits, it does not regenerate.** A key the screen does not offer —
+  `surround`, `rotate`, `packetsize`, anything set over SSH — is copied
+  through untouched, comments included.
+- **The row is there before the bundle is**, and says so. A config file
+  written before the program that reads it arrives is still a config file.
+- **Nothing is written until the Save row**, and the header says "unsaved
+  changes" until then. A write that fails — read-only filesystem, no space —
+  says why, on the panel.
+- Moonlight reads the file when it starts, so a change takes effect on the
+  next stream rather than the running one.
+
+One step still needs SSH: pairing prints a PIN that has to be typed into the
+host, and there is no way to show it on a screen the launcher has handed to
+another program.
 
     /root/bundles/moonlight/current/bin/moonlight pair <host>
-    mkdir -p /root/.config/moonlight
-    cp /root/bundles/moonlight/current/share/moonlight/moonlight.conf \
-       /root/.config/moonlight/moonlight.conf
-    echo 'address = <host>' >> /root/.config/moonlight/moonlight.conf
 
-The template carries the hardware-dictated defaults — 720p30, h264, modest
-bitrate — and says what to lower first if decode cannot keep up. None of this
-has been run on the handheld yet; the
+None of this has been run on the handheld yet; the
 [`mayonnaios_bundles`](https://github.com/kek/mayonnaios_bundles) README lists
 what only hardware can answer.
 

--- a/config/target.exs
+++ b/config/target.exs
@@ -163,6 +163,15 @@ config :mayonnaios, :viewport,
 # with a usage message would look exactly like a working launcher.
 #
 #     %{name: "Spinning cube (smooth)", path: "/usr/bin/kmscube", args: ["-M", "smooth"]}
+# The one place the Moonlight config file is named. It is used twice below --
+# on Moonlight's own command line, and by `MayonnaiOS.Moonlight`, which is
+# what the settings screen writes through -- and a screen that edited a
+# different file from the one the stream reads would be the kind of bug that
+# looks like the setting having no effect.
+moonlight_config = "/root/.config/moonlight/moonlight.conf"
+
+config :mayonnaios, moonlight_config: moonlight_config
+
 config :mayonnaios, :programs, [
   # Not in the firmware. This path only exists once MayonnaiOS.Bundle has
   # installed RetroArch onto the writable partition, and until then Programs
@@ -231,23 +240,30 @@ config :mayonnaios, :programs, [
   #
   # -config names the player's own file rather than the bundle's, because the
   # one thing a stream cannot start without is the host's address, and no
-  # bundle can know it. The file does not exist until the player creates it
-  # over SSH -- the same session in which they pair, since pairing prints a
-  # PIN that must be typed into the host:
+  # bundle can know it. The System menu's "Moonlight settings" row below
+  # writes that file -- it seeds it from the bundle's template, which is the
+  # copy this used to ask for -- so the only step left that needs SSH is
+  # pairing, which prints a PIN that must be typed into the host:
   #
   #     /root/bundles/moonlight/current/bin/moonlight pair <host>
-  #     cp /root/bundles/moonlight/current/share/moonlight/moonlight.conf \
-  #        /root/.config/moonlight/moonlight.conf
-  #     echo 'address = <host>' >> /root/.config/moonlight/moonlight.conf
   #
   # The bundle's template carries the hardware-dictated defaults (720p30,
   # h264, SDL) and comments on what to lower first if decode cannot keep up.
   %{
     name: "Moonlight",
     path: "/root/bundles/moonlight/current/bin/moonlight",
-    args: ["stream", "-config", "/root/.config/moonlight/moonlight.conf"],
+    args: ["stream", "-config", moonlight_config],
     needs_udev: true
   },
+  # The screen that writes the file above: host address, resolution, frame
+  # rate, bitrate, codec and app. An app rather than a program, and with no
+  # `category`, so `MayonnaiOS.Browser` files it under System -- it is a
+  # setting, not a thing to play.
+  #
+  # It is listed whether or not the Moonlight bundle is installed, and says
+  # which: a config file written before the program that reads it arrives is
+  # still a config file, and the row that greys out is the Moonlight one.
+  %{name: "Moonlight settings", app: MayonnaiOS.Moonlight.App},
   %{name: "Spinning cube (kmscube)", path: "/usr/bin/kmscube"},
   %{name: "Spinning cube (smooth)", path: "/usr/bin/kmscube", args: ["-M", "smooth"]},
   # An app rather than a program: a module in this firmware, started in this

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -22,7 +22,7 @@ defmodule MayonnaiOS.Application do
         [status()] ++
         viewport() ++
         [controller_sessions(), pairing_sessions(), pickle_sessions()] ++
-        [top_sessions(), update_sessions()] ++
+        [top_sessions(), update_sessions(), moonlight_sessions()] ++
         target_children()
 
     # See https://elixir.hexdocs.pm/Supervisor.html
@@ -101,6 +101,13 @@ defmodule MayonnaiOS.Application do
   # works on a laptop and fails with "no such supervisor" rather than an
   # exception if it is ever started before this line runs.
   defp update_sessions, do: MayonnaiOS.Update.App.sessions()
+
+  # The Moonlight settings screen's DynamicSupervisor, empty until the row is
+  # opened -- same arrangement as the other apps, so
+  # `MayonnaiOS.Moonlight.App` works on a laptop and fails with "no such
+  # supervisor" rather than an exception if it is ever started before this
+  # line runs.
+  defp moonlight_sessions, do: MayonnaiOS.Moonlight.App.sessions()
 
   # List all child processes to be supervised
   if Mix.target() == :host do

--- a/lib/mayonnaios/moonlight.ex
+++ b/lib/mayonnaios/moonlight.ex
@@ -1,0 +1,457 @@
+defmodule MayonnaiOS.Moonlight do
+  @moduledoc """
+  The player's own `moonlight.conf`: what is in it, and how to change it
+  without losing what this firmware did not put there.
+
+  Moonlight Embedded reads one config file, named on its command line by
+  `MayonnaiOS.Programs`' row for it, and everything a player would want to
+  change about a stream is a line in that file. Until this module existed the
+  only way to write those lines was an SSH session -- see the README's Game
+  streaming section -- which is a poor arrangement for the two settings most
+  likely to need changing, because both are things you discover from the
+  couch: the host moved, or 720p30 stutters and the bitrate has to come down.
+
+  ## The file is edited, not generated
+
+  `render/2` replaces the value of the keys this screen owns *in place* and
+  copies every other line through untouched -- comments, blank lines, and any
+  key a player set over SSH that no row here offers (`surround`, `rotate`,
+  `viewonly`, `packetsize`). A settings screen that rewrote the file from its
+  own idea of what belongs in it would silently delete those, and the failure
+  would show up as "the stream stopped rotating" days later with nothing
+  connecting it to a visit to this screen.
+
+  Keys the screen owns but the file does not have yet are appended; a key
+  whose value is cleared has its line removed rather than written empty,
+  because `address = ` parses as an address of the empty string, not as an
+  absent address.
+
+  ## Where the first version of the file comes from
+
+  Opening the screen on a device that has never streamed shows the bundle's
+  own template -- `share/moonlight/moonlight.conf`, which carries the
+  hardware-dictated defaults and the comments explaining them -- rather than
+  an empty page. Saving then writes that template plus the player's changes
+  to `/root/.config/moonlight/moonlight.conf`, which is exactly the `cp` the
+  README's SSH session does, done by pressing A.
+
+  With no bundle installed there is no template either, so `@base` below is
+  a minimal stand-in with the same defaults in it. That path is reachable:
+  the Moonlight row is visible before the bundle is, and so is this one.
+
+  ## Resolution is two keys and one row
+
+  `width` and `height` are separate keys in the file and one choice on the
+  screen, because they are one decision. A file that names a size this screen
+  does not offer keeps it -- `choices/2` puts the current value in the list
+  rather than snapping it to the nearest known one, so a hand-tuned 1600x900
+  survives being looked at.
+
+  ## What this module cannot tell you
+
+  Whether the device is paired with the host. Pairing is a challenge exchange
+  that leaves its result in the host's own list of clients; the only thing on
+  this side is a client certificate in `~/.cache/moonlight`, and that file is
+  written on first run whether or not any host ever accepted it. So the screen
+  does not claim to know, and pairing stays the one-time SSH step the README
+  describes.
+  """
+
+  alias MayonnaiOS.Bundle
+
+  @bundle "moonlight"
+
+  @default_config_path "/root/.config/moonlight/moonlight.conf"
+
+  @type field :: %{
+          id: atom(),
+          label: String.t(),
+          kind: :text | :choice,
+          choices: [String.t()],
+          suffix: String.t(),
+          placeholder: String.t(),
+          note: String.t()
+        }
+
+  @type settings :: %{atom() => String.t()}
+
+  @type source :: :file | :template | :defaults
+
+  # The rows, in the order they are drawn. `keys` is how a row becomes lines
+  # in the file, and it is a list because resolution is two of them.
+  #
+  # The choices are what this hardware can actually be asked for rather than
+  # everything Moonlight accepts: the stream is decoded in software on four
+  # A53s and the panel is 640x480, so 1080p is on the list as the thing a
+  # Sunshine host will happily send and this device will drop frames on, and
+  # 4K is not on it at all.
+  @fields [
+    %{
+      id: :address,
+      label: "Host address",
+      kind: :text,
+      keys: ["address"],
+      choices: [],
+      suffix: "",
+      placeholder: "not set",
+      note: "The Sunshine or GeForce host. An IP address or a name."
+    },
+    %{
+      id: :resolution,
+      label: "Resolution",
+      kind: :choice,
+      keys: ["width", "height"],
+      choices: ["640x480", "1280x720", "1920x1080"],
+      suffix: "",
+      placeholder: "",
+      note: "The panel is 640x480; anything larger is scaled down to it."
+    },
+    %{
+      id: :fps,
+      label: "Frame rate",
+      kind: :choice,
+      keys: ["fps"],
+      choices: ["30", "60"],
+      suffix: " fps",
+      placeholder: "",
+      note: "30 is the honest starting point for a software decoder."
+    },
+    %{
+      id: :bitrate,
+      label: "Bitrate",
+      kind: :choice,
+      keys: ["bitrate"],
+      choices: ["2000", "5000", "10000", "20000"],
+      suffix: " kbps",
+      placeholder: "",
+      note: "Lower this first if the picture stutters: bitrate costs decode."
+    },
+    %{
+      id: :codec,
+      label: "Codec",
+      kind: :choice,
+      keys: ["codec"],
+      choices: ["h264", "hevc", "auto"],
+      suffix: "",
+      placeholder: "",
+      note: "HEVC halves the bitrate and roughly doubles the decode cost."
+    },
+    %{
+      id: :app,
+      label: "App",
+      kind: :text,
+      keys: ["app"],
+      choices: [],
+      suffix: "",
+      placeholder: "Steam",
+      note: "What to launch on the host. Empty means Moonlight's own default."
+    }
+  ]
+
+  # The same values the bundle's template carries, so a device with no bundle
+  # and no file shows the same starting point as one that has both.
+  @defaults %{
+    address: "",
+    resolution: "1280x720",
+    fps: "30",
+    bitrate: "5000",
+    codec: "h264",
+    app: ""
+  }
+
+  # The file to edit when there is neither a saved one nor a bundle template.
+  # `platform = sdl` is here for the reason the template gives: it is the only
+  # platform in this build, and naming it skips the auto-detection walk.
+  @base """
+  ## Moonlight Embedded on this device.
+  ##
+  ## Written by the Moonlight settings screen; edit it there or over SSH,
+  ## either is fine. Keys this screen does not offer are left alone.
+
+  platform = sdl
+  """
+
+  # Appended above any key this screen adds to a file that did not have it,
+  # once. Idempotent by inspection of the text rather than by a flag, because
+  # the file is also a thing a player edits by hand.
+  @marker "## Set from the Moonlight settings screen:"
+
+  # `key = value`, which is what Moonlight's own parser reads. A comment line
+  # cannot match: `#` is not in the key class.
+  @line ~r/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)$/
+
+  @doc "The rows this screen offers, in the order they are drawn."
+  @spec fields() :: [field()]
+  def fields, do: @fields
+
+  @doc "The starting values: what the bundle's template asks for."
+  @spec defaults() :: settings()
+  def defaults, do: @defaults
+
+  @doc """
+  The player's config file.
+
+  Configurable so a test can point it at a tmp directory; the default is the
+  path `config/target.exs` passes Moonlight on its command line, and the two
+  must agree or the screen edits a file nothing reads.
+  """
+  @spec config_path() :: String.t()
+  def config_path do
+    Application.get_env(:mayonnaios, :moonlight_config, @default_config_path)
+  end
+
+  @doc """
+  The bundle's template, or `nil` when the bundle is not installed.
+  """
+  @spec template_path() :: String.t() | nil
+  def template_path do
+    case Bundle.current(@bundle) do
+      nil -> nil
+      dir -> exists(Path.join([dir, "share", "moonlight", "moonlight.conf"]))
+    end
+  end
+
+  @doc """
+  Whether the Moonlight bundle is installed.
+
+  The screen is usable without it -- a config file can be written before the
+  program that reads it arrives -- but the panel says so, on the same grounds
+  as `MayonnaiOS.Programs`: a row that quietly does nothing looks exactly like
+  a row that worked.
+  """
+  @spec installed?() :: boolean()
+  def installed? do
+    case Bundle.current(@bundle) do
+      nil -> false
+      dir -> File.exists?(Path.join([dir, "bin", "moonlight"]))
+    end
+  end
+
+  @doc """
+  The current settings and where they came from.
+
+  `:file` is the player's own config, `:template` the bundle's untouched
+  defaults, `:defaults` this module's copy of them. The source is part of the
+  answer rather than a detail: "5000 kbps" means something different when it
+  is what you chose than when it is what nobody has chosen yet.
+  """
+  @spec load() :: {settings(), source()}
+  def load do
+    {text, source} = base_text()
+    {parse(text), source}
+  end
+
+  @doc """
+  Parse a config file into settings, with `defaults/0` for anything absent.
+  """
+  @spec parse(String.t()) :: settings()
+  def parse(text) do
+    pairs = pairs_in(text)
+
+    @defaults
+    |> put_present(:address, pairs["address"])
+    |> put_resolution(pairs["width"], pairs["height"])
+    |> put_present(:fps, pairs["fps"])
+    |> put_present(:bitrate, pairs["bitrate"])
+    |> put_present(:codec, pairs["codec"])
+    |> put_present(:app, pairs["app"])
+  end
+
+  @doc """
+  Apply settings to a config file's text.
+
+  Managed keys are replaced where they already are, cleared ones are removed,
+  and the rest are appended. Every other line is copied through: see the
+  moduledoc for why that is the whole point of this function.
+  """
+  @spec render(String.t(), settings()) :: String.t()
+  def render(text, settings) do
+    wanted = Map.new(config_pairs(settings))
+    lines = String.split(text, "\n")
+
+    {kept, seen} =
+      Enum.map_reduce(lines, MapSet.new(), fn line, seen ->
+        case Regex.run(@line, line) do
+          [_, key, _value] ->
+            case Map.fetch(wanted, key) do
+              :error -> {line, seen}
+              {:ok, ""} -> {:drop, MapSet.put(seen, key)}
+              {:ok, value} -> {"#{key} = #{value}", MapSet.put(seen, key)}
+            end
+
+          _no_match ->
+            {line, seen}
+        end
+      end)
+
+    missing =
+      for {key, value} <- config_pairs(settings),
+          value != "",
+          not MapSet.member?(seen, key),
+          do: "#{key} = #{value}"
+
+    kept
+    |> Enum.reject(&(&1 == :drop))
+    |> append(missing, text)
+    |> Enum.join("\n")
+  end
+
+  @doc """
+  Write settings to `config_path/0`, creating the directory if it is missing.
+
+  Returns the path on success so the panel can say where it went -- a player
+  who is about to be told to edit the file by hand needs the name of it.
+  """
+  @spec save(settings()) :: {:ok, String.t()} | {:error, term()}
+  def save(settings) do
+    path = config_path()
+    {text, _source} = base_text()
+
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         :ok <- File.write(path, render(text, settings)) do
+      {:ok, path}
+    end
+  end
+
+  @doc """
+  The values a choice row can take, with the current one included.
+
+  A file that names a size, rate or codec this screen does not offer is a
+  file someone meant that way; the row shows it and steps away from it rather
+  than pretending the nearest listed value was what they wrote.
+  """
+  @spec choices(field(), settings()) :: [String.t()]
+  def choices(%{kind: :choice, id: id, choices: choices}, settings) do
+    current = Map.get(settings, id, "")
+    if current == "" or current in choices, do: choices, else: choices ++ [current]
+  end
+
+  def choices(_field, _settings), do: []
+
+  @doc """
+  What a row's value reads as on the panel.
+
+  An empty text row reads as its placeholder -- "not set" for the address,
+  "Steam" for the app, which is the value Moonlight uses when the key is
+  absent. Both are the truth about an empty field, and neither is blank.
+  """
+  @spec display(field(), settings()) :: String.t()
+  def display(%{id: id, suffix: suffix, placeholder: placeholder}, settings) do
+    case Map.get(settings, id, "") do
+      "" -> placeholder
+      value -> value <> suffix
+    end
+  end
+
+  @doc """
+  The next value of a choice row, `+1` or `-1` from the current one, wrapping.
+  """
+  @spec step(field(), settings(), -1 | 1) :: settings()
+  def step(%{kind: :choice, id: id} = field, settings, delta) do
+    options = choices(field, settings)
+    current = Map.get(settings, id, "")
+
+    case Enum.find_index(options, &(&1 == current)) do
+      nil ->
+        Map.put(settings, id, hd(options))
+
+      index ->
+        Map.put(settings, id, Enum.at(options, Integer.mod(index + delta, length(options))))
+    end
+  end
+
+  def step(_field, settings, _delta), do: settings
+
+  @doc """
+  The config keys and values a set of settings becomes.
+
+  Public because it is the tested surface, and because it is the only place
+  that knows one row can be two keys.
+  """
+  @spec config_pairs(settings()) :: [{String.t(), String.t()}]
+  def config_pairs(settings) do
+    Enum.flat_map(@fields, fn field -> keys_of(field, Map.get(settings, field.id, "")) end)
+  end
+
+  # -- reading -------------------------------------------------------------------
+
+  # The text to edit, and where it came from. The player's file first, the
+  # bundle's template second, this module's copy of it last.
+  defp base_text do
+    with nil <- read(config_path(), :file),
+         nil <- read(template_path(), :template) do
+      {@base, :defaults}
+    end
+  end
+
+  defp read(nil, _source), do: nil
+
+  defp read(path, source) do
+    case File.read(path) do
+      {:ok, text} -> {text, source}
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp pairs_in(text) do
+    text
+    |> String.split("\n")
+    |> Enum.reduce(%{}, fn line, acc ->
+      case Regex.run(@line, line) do
+        [_, key, value] -> Map.put(acc, key, String.trim(value))
+        _no_match -> acc
+      end
+    end)
+  end
+
+  defp put_present(settings, _id, nil), do: settings
+  defp put_present(settings, _id, ""), do: settings
+  defp put_present(settings, id, value), do: Map.put(settings, id, value)
+
+  # Both halves or neither: a file with a width and no height is not naming a
+  # resolution, and guessing the other half from the default would produce a
+  # size the player never asked for.
+  defp put_resolution(settings, width, height)
+       when is_binary(width) and is_binary(height) and width != "" and height != "" do
+    Map.put(settings, :resolution, "#{width}x#{height}")
+  end
+
+  defp put_resolution(settings, _width, _height), do: settings
+
+  # -- writing -------------------------------------------------------------------
+
+  defp keys_of(%{id: :resolution}, value) do
+    case String.split(value, "x") do
+      [width, height] -> [{"width", width}, {"height", height}]
+      _not_a_size -> [{"width", ""}, {"height", ""}]
+    end
+  end
+
+  defp keys_of(%{keys: [key]}, value), do: [{key, value}]
+
+  defp append(lines, [], _text), do: lines
+
+  defp append(lines, missing, text) do
+    # A file that already ends in a newline splits to a trailing empty string;
+    # dropping it keeps the appended block flush against the last line rather
+    # than one blank line further down on every save.
+    kept = trim_trailing_blank(lines)
+
+    header =
+      cond do
+        String.contains?(text, @marker) -> []
+        # Nothing above to separate from: a file whose every line was a key
+        # this screen cleared, or one that had no lines at all.
+        kept == [] -> [@marker]
+        true -> ["", @marker]
+      end
+
+    kept ++ header ++ missing ++ [""]
+  end
+
+  defp trim_trailing_blank(lines) do
+    lines |> Enum.reverse() |> Enum.drop_while(&(&1 == "")) |> Enum.reverse()
+  end
+
+  defp exists(path), do: if(File.exists?(path), do: path)
+end

--- a/lib/mayonnaios/moonlight/app.ex
+++ b/lib/mayonnaios/moonlight/app.ex
@@ -1,0 +1,382 @@
+defmodule MayonnaiOS.Moonlight.App do
+  @moduledoc """
+  The System menu's "Moonlight settings" row: the rows of
+  `MayonnaiOS.Moonlight`'s config file, edited with the pad.
+
+  An app rather than a program, on the same terms as `MayonnaiOS.Update.App`:
+  a module in this firmware, started in this VM, with a scene of its own and
+  no external process handed the screen. It needs no hardware, so unlike the
+  two Bluetooth apps nothing stops a second one -- there is one process
+  because there is one screen.
+
+  ## The buttons
+
+      up / down       move between the rows
+      left / right    change a choice row's value
+      A               open a text row's editor, or save on the last row
+      A while editing keep what was typed and close the editor
+      Y while editing remove the character under the caret
+      B / Menu        leave, which is the launcher's own and not this app's
+
+  While the editor is open the D-pad belongs to it -- left and right move the
+  caret, up and down change the character under it -- which is the same
+  arrangement, and the same character picker, as the file browser's rename
+  editor. A handheld has no text input, so a picker is what there is; see
+  `MayonnaiOS.Browser` for the argument.
+
+  ## Nothing is written until the Save row
+
+  Every other change is in memory, and the panel says "unsaved changes" while
+  any of them differ from what is on the disk. Two reasons for an explicit
+  save rather than a write per change. A `moonlight.conf` lives on the data
+  partition, and writing it on every press of right would put four writes on
+  the flash for one decision about the bitrate. And a write can fail --
+  a read-only filesystem, a full one -- which needs somewhere to say so; a
+  row that reports its own outcome is that somewhere.
+
+  The cost is the obvious one: Menu leaves without asking, and unsaved changes
+  go with it. That is why the header carries them rather than a footnote.
+
+  ## Leaving does not stop a stream
+
+  Moonlight reads its config when it starts. Changing a value here while a
+  stream is running changes the next stream, not this one -- and the launcher
+  cannot have both on the screen at once anyway, since a running program owns
+  the panel. The footer says so, because "I turned the bitrate down and
+  nothing happened" is otherwise a reasonable thing to conclude.
+  """
+
+  use GenServer
+
+  alias MayonnaiOS.Moonlight
+
+  @sessions MayonnaiOS.Moonlight.App.Sessions
+
+  # The launcher's vocabulary, in which the atom named "b" is the button
+  # printed A on this board's shell -- see `MayonnaiOS.Launcher`'s moduledoc
+  # for the device tree's account of that.
+  @accept :btn_b
+  @remove :btn_x
+  @menu :btn_mode
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @left :btn_dpad_left
+  @right :btn_dpad_right
+
+  # What the address and app rows can type. Digits and a dot first, because
+  # the field that is empty on a new device is the host address and the
+  # character it most often starts with is a digit; letters follow for the
+  # host that has a name, and for "Desktop".
+  @alphabet String.graphemes(
+              "0123456789." <>
+                "abcdefghijklmnopqrstuvwxyz" <>
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ" <> "-_ "
+            )
+
+  # -- the app protocol the Launcher uses --------------------------------------
+
+  @doc """
+  Start the app. Idempotent: opening the row again while it is already running
+  shows the same process rather than starting a second one.
+  """
+  @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(opts \\ []) do
+    case DynamicSupervisor.start_child(@sessions, {__MODULE__, opts}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Stop the app."
+  @spec stop() :: :ok
+  def stop do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(@sessions, pid)
+    end
+  end
+
+  @doc """
+  Forward an evdev report from the Launcher.
+
+  A cast, for the same reason `MayonnaiOS.Update.App.input/1` is: nothing here
+  may make a button press wait on this process.
+  """
+  @spec input([tuple()]) :: :ok
+  def input(events) do
+    if Process.whereis(__MODULE__), do: GenServer.cast(__MODULE__, {:input, events}), else: :ok
+  end
+
+  @doc "The scene the launcher shows while this app has the buttons."
+  @spec scene() :: module()
+  def scene, do: MayonnaiOS.Scene.Moonlight
+
+  @doc """
+  Be told when the state changes, as `{:moonlight_app, snapshot}`.
+
+  The same arrangement as `MayonnaiOS.Update.App.watch/1`: the scene calls
+  this instead of polling, and the watcher is monitored so a scene torn down
+  by `set_root/3` drops itself.
+  """
+  @spec watch(pid()) :: map() | :stopped
+  def watch(pid) do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, {:watch, pid}), else: :stopped
+  end
+
+  @doc "Everything the panel needs, as one map. `:stopped` if the app is not running."
+  @spec snapshot() :: map() | :stopped
+  def snapshot do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, :snapshot), else: :stopped
+  end
+
+  @doc "The DynamicSupervisor the app runs under, for the application tree."
+  @spec sessions() :: Supervisor.child_spec()
+  def sessions do
+    %{
+      id: @sessions,
+      start: {DynamicSupervisor, :start_link, [[name: @sessions, strategy: :one_for_one]]},
+      type: :supervisor
+    }
+  end
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      # Temporary, like the other app sessions: whatever went wrong is in the
+      # log, and a restart would land on a screen the user already left.
+      restart: :temporary
+    }
+  end
+
+  @doc false
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc """
+  The rows, which are the config's fields plus the one that writes them.
+
+  Public because the scene draws them and the tests count them, and neither
+  should have its own idea of how many there are.
+  """
+  @spec rows() :: [map()]
+  def rows do
+    Moonlight.fields() ++
+      [
+        %{
+          id: :save,
+          label: "Save",
+          kind: :action,
+          choices: [],
+          suffix: "",
+          placeholder: "",
+          note: ""
+        }
+      ]
+  end
+
+  # -- state --------------------------------------------------------------------
+
+  @impl GenServer
+  def init(_opts) do
+    {settings, source} = Moonlight.load()
+
+    {:ok,
+     %{
+       settings: settings,
+       # What is on the disk, or what would be if nothing were changed. The
+       # difference between this and `settings` is the whole of "unsaved".
+       saved: settings,
+       source: source,
+       installed?: Moonlight.installed?(),
+       path: Moonlight.config_path(),
+       cursor: 0,
+       editor: nil,
+       message: nil,
+       watchers: []
+     }}
+  end
+
+  @impl GenServer
+  def handle_call(:snapshot, _from, state), do: {:reply, snapshot_of(state), state}
+
+  def handle_call({:watch, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, snapshot_of(state), %{state | watchers: [pid | state.watchers]}}
+  end
+
+  @impl GenServer
+  def handle_cast({:input, events}, state) do
+    {:noreply, state |> apply_events(events) |> notify(state)}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | watchers: List.delete(state.watchers, pid)}}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # -- input ------------------------------------------------------------------
+
+  defp apply_events(state, events) do
+    Enum.reduce(events, state, fn
+      {:ev_key, key, 1}, acc -> press(acc, key)
+      _event, acc -> acc
+    end)
+  end
+
+  # Menu is the launcher's; it stops this app before this process would see
+  # the press at all. Dropped here anyway so that a keyboard, a test or a
+  # future caller cannot make it mean something else by accident.
+  defp press(state, @menu), do: state
+
+  # -- while the editor is open, the D-pad is the editor's --
+
+  defp press(%{editor: editor} = state, key) when editor != nil do
+    case key do
+      @left -> %{state | editor: move_caret(editor, -1)}
+      @right -> %{state | editor: move_caret(editor, +1)}
+      @up -> %{state | editor: step_char(editor, -1)}
+      @down -> %{state | editor: step_char(editor, +1)}
+      @remove -> %{state | editor: drop_char(editor)}
+      @accept -> accept(state, editor)
+      _other -> state
+    end
+  end
+
+  # -- the row list --
+
+  defp press(state, @up), do: move(state, -1)
+  defp press(state, @down), do: move(state, +1)
+  defp press(state, @left), do: change(state, -1)
+  defp press(state, @right), do: change(state, +1)
+  defp press(state, @accept), do: open(state)
+  defp press(state, _key), do: state
+
+  defp move(state, delta) do
+    count = length(rows())
+    cursor = Integer.mod(state.cursor + delta, count)
+    %{state | cursor: cursor, message: nil}
+  end
+
+  # Left and right on a text row do nothing: there is no next address, and a
+  # direction that silently means nothing on some rows and something on others
+  # is better than one that opens an editor nobody asked for.
+  defp change(state, delta) do
+    case current_row(state) do
+      %{kind: :choice} = field ->
+        %{state | settings: Moonlight.step(field, state.settings, delta), message: nil}
+
+      _other ->
+        state
+    end
+  end
+
+  defp open(state) do
+    case current_row(state) do
+      %{kind: :text, id: id} ->
+        chars = state.settings |> Map.get(id, "") |> String.graphemes()
+        # The caret starts at the end: the common edit to an address that is
+        # already there is to change its last digits, and the common edit to
+        # an empty one is to type it, which is also the end.
+        %{state | editor: %{id: id, chars: chars, caret: length(chars)}, message: nil}
+
+      %{kind: :action, id: :save} ->
+        save(state)
+
+      _other ->
+        state
+    end
+  end
+
+  defp save(state) do
+    case Moonlight.save(state.settings) do
+      {:ok, path} ->
+        %{
+          state
+          | saved: state.settings,
+            source: :file,
+            path: path,
+            message: {:ok, "Saved to #{path}"}
+        }
+
+      {:error, reason} ->
+        %{state | message: {:error, "Could not write #{state.path}: #{why(reason)}"}}
+    end
+  end
+
+  defp accept(state, %{id: id, chars: chars}) do
+    %{state | settings: Map.put(state.settings, id, Enum.join(chars)), editor: nil}
+  end
+
+  defp current_row(state), do: Enum.at(rows(), state.cursor)
+
+  # -- the character picker ------------------------------------------------------
+  #
+  # The same three operations as `MayonnaiOS.Browser`'s rename editor, on the
+  # same terms: the caret can sit one past the end, where up or down puts a
+  # character there rather than doing nothing.
+
+  defp move_caret(%{chars: chars, caret: caret} = editor, delta) do
+    %{editor | caret: caret |> Kernel.+(delta) |> max(0) |> min(length(chars))}
+  end
+
+  defp step_char(%{chars: chars, caret: caret} = editor, delta) do
+    if caret >= length(chars) do
+      %{editor | chars: chars ++ [next_char(nil, delta)]}
+    else
+      current = Enum.at(chars, caret)
+      %{editor | chars: List.replace_at(chars, caret, next_char(current, delta))}
+    end
+  end
+
+  # A character the picker does not know -- one a hand-edited file put in the
+  # address -- has no position to step from, so the first press replaces it
+  # with the start of the alphabet rather than doing nothing at all.
+  defp next_char(current, delta) do
+    case Enum.find_index(@alphabet, &(&1 == current)) do
+      nil -> hd(@alphabet)
+      index -> Enum.at(@alphabet, Integer.mod(index + delta, length(@alphabet)))
+    end
+  end
+
+  defp drop_char(%{chars: []} = editor), do: editor
+
+  defp drop_char(%{chars: chars, caret: caret} = editor) do
+    at = min(caret, length(chars) - 1)
+    chars = List.delete_at(chars, at)
+    %{editor | chars: chars, caret: min(at, length(chars))}
+  end
+
+  # -- snapshot -----------------------------------------------------------------
+
+  defp snapshot_of(state) do
+    %{
+      settings: state.settings,
+      source: state.source,
+      installed?: state.installed?,
+      path: state.path,
+      cursor: state.cursor,
+      editor: state.editor,
+      message: state.message,
+      unsaved?: state.settings != state.saved
+    }
+  end
+
+  defp notify(state, previous) do
+    if previous != nil and snapshot_of(state) == snapshot_of(previous) do
+      state
+    else
+      snapshot = snapshot_of(state)
+      Enum.each(state.watchers, &send(&1, {:moonlight_app, snapshot}))
+      state
+    end
+  end
+
+  # The words for a write that did not happen. `MayonnaiOS.Browser.why/1`
+  # already has this vocabulary and this reuses it, so the panel and the ring
+  # log say the same thing about the same errno.
+  defp why(reason), do: MayonnaiOS.Browser.why(reason)
+end

--- a/lib/mayonnaios/scene/moonlight.ex
+++ b/lib/mayonnaios/scene/moonlight.ex
@@ -1,0 +1,395 @@
+defmodule MayonnaiOS.Scene.Moonlight do
+  @moduledoc """
+  What the panel shows while `MayonnaiOS.Moonlight.App` has the buttons.
+
+  Draws `MayonnaiOS.Moonlight.App.snapshot/0` and nothing else, told when to
+  redraw by `App.watch/1` -- the same arrangement as `MayonnaiOS.Scene.Update`
+  and for the same reason: `set_root/3` terminates this scene on every repaint
+  the launcher does, so nothing may be remembered here.
+
+  ## One screen or the other
+
+  With the editor open the rows are gone and the character cells have the
+  panel. A settings list with a text field being edited inside one of its rows
+  would put a caret in a 15 px cell inside a 34 px row on a 640x480 display,
+  and there is no reading that. The row being edited is named above the cells
+  instead, so nothing is lost but the six values that are not being changed.
+
+  ## The line under the rows is the manual
+
+  A handheld has no tooltips, so the selected row's note is drawn under the
+  list: what the address is for, why 30 fps rather than 60, what to lower
+  first when the picture stutters. It changes with the cursor, which makes the
+  D-pad the way to read the manual as well as the way to change the setting.
+  """
+
+  use Scenic.Scene
+
+  alias MayonnaiOS.Moonlight
+  alias MayonnaiOS.Moonlight.App
+  alias MayonnaiOS.Scene.StatusBar
+  alias MayonnaiOS.Theme
+  alias Scenic.Graph
+
+  import Scenic.Primitives
+
+  @width 640
+  @height 480
+
+  # The shared top bar owns the top of the panel on every screen, so the title
+  # starts below it. The height comes from the bar rather than being copied.
+  @status_bar StatusBar.height()
+  @title_y @status_bar + 20
+  @rule_y @status_bar + 30
+
+  @head_y @rule_y + 26
+  @top @rule_y + 40
+  @pitch 34
+
+  @left 20
+  @span @width - 2 * @left
+  # Where a row's value starts. Far enough right that the longest label
+  # ("Host address") clears it at 18 px in the theme's body font.
+  @value_x 220
+
+  @note_y 380
+  @message_y 408
+
+  # How many characters fit on a full-width 15 px line, and in the gap between
+  # a row's label and the right edge at 18 px. The theme's body font runs
+  # about half its size per glyph -- "Host address" is 108 px at 18 -- so
+  # these are that arithmetic rather than a guess, and they are what keeps a
+  # long hostname or a long errno from running off the panel.
+  @line_chars 78
+  @value_chars 44
+
+  @footer_rule 446
+  @footer_y 466
+
+  # The editor draws one character per cell so the caret can sit under exactly
+  # one of them -- the browser's rename editor's argument, and its geometry.
+  @cell 15
+  @cells 36
+  @cells_y @top + 60
+
+  # Every colour comes from the current `MayonnaiOS.Theme` rather than a
+  # module attribute, for the reason `MayonnaiOS.Scene.Home` gives: a theme is
+  # chosen at runtime and an attribute is a compile-time constant.
+  defp font, do: Theme.current().font
+  defp bg, do: Theme.current().bg
+  defp title, do: Theme.current().title
+  defp head, do: Theme.current().head
+  defp label, do: Theme.current().label
+  defp pass, do: Theme.current().pass
+  defp fail, do: Theme.current().fail
+  defp wait, do: Theme.current().wait
+  defp dim, do: Theme.current().dim
+  defp row_bg, do: Theme.current().row_bg
+
+  @impl Scenic.Scene
+  def init(scene, _param, _opts) do
+    {:ok, show(scene, watch())}
+  end
+
+  @impl GenServer
+  def handle_info({:moonlight_app, snapshot}, scene), do: {:noreply, show(scene, snapshot)}
+  def handle_info(_message, scene), do: {:noreply, scene}
+
+  # The app not running is a state to render rather than crash on, matching
+  # `MayonnaiOS.Scene.Update`.
+  defp watch do
+    App.watch(self())
+  rescue
+    _error -> :stopped
+  catch
+    :exit, _reason -> :stopped
+  end
+
+  defp show(scene, snapshot), do: push_graph(scene, graph(snapshot))
+
+  @doc """
+  The height of the strip this scene leaves for the shared top bar, public so
+  a test can assert that nothing is drawn above it.
+  """
+  @spec status_bar() :: pos_integer()
+  def status_bar, do: @status_bar
+
+  @doc """
+  Build the graph for a snapshot.
+
+  Public because it is the tested surface: no viewport, no driver and no
+  framebuffer, so a host test can assert what the panel says for a device with
+  no bundle, an unset address, an open editor and a failed write -- states
+  that would otherwise only be findable by holding the device.
+  """
+  @spec graph(map() | :stopped) :: Scenic.Graph.t()
+  def graph(:stopped) do
+    base()
+    |> text("Not running", font_size: 22, fill: {:color, fail()}, translate: {@left, @top + 20})
+    |> footer("Menu goes back.")
+  end
+
+  def graph(%{editor: editor} = snapshot) when editor != nil do
+    base()
+    |> heading(snapshot)
+    |> text(editor_label(editor),
+      font_size: 18,
+      fill: {:color, title()},
+      translate: {@left, @top + 24}
+    )
+    |> cells(editor)
+    |> text("Left and right move. Up and down change the character.",
+      font_size: 16,
+      fill: {:color, label()},
+      translate: {@left, @cells_y + 62}
+    )
+    |> text("Y removes it. A keeps it.",
+      font_size: 16,
+      fill: {:color, label()},
+      translate: {@left, @cells_y + 84}
+    )
+    |> footer("Nothing is written until the Save row.")
+  end
+
+  def graph(snapshot) do
+    base()
+    |> heading(snapshot)
+    |> rows(snapshot)
+    |> note(snapshot)
+    |> message(snapshot)
+    |> footer(footer_words(snapshot))
+  end
+
+  defp base do
+    Graph.build(font: font(), font_size: 18)
+    |> rect({@width, @height}, fill: {:color, bg()})
+    |> StatusBar.mount()
+    |> text("Moonlight settings",
+      font_size: 20,
+      fill: {:color, title()},
+      translate: {@left, @title_y}
+    )
+    |> rect({@span, 2}, fill: {:color, head()}, translate: {@left, @rule_y})
+  end
+
+  # One line saying what is being edited and whether it has been saved. The
+  # bundle being absent comes first when it is: a config file for a program
+  # that is not installed is still worth writing, and is also the more useful
+  # thing to be told.
+  defp heading(graph, snapshot) do
+    {words, colour} = heading_words(snapshot)
+
+    text(graph, truncate_left(words, @line_chars),
+      font_size: 15,
+      fill: {:color, colour},
+      translate: {@left, @head_y}
+    )
+  end
+
+  defp heading_words(%{installed?: false}),
+    do: {"Moonlight is not installed. These settings will be waiting when it is.", wait()}
+
+  defp heading_words(%{unsaved?: true}), do: {"Unsaved changes.", wait()}
+  defp heading_words(%{source: :file, path: path}), do: {path, dim()}
+
+  defp heading_words(%{source: :template}),
+    do: {"The bundle's defaults. Nothing has been saved on this device yet.", dim()}
+
+  defp heading_words(_snapshot),
+    do: {"Defaults. Nothing has been saved on this device yet.", dim()}
+
+  # -- the rows -------------------------------------------------------------------
+
+  defp rows(graph, snapshot) do
+    App.rows()
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {row, index}, acc ->
+      draw_row(acc, row, index, snapshot)
+    end)
+  end
+
+  defp draw_row(graph, row, index, snapshot) do
+    y = @top + index * @pitch
+    selected? = index == snapshot.cursor
+
+    graph
+    |> row_background(y, selected?)
+    |> text(row.label,
+      font_size: 18,
+      fill: {:color, if(selected?, do: title(), else: label())},
+      translate: {@left + 8, y + 22}
+    )
+    |> row_value(row, y, selected?, snapshot)
+  end
+
+  defp row_background(graph, _y, false), do: graph
+
+  defp row_background(graph, y, true) do
+    rect(graph, {@span, @pitch - 4}, fill: {:color, row_bg()}, translate: {@left, y})
+  end
+
+  # The Save row's "value" is what pressing A on it does, which is the only
+  # thing on this screen that touches the disk and so the only one worth
+  # spelling out where a value would be.
+  defp row_value(graph, %{id: :save}, y, selected?, snapshot) do
+    text(graph, save_words(snapshot),
+      font_size: 16,
+      fill: {:color, if(selected?, do: head(), else: dim())},
+      translate: {@value_x, y + 22}
+    )
+  end
+
+  defp row_value(graph, row, y, selected?, snapshot) do
+    value = Moonlight.display(row, snapshot.settings)
+    set? = Map.get(snapshot.settings, row.id, "") != ""
+
+    graph
+    |> text(truncate(value, @value_chars),
+      font_size: 18,
+      fill: {:color, value_colour(set?, selected?)},
+      translate: {@value_x, y + 22}
+    )
+    |> arrows(row, y, selected?)
+  end
+
+  # An unset value is drawn in the dim colour whether or not the cursor is on
+  # it, so "not set" cannot be mistaken for a value that happens to say that.
+  defp value_colour(false, _selected?), do: dim()
+  defp value_colour(true, true), do: title()
+  defp value_colour(true, false), do: label()
+
+  # Little chevrons on the selected choice row, because "left and right change
+  # this" is not discoverable from a row that looks exactly like the text rows
+  # above and below it.
+  defp arrows(graph, %{kind: :choice}, y, true) do
+    graph
+    |> text("<", font_size: 18, fill: {:color, head()}, translate: {@value_x - 22, y + 22})
+    |> text(">", font_size: 18, fill: {:color, head()}, translate: {@left + @span - 24, y + 22})
+  end
+
+  defp arrows(graph, _row, _y, _selected?), do: graph
+
+  defp save_words(%{unsaved?: true}), do: "A writes the changes"
+  defp save_words(_snapshot), do: "nothing to write"
+
+  # -- the lines under the rows -----------------------------------------------------
+
+  # The selected row's note, which is the manual; see the moduledoc.
+  defp note(graph, snapshot) do
+    case Enum.at(App.rows(), snapshot.cursor) do
+      %{note: words} when is_binary(words) and words != "" ->
+        text(graph, words, font_size: 15, fill: {:color, label()}, translate: {@left, @note_y})
+
+      _other ->
+        graph
+    end
+  end
+
+  # A stream needs an address and this screen is where one would notice it is
+  # missing, so the absence is said out loud rather than left to the "not set"
+  # on a row that may be scrolled past.
+  defp message(graph, %{message: nil} = snapshot) do
+    if Map.get(snapshot.settings, :address, "") == "" do
+      text(graph, "A stream cannot start without a host address.",
+        font_size: 15,
+        fill: {:color, wait()},
+        translate: {@left, @message_y}
+      )
+    else
+      graph
+    end
+  end
+
+  defp message(graph, %{message: {level, words}}) do
+    colour = if level == :error, do: fail(), else: pass()
+
+    text(graph, truncate_left(words, @line_chars),
+      font_size: 15,
+      fill: {:color, colour},
+      translate: {@left, @message_y}
+    )
+  end
+
+  defp footer_words(%{cursor: cursor}) do
+    case Enum.at(App.rows(), cursor) do
+      %{kind: :choice} -> "Left and right change it. Menu goes back."
+      %{kind: :text} -> "A edits it. Menu goes back."
+      _save -> "A saves. Moonlight reads the file when it starts. Menu goes back."
+    end
+  end
+
+  defp footer(graph, words) do
+    graph
+    |> rect({@span, 1}, fill: {:color, dim()}, translate: {@left, @footer_rule})
+    |> text(words, font_size: 14, fill: {:color, label()}, translate: {@left, @footer_y})
+  end
+
+  # -- the editor ---------------------------------------------------------------
+
+  defp editor_label(%{id: id}) do
+    case Enum.find(Moonlight.fields(), &(&1.id == id)) do
+      %{label: label} -> label
+      nil -> to_string(id)
+    end
+  end
+
+  # One character per cell, and the caret is a box under a cell rather than a
+  # bar between two: with a proportional font there is no honest way to draw a
+  # bar in the right place, and a caret in the wrong place is worse than none.
+  defp cells(graph, %{chars: chars, caret: caret}) do
+    count = length(chars)
+    # The append slot is a cell too, so a value can be grown at the end.
+    start = min(max(0, caret - @cells + 1), max(0, count + 1 - @cells))
+
+    Enum.reduce(0..(@cells - 1), graph, fn column, acc ->
+      index = start + column
+      x = @left + 4 + column * @cell
+
+      cond do
+        index > count ->
+          acc
+
+        index == count ->
+          acc
+          |> caret_box(x, index == caret)
+          |> text("+", font_size: 20, fill: {:color, dim()}, translate: {x + 3, @cells_y + 20})
+
+        true ->
+          acc
+          |> caret_box(x, index == caret)
+          |> text(Enum.at(chars, index),
+            font_size: 20,
+            fill: {:color, title()},
+            translate: {x + 3, @cells_y + 20}
+          )
+      end
+    end)
+  end
+
+  defp caret_box(graph, _x, false), do: graph
+
+  defp caret_box(graph, x, true) do
+    rect(graph, {@cell, 28},
+      fill: {:color, row_bg()},
+      stroke: {1, head()},
+      translate: {x, @cells_y}
+    )
+  end
+
+  # -- fitting the panel ----------------------------------------------------------
+
+  defp truncate(text, limit) do
+    if String.length(text) > limit, do: String.slice(text, 0, limit - 1) <> "…", else: text
+  end
+
+  # For the heading, which is usually a path: `MayonnaiOS.Scene.Home`'s
+  # argument applies unchanged -- the end of a path is the part that says
+  # which file, and the start is the part every path on this device shares.
+  defp truncate_left(text, limit) do
+    if String.length(text) > limit do
+      "…" <> String.slice(text, String.length(text) - limit + 1, limit)
+    else
+      text
+    end
+  end
+end

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -99,6 +99,20 @@ defmodule MayonnaiOS.BrowserTest do
              ]
     end
 
+    test "the Moonlight settings row is a setting, not a game" do
+      Application.put_env(:mayonnaios, :programs, [
+        %{
+          name: "Moonlight",
+          path: "/nonexistent/moonlight",
+          args: ["stream", "-config", "/nonexistent/moonlight.conf"]
+        },
+        %{name: "Moonlight settings", app: MayonnaiOS.Moonlight.App}
+      ])
+
+      assert names(open(Browser.new(), "Games")) == ["Moonlight"]
+      assert "Moonlight settings" in names(open(Browser.new(), "System"))
+    end
+
     test "the built-in System rows carry the launcher's own verbs" do
       system = open(Browser.new(), "System")
 

--- a/test/moonlight/app_test.exs
+++ b/test/moonlight/app_test.exs
@@ -1,0 +1,462 @@
+defmodule MayonnaiOS.Moonlight.AppTest do
+  # Not async: the app is a named process, and the config path it reads is
+  # application environment.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Moonlight
+  alias MayonnaiOS.Moonlight.App
+  alias MayonnaiOS.Scene.Moonlight, as: Scene
+
+  # The launcher's vocabulary; see `MayonnaiOS.Launcher`'s moduledoc for why
+  # the atom named "b" is the button printed A.
+  @accept :btn_b
+  @remove :btn_x
+  @menu :btn_mode
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @left :btn_dpad_left
+  @right :btn_dpad_right
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "moonlight-app-#{System.unique_integer([:positive])}")
+    config = Path.join([base, "config", "moonlight.conf"])
+    File.mkdir_p!(base)
+
+    prev = %{
+      bundle_root: Application.get_env(:mayonnaios, :bundle_root),
+      moonlight_config: Application.get_env(:mayonnaios, :moonlight_config)
+    }
+
+    Application.put_env(:mayonnaios, :bundle_root, Path.join(base, "bundles"))
+    Application.put_env(:mayonnaios, :moonlight_config, config)
+
+    on_exit(fn ->
+      App.stop()
+      File.rm_rf(base)
+
+      Enum.each(prev, fn
+        {k, nil} -> Application.delete_env(:mayonnaios, k)
+        {k, v} -> Application.put_env(:mayonnaios, k, v)
+      end)
+    end)
+
+    %{base: base, config: config}
+  end
+
+  # A press is a whole evdev report, the way the launcher forwards one, and
+  # `input/1` is a cast -- so every helper here reads the snapshot afterwards,
+  # which is the call that makes the cast have landed.
+  defp press(key) do
+    App.input([{:ev_key, key, 1}])
+    App.snapshot()
+  end
+
+  # `1..times//1` rather than `1..times`: a descending range is still a range,
+  # so `1..0` would press twice where nothing should be pressed at all.
+  defp press(key, times) do
+    Enum.reduce(1..times//1, App.snapshot(), fn _n, _acc -> press(key) end)
+  end
+
+  defp start! do
+    {:ok, _pid} = App.start()
+    App.snapshot()
+  end
+
+  # The index of a row by its id, so a test says what it means rather than
+  # counting rows that a later field would renumber.
+  defp row(id), do: Enum.find_index(App.rows(), &(&1.id == id))
+
+  defp go_to(id) do
+    press(@down, row(id))
+  end
+
+  describe "starting" do
+    test "opens on the defaults when nothing has been saved" do
+      snapshot = start!()
+
+      assert snapshot.settings == Moonlight.defaults()
+      assert snapshot.source == :defaults
+      assert snapshot.cursor == 0
+      assert snapshot.editor == nil
+      refute snapshot.unsaved?
+      refute snapshot.installed?
+    end
+
+    test "opens on the saved file when there is one", %{config: config} do
+      File.mkdir_p!(Path.dirname(config))
+      File.write!(config, "address = saved.lan\nfps = 60\n")
+
+      snapshot = start!()
+
+      assert snapshot.settings.address == "saved.lan"
+      assert snapshot.settings.fps == "60"
+      assert snapshot.source == :file
+    end
+
+    test "starting twice is the same process" do
+      {:ok, first} = App.start()
+      {:ok, second} = App.start()
+
+      assert first == second
+    end
+
+    test "snapshot and watch say so when it is not running" do
+      assert App.snapshot() == :stopped
+      assert App.watch(self()) == :stopped
+    end
+  end
+
+  describe "moving between rows" do
+    test "down and up wrap" do
+      start!()
+      last = length(App.rows()) - 1
+
+      assert press(@up).cursor == last
+      assert press(@down).cursor == 0
+    end
+
+    test "the last row is the one that saves" do
+      start!()
+
+      assert List.last(App.rows()).id == :save
+    end
+  end
+
+  describe "choice rows" do
+    test "right and left change the value" do
+      start!()
+      go_to(:fps)
+
+      assert press(@right).settings.fps == "60"
+      assert press(@right).settings.fps == "30"
+      assert press(@left).settings.fps == "60"
+    end
+
+    test "changing one is an unsaved change" do
+      start!()
+      go_to(:bitrate)
+
+      assert press(@right).unsaved?
+    end
+
+    test "a value the screen does not offer is stepped away from, not snapped to", %{
+      config: config
+    } do
+      File.mkdir_p!(Path.dirname(config))
+      File.write!(config, "width = 1600\nheight = 900\n")
+      start!()
+      go_to(:resolution)
+
+      assert App.snapshot().settings.resolution == "1600x900"
+      # It sits at the end of the list, so one step back lands on the last
+      # value the screen does offer.
+      assert press(@left).settings.resolution == "1920x1080"
+    end
+
+    test "left and right do nothing on a text row" do
+      start!()
+      go_to(:address)
+
+      assert press(@right).settings.address == ""
+      assert press(@left).settings.address == ""
+    end
+  end
+
+  describe "the editor" do
+    test "A opens it on a text row, with the caret at the end", %{config: config} do
+      File.mkdir_p!(Path.dirname(config))
+      File.write!(config, "address = 10.0\n")
+      start!()
+      go_to(:address)
+
+      snapshot = press(@accept)
+
+      assert snapshot.editor.id == :address
+      assert snapshot.editor.chars == ["1", "0", ".", "0"]
+      assert snapshot.editor.caret == 4
+    end
+
+    test "down at the end puts a character there and then steps it" do
+      start!()
+      go_to(:address)
+      press(@accept)
+
+      assert press(@down).editor.chars == ["0"]
+      assert press(@down).editor.chars == ["1"]
+    end
+
+    test "up from nothing starts at the other end of the alphabet" do
+      start!()
+      go_to(:address)
+      press(@accept)
+
+      # The first press has no character to step from, so it puts the first
+      # one of the alphabet down; the second steps back from it.
+      assert press(@up).editor.chars == ["0"]
+      assert press(@up).editor.chars == [" "]
+    end
+
+    test "left and right move the caret" do
+      start!()
+      go_to(:address)
+      press(@accept)
+      press(@down, 2)
+
+      assert press(@left).editor.caret == 0
+      assert press(@right).editor.caret == 1
+      # One past the end is a real position: it is where a character is added.
+      assert press(@right).editor.caret == 1
+    end
+
+    test "Y removes the character under the caret" do
+      start!()
+      go_to(:address)
+      press(@accept)
+      press(@down)
+      press(@down)
+      press(@left)
+
+      assert press(@remove).editor.chars == []
+    end
+
+    test "Y on an empty value does nothing" do
+      start!()
+      go_to(:address)
+      press(@accept)
+
+      assert press(@remove).editor.chars == []
+    end
+
+    test "A keeps what was typed and closes the editor" do
+      start!()
+      go_to(:address)
+      press(@accept)
+      press(@down)
+
+      snapshot = press(@accept)
+
+      assert snapshot.editor == nil
+      assert snapshot.settings.address == "0"
+      assert snapshot.unsaved?
+    end
+
+    test "the row list's bindings are off while it is open" do
+      start!()
+      go_to(:app)
+      press(@accept)
+
+      # Up and down belong to the character picker now, so neither moves the
+      # cursor off the row being edited -- which is the property that keeps a
+      # D-pad press from meaning two things at once.
+      assert press(@up).cursor == row(:app)
+      assert press(@down).cursor == row(:app)
+    end
+  end
+
+  describe "saving" do
+    test "A on the last row writes the file", %{config: config} do
+      start!()
+      go_to(:address)
+      press(@accept)
+      press(@down)
+      press(@accept)
+      go_to(:save)
+
+      snapshot = press(@accept)
+
+      assert {:ok, _words} = snapshot.message
+      refute snapshot.unsaved?
+      assert snapshot.source == :file
+      assert File.read!(config) =~ "address = 0"
+    end
+
+    test "a write that cannot happen is a message, not a crash", %{base: base} do
+      blocked = Path.join(base, "blocked")
+      File.write!(blocked, "not a directory")
+      Application.put_env(:mayonnaios, :moonlight_config, Path.join([blocked, "x", "m.conf"]))
+
+      start!()
+      go_to(:save)
+
+      assert {:error, words} = press(@accept).message
+      assert words =~ "Could not write"
+      assert Process.whereis(App) != nil
+    end
+
+    test "moving the cursor clears the last message" do
+      start!()
+      go_to(:save)
+      press(@accept)
+
+      assert press(@up).message == nil
+    end
+  end
+
+  describe "the launcher's own buttons" do
+    test "Menu changes nothing here -- the launcher stops the app on it" do
+      before = start!()
+
+      assert press(@menu) == before
+    end
+  end
+
+  describe "watchers" do
+    test "are told when something changes and not when nothing does" do
+      start!()
+      App.watch(self())
+
+      App.input([{:ev_key, @down, 1}])
+      assert_receive {:moonlight_app, %{cursor: 1}}
+
+      # A key nothing is bound to produces no snapshot change and so no push.
+      App.input([{:ev_key, :btn_start, 1}])
+      refute_receive {:moonlight_app, _snapshot}, 50
+    end
+  end
+
+  describe "the scene" do
+    # graph/1 is the tested surface: no viewport, no driver, no framebuffer.
+    # Same helper the other scene tests use.
+    defp texts(graph) do
+      Scenic.Graph.reduce(graph, [], fn
+        %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+        _primitive, acc -> acc
+      end)
+    end
+
+    defp snapshot(overrides \\ %{}) do
+      Map.merge(
+        %{
+          settings: Moonlight.defaults(),
+          source: :defaults,
+          installed?: true,
+          path: "/root/.config/moonlight/moonlight.conf",
+          cursor: 0,
+          editor: nil,
+          message: nil,
+          unsaved?: false
+        },
+        overrides
+      )
+    end
+
+    test "not running" do
+      assert Enum.member?(texts(Scene.graph(:stopped)), "Not running")
+    end
+
+    test "every row is drawn, with its value" do
+      texts = texts(Scene.graph(snapshot()))
+
+      assert Enum.member?(texts, "Host address")
+      assert Enum.member?(texts, "not set")
+      assert Enum.member?(texts, "Resolution")
+      assert Enum.member?(texts, "1280x720")
+      assert Enum.member?(texts, "30 fps")
+      assert Enum.member?(texts, "5000 kbps")
+      assert Enum.member?(texts, "h264")
+      assert Enum.member?(texts, "Save")
+    end
+
+    test "a missing bundle is said before anything else" do
+      texts = texts(Scene.graph(snapshot(%{installed?: false})))
+
+      assert Enum.any?(texts, &String.contains?(&1, "not installed"))
+    end
+
+    test "unsaved changes are on the panel, not in a footnote" do
+      texts = texts(Scene.graph(snapshot(%{unsaved?: true})))
+
+      assert Enum.member?(texts, "Unsaved changes.")
+      assert Enum.any?(texts, &String.contains?(&1, "A writes the changes"))
+    end
+
+    test "a saved file is named" do
+      texts = texts(Scene.graph(snapshot(%{source: :file, path: "/tmp/m.conf"})))
+
+      assert Enum.member?(texts, "/tmp/m.conf")
+    end
+
+    test "an unset address is said out loud" do
+      assert Enum.any?(
+               texts(Scene.graph(snapshot())),
+               &String.contains?(&1, "cannot start without a host address")
+             )
+    end
+
+    test "a set address takes that line away" do
+      settings = Map.put(Moonlight.defaults(), :address, "10.0.0.5")
+
+      refute Enum.any?(
+               texts(Scene.graph(snapshot(%{settings: settings}))),
+               &String.contains?(&1, "cannot start without")
+             )
+    end
+
+    test "a failed write is red words on the panel" do
+      texts =
+        texts(Scene.graph(snapshot(%{message: {:error, "Could not write /x: no permission"}})))
+
+      assert Enum.member?(texts, "Could not write /x: no permission")
+    end
+
+    test "the selected row's note is the manual" do
+      texts = texts(Scene.graph(snapshot(%{cursor: 3})))
+
+      assert Enum.any?(texts, &String.contains?(&1, "Lower this first"))
+    end
+
+    test "the footer says what the buttons do on this row" do
+      choice = texts(Scene.graph(snapshot(%{cursor: 1})))
+      text_row = texts(Scene.graph(snapshot(%{cursor: 0})))
+      save = texts(Scene.graph(snapshot(%{cursor: length(App.rows()) - 1})))
+
+      assert Enum.any?(choice, &String.contains?(&1, "Left and right change it"))
+      assert Enum.any?(text_row, &String.contains?(&1, "A edits it"))
+      assert Enum.any?(save, &String.contains?(&1, "A saves"))
+    end
+
+    test "the editor takes the panel and the rows go" do
+      editor = %{id: :address, chars: ["1", "0"], caret: 2}
+      texts = texts(Scene.graph(snapshot(%{editor: editor})))
+
+      assert Enum.member?(texts, "Host address")
+      refute Enum.member?(texts, "Resolution")
+      assert Enum.member?(texts, "1")
+      assert Enum.member?(texts, "0")
+      assert Enum.any?(texts, &String.contains?(&1, "Y removes it"))
+    end
+
+    test "a hostname longer than the row is cut rather than drawn off the panel" do
+      long = String.duplicate("a", 80) <> ".lan"
+      settings = Map.put(Moonlight.defaults(), :address, long)
+      texts = texts(Scene.graph(snapshot(%{settings: settings})))
+
+      refute Enum.member?(texts, long)
+      assert Enum.any?(texts, &(String.starts_with?(&1, "aaa") and String.ends_with?(&1, "…")))
+    end
+
+    test "a long failure keeps its reason rather than its path" do
+      words =
+        "Could not write /root/.config/moonlight/moonlight.conf: that filesystem is read-only"
+
+      texts = texts(Scene.graph(snapshot(%{message: {:error, words}})))
+
+      refute Enum.member?(texts, words)
+      assert Enum.any?(texts, &String.ends_with?(&1, "that filesystem is read-only"))
+    end
+
+    test "nothing is drawn over the shared top bar" do
+      graph = Scene.graph(snapshot())
+
+      Scenic.Graph.reduce(graph, nil, fn
+        %Scenic.Primitive{module: Scenic.Primitive.Text, transforms: %{translate: {_x, y}}},
+        acc ->
+          assert y >= Scene.status_bar()
+          acc
+
+        _primitive, acc ->
+          acc
+      end)
+    end
+  end
+end

--- a/test/moonlight_test.exs
+++ b/test/moonlight_test.exs
@@ -1,0 +1,279 @@
+defmodule MayonnaiOS.MoonlightTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Moonlight
+
+  # The property that matters here is that editing a config file is *editing*
+  # it: a key this screen does not offer must survive being saved over, and a
+  # comment must still be there afterwards. Everything else is arithmetic.
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "moonlight-test-#{System.unique_integer([:positive])}")
+    bundles = Path.join(base, "bundles")
+    config = Path.join([base, "config", "moonlight.conf"])
+    File.mkdir_p!(base)
+
+    prev = %{
+      bundle_root: Application.get_env(:mayonnaios, :bundle_root),
+      moonlight_config: Application.get_env(:mayonnaios, :moonlight_config)
+    }
+
+    Application.put_env(:mayonnaios, :bundle_root, bundles)
+    Application.put_env(:mayonnaios, :moonlight_config, config)
+
+    on_exit(fn ->
+      File.rm_rf(base)
+
+      Enum.each(prev, fn
+        {k, nil} -> Application.delete_env(:mayonnaios, k)
+        {k, v} -> Application.put_env(:mayonnaios, k, v)
+      end)
+    end)
+
+    %{base: base, bundles: bundles, config: config}
+  end
+
+  # A bundle as it looks once installed: a version directory and a `current`
+  # symlink pointing at it, which is what Bundle.publish/3 leaves behind.
+  defp install_moonlight(bundles, template \\ nil) do
+    dir = Path.join([bundles, "moonlight", "2.7.1"])
+    File.mkdir_p!(Path.join(dir, "bin"))
+    File.write!(Path.join([dir, "bin", "moonlight"]), "elf")
+
+    if template do
+      File.mkdir_p!(Path.join([dir, "share", "moonlight"]))
+      File.write!(Path.join([dir, "share", "moonlight", "moonlight.conf"]), template)
+    end
+
+    File.ln_s!(dir, Path.join([bundles, "moonlight", "current"]))
+    dir
+  end
+
+  describe "parse/1" do
+    test "reads the keys the screen owns" do
+      settings =
+        Moonlight.parse("""
+        address = 192.168.1.10
+        width = 1920
+        height = 1080
+        fps = 60
+        bitrate = 20000
+        codec = hevc
+        app = Desktop
+        """)
+
+      assert settings == %{
+               address: "192.168.1.10",
+               resolution: "1920x1080",
+               fps: "60",
+               bitrate: "20000",
+               codec: "hevc",
+               app: "Desktop"
+             }
+    end
+
+    test "anything absent keeps its default" do
+      assert Moonlight.parse("address = host.lan") ==
+               Map.put(Moonlight.defaults(), :address, "host.lan")
+    end
+
+    test "comments are not keys" do
+      assert Moonlight.parse("## address = 10.0.0.1").address == ""
+    end
+
+    test "a width with no height is not a resolution" do
+      settings = Moonlight.parse("width = 1920")
+      assert settings.resolution == Moonlight.defaults().resolution
+    end
+
+    test "whitespace around the separator is allowed, as Moonlight's own parser allows it" do
+      assert Moonlight.parse("fps=60").fps == "60"
+      assert Moonlight.parse("  bitrate   =   3000  ").bitrate == "3000"
+    end
+  end
+
+  describe "render/2" do
+    test "replaces a value where it already is" do
+      text = "width = 1280\nheight = 720\nfps = 30\n"
+      settings = Map.merge(Moonlight.defaults(), %{fps: "60"})
+
+      assert Moonlight.render(text, settings) =~ "fps = 60"
+      refute Moonlight.render(text, settings) =~ "fps = 30"
+    end
+
+    test "keeps comments, blank lines and keys the screen does not offer" do
+      text = """
+      ## Hardware notes worth keeping.
+
+      platform = sdl
+      surround = 5.1
+      rotate = 90
+      fps = 30
+      """
+
+      rendered = Moonlight.render(text, Map.put(Moonlight.defaults(), :fps, "60"))
+
+      assert rendered =~ "## Hardware notes worth keeping."
+      assert rendered =~ "platform = sdl"
+      assert rendered =~ "surround = 5.1"
+      assert rendered =~ "rotate = 90"
+      assert rendered =~ "fps = 60"
+    end
+
+    test "appends a key the file does not have yet" do
+      rendered =
+        Moonlight.render("platform = sdl\n", Map.put(Moonlight.defaults(), :address, "10.0.0.5"))
+
+      assert rendered =~ "address = 10.0.0.5"
+      assert rendered =~ "platform = sdl"
+    end
+
+    test "a cleared value removes its line rather than writing it empty" do
+      text = "address = 10.0.0.5\napp = Desktop\n"
+      settings = Map.merge(Moonlight.defaults(), %{address: "10.0.0.5", app: ""})
+      rendered = Moonlight.render(text, settings)
+
+      refute rendered =~ "app"
+      assert rendered =~ "address = 10.0.0.5"
+    end
+
+    test "one resolution row is two keys" do
+      rendered =
+        Moonlight.render(
+          "platform = sdl\n",
+          Map.put(Moonlight.defaults(), :resolution, "640x480")
+        )
+
+      assert rendered =~ "width = 640"
+      assert rendered =~ "height = 480"
+    end
+
+    test "rendering twice is rendering once" do
+      settings = Map.merge(Moonlight.defaults(), %{address: "10.0.0.5", fps: "60"})
+      once = Moonlight.render("platform = sdl\n", settings)
+
+      assert Moonlight.render(once, settings) == once
+    end
+
+    test "what was rendered is what parses back" do
+      settings = Map.merge(Moonlight.defaults(), %{address: "host.lan", resolution: "1920x1080"})
+
+      assert "platform = sdl\n" |> Moonlight.render(settings) |> Moonlight.parse() == settings
+    end
+  end
+
+  describe "save/1" do
+    test "creates the directory and writes the file", %{config: config} do
+      refute File.exists?(config)
+
+      assert {:ok, ^config} = Moonlight.save(Map.put(Moonlight.defaults(), :address, "10.0.0.5"))
+      assert File.read!(config) =~ "address = 10.0.0.5"
+    end
+
+    test "seeds from the bundle's template when there is no file yet", %{
+      bundles: bundles,
+      config: config
+    } do
+      install_moonlight(bundles, "## the bundle's own notes\nplatform = sdl\nfps = 30\n")
+
+      assert {:ok, ^config} = Moonlight.save(Map.put(Moonlight.defaults(), :address, "10.0.0.5"))
+
+      written = File.read!(config)
+      assert written =~ "## the bundle's own notes"
+      assert written =~ "platform = sdl"
+      assert written =~ "address = 10.0.0.5"
+    end
+
+    test "with no bundle and no file there is still something to write", %{config: config} do
+      assert {:ok, ^config} = Moonlight.save(Moonlight.defaults())
+      assert File.read!(config) =~ "platform = sdl"
+    end
+
+    test "a second save edits the first rather than starting again", %{config: config} do
+      {:ok, _} = Moonlight.save(Map.put(Moonlight.defaults(), :address, "10.0.0.5"))
+      File.write!(config, File.read!(config) <> "rotate = 90\n")
+
+      {:ok, _} = Moonlight.save(Map.merge(Moonlight.defaults(), %{address: "10.0.0.6"}))
+
+      written = File.read!(config)
+      assert written =~ "address = 10.0.0.6"
+      refute written =~ "10.0.0.5"
+      assert written =~ "rotate = 90"
+    end
+
+    test "a directory that cannot be created is an error, not an exception", %{base: base} do
+      blocked = Path.join(base, "blocked")
+      File.write!(blocked, "not a directory")
+      Application.put_env(:mayonnaios, :moonlight_config, Path.join([blocked, "x", "m.conf"]))
+
+      assert {:error, _reason} = Moonlight.save(Moonlight.defaults())
+    end
+  end
+
+  describe "load/1" do
+    test "says where the values came from", %{bundles: bundles, config: config} do
+      assert {settings, :defaults} = Moonlight.load()
+      assert settings == Moonlight.defaults()
+
+      install_moonlight(bundles, "fps = 60\n")
+      assert {%{fps: "60"}, :template} = Moonlight.load()
+
+      File.mkdir_p!(Path.dirname(config))
+      File.write!(config, "fps = 30\naddress = saved.lan\n")
+      assert {%{fps: "30", address: "saved.lan"}, :file} = Moonlight.load()
+    end
+  end
+
+  describe "installed?/0" do
+    test "is the binary, not the directory", %{bundles: bundles} do
+      refute Moonlight.installed?()
+
+      install_moonlight(bundles)
+      assert Moonlight.installed?()
+    end
+  end
+
+  describe "choices/2 and step/3" do
+    defp field(id), do: Enum.find(Moonlight.fields(), &(&1.id == id))
+
+    test "a value the screen does not offer is kept in the list" do
+      settings = Map.put(Moonlight.defaults(), :resolution, "1600x900")
+
+      assert "1600x900" in Moonlight.choices(field(:resolution), settings)
+    end
+
+    test "stepping wraps" do
+      settings = Map.put(Moonlight.defaults(), :fps, "60")
+
+      assert Moonlight.step(field(:fps), settings, +1).fps == "30"
+      assert Moonlight.step(field(:fps), settings, -1).fps == "30"
+    end
+
+    test "a text row has no choices and does not step" do
+      settings = Moonlight.defaults()
+
+      assert Moonlight.choices(field(:address), settings) == []
+      assert Moonlight.step(field(:address), settings, +1) == settings
+    end
+  end
+
+  describe "display/2" do
+    test "an empty text row reads as its placeholder" do
+      assert Moonlight.display(field(:address), Moonlight.defaults()) == "not set"
+      assert Moonlight.display(field(:app), Moonlight.defaults()) == "Steam"
+    end
+
+    test "a value carries its unit" do
+      assert Moonlight.display(field(:fps), Moonlight.defaults()) == "30 fps"
+      assert Moonlight.display(field(:bitrate), Moonlight.defaults()) == "5000 kbps"
+    end
+  end
+
+  describe "config_pairs/1" do
+    test "every key Moonlight's own parser knows" do
+      keys = Moonlight.defaults() |> Moonlight.config_pairs() |> Enum.map(&elem(&1, 0))
+
+      assert keys == ["address", "width", "height", "fps", "bitrate", "codec", "app"]
+    end
+  end
+end


### PR DESCRIPTION
Adds **System → Moonlight settings**: host address, resolution, frame rate,
bitrate, codec and app, written to the same `moonlight.conf` the launcher
passes Moonlight on its command line.

The design decision worth reviewing is that saving **edits** the file rather
than regenerating it — managed keys are replaced in place, everything else
(comments, `platform`, `surround`, anything set over SSH) is copied through.
`MayonnaiOS.Moonlight`'s moduledoc argues why; `render/2` is where it lives.

Pairing is deliberately not here. It prints a PIN that must be typed into the
host, and there is no way to show it on a screen the launcher has handed to
another program, so that stays the one SSH step.

## Trying it

Host tests cover the config module, the app's state machine and the scene's
graph:

    MIX_TARGET=host mix test test/moonlight_test.exs test/moonlight/

Not run on hardware — the panel layout is asserted from `graph/1` only, and
the host UI does not render (pre-existing).

## Note for `mayonnaios_bundles`

The bundle template's header now reads slightly wrong once copied: it says the
launcher "supplies the host on the command line", which it does not, and that
player changes should not go in this file — which is exactly what the copy is
for. Worth a follow-up over there.
