### PR TITLE
Add a WiFi settings screen to the System menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Software:
   device already holds
 - RetroArch, with cores installed and upgraded independently of the firmware
 - Checksum-verified bundle install, with versioned directories and rollback
+- A WiFi settings screen: what is on the air, what the device is configured
+  to join, and a character wheel to type a passphrase on — so the network is
+  not fixed at build time
 - A web UI for uploading games from a phone
 - File management built into that browser: copy, move, rename and delete
   across both cards, with a clipboard instead of a destination to type
@@ -59,8 +62,10 @@ Software:
 ## Building and flashing
 
 The WiFi credentials come from the environment, so that firmware without them
-fails the build rather than producing an image you cannot reach. Set them, pick
-the target, and build:
+fails the build rather than producing an image you cannot reach. They are the
+network the device joins on a fresh card; more can be added on the device
+afterwards, from the **WiFi** screen below. Set them, pick the target, and
+build:
 
     export RG40XXV_WIFI_SSID="your-ssid"
     export RG40XXV_WIFI_PSK="your-psk"
@@ -79,6 +84,51 @@ If `mix deps.get` starts compiling Buildroot instead of downloading a system,
 your tree does not match any published release and you are in for a full
 system build, which takes a while. That is usually a sign you changed something
 under `nerves_system_rg40xxv` — a comment is enough.
+
+## Changing which WiFi it joins
+
+Pick **WiFi** under System. It lists what is on the air with signal, security
+and whether this device already knows it, plus any saved network that is out
+of range — so a network can be forgotten from the other end of the house.
+
+    D-pad     move the cursor
+    A         join it. Open networks join straight away; a secured one you
+              have not joined before opens the passphrase wheel
+    X         retype the passphrase of a saved network
+    Y         forget a saved network. Twice — the first press arms the row
+
+Typing happens on a character wheel, because there is no keyboard: up and
+down cycle the character under the caret, left and right move it, and **L1
+and R1 jump between lowercase, uppercase, digits and symbols** — which is
+the difference between reaching `Q` in two presses and in twenty-six. The
+passphrase is shown rather than masked; every character is picked by reading
+the wheel, so hiding the result would only hide a mistake made twenty presses
+ago.
+
+Two things this screen guarantees, both because this device's only reliable
+way in is the radio it is reconfiguring:
+
+- **Joining never replaces the network that already works.** A new network is
+  added alongside the ones already configured, most-recently-chosen first, so
+  a passphrase picked wrong costs one walk back into range rather than a card
+  reflash. The credentials built into the firmware keep working forever.
+- **A refused passphrase says so, and is withdrawn again.** `wpa_supplicant`
+  reports a rejected key as an event rather than as a silence, so the screen
+  can say *the access point refused that passphrase* instead of *something
+  did not work* — and the bad network is removed, because one the supplicant
+  keeps retrying is one that interrupts the network that does work.
+
+Enterprise (802.1X) and WEP networks appear in the list with what they would
+need written on the row, and cannot be joined from here — neither is a
+passphrase, and neither can be picked from a wheel. Configure those over SSH
+with `VintageNet.configure/2`. `MayonnaiOS.WiFi` has the rest, including what
+a join actually writes.
+
+From IEx, if you would rather:
+
+    iex> MayonnaiOS.WiFi.list()
+    iex> MayonnaiOS.WiFi.join(%{ssid: "kitchen", security: :wpa_psk}, "a passphrase")
+    iex> MayonnaiOS.WiFi.forget("kitchen")
 
 ## Putting games on it
 

--- a/config/target.exs
+++ b/config/target.exs
@@ -286,6 +286,16 @@ config :mayonnaios, :programs, [
   # the Bluetooth apps neither takes a device away from anything.
   %{name: "BEAM processes", app: {MayonnaiOS.Top, :beam}},
   %{name: "OS processes", app: {MayonnaiOS.Top, :os}},
+  # The WiFi settings screen: what is on the air, what this device is
+  # configured to join, and a character wheel to type a passphrase on.
+  #
+  # It is what makes the credentials above a *default* rather than the only
+  # network this firmware can ever reach: `MayonnaiOS.WiFi.join/3` appends to
+  # the network list instead of replacing it, so a network picked on the panel
+  # is added alongside the one built in and the built-in one goes on working.
+  # See that module for why appending is the only safe shape for this on a
+  # device whose sole reliable way in is the radio being configured.
+  %{name: "WiFi", app: MayonnaiOS.WiFi.App},
   # Checks kek/mayonnaios's GitHub releases for a newer version than the one
   # running, and downloads and applies it with fwup if there is one -- the
   # online half of what `mix upload` does from a dev machine. See

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -22,7 +22,7 @@ defmodule MayonnaiOS.Application do
         [status()] ++
         viewport() ++
         [controller_sessions(), pairing_sessions(), pickle_sessions()] ++
-        [top_sessions(), update_sessions()] ++
+        [top_sessions(), update_sessions(), wifi_sessions()] ++
         target_children()
 
     # See https://elixir.hexdocs.pm/Supervisor.html
@@ -101,6 +101,14 @@ defmodule MayonnaiOS.Application do
   # works on a laptop and fails with "no such supervisor" rather than an
   # exception if it is ever started before this line runs.
   defp update_sessions, do: MayonnaiOS.Update.App.sessions()
+
+  # The WiFi settings app's DynamicSupervisor, empty until the row is opened.
+  # Everywhere rather than only on the target, like the others: on a laptop
+  # `MayonnaiOS.WiFi.App.start/0` then runs and the screen says there is no
+  # radio, which is a more useful thing to be told than "no such supervisor"
+  # -- and it is the only way to look at the screen without holding the
+  # device.
+  defp wifi_sessions, do: MayonnaiOS.WiFi.App.sessions()
 
   # List all child processes to be supervised
   if Mix.target() == :host do

--- a/lib/mayonnaios/scene/wifi.ex
+++ b/lib/mayonnaios/scene/wifi.ex
@@ -1,0 +1,612 @@
+defmodule MayonnaiOS.Scene.WiFi do
+  @moduledoc """
+  What the panel shows while `MayonnaiOS.WiFi.App` has the buttons.
+
+  Draws `MayonnaiOS.WiFi.App.snapshot/0` and nothing else, told when to
+  redraw by `App.watch/1` -- the same arrangement as `MayonnaiOS.Scene.Update`
+  and for the same reason: `Scenic.ViewPort.set_root/3` terminates this scene
+  on every repaint the launcher does, so nothing may be remembered here.
+
+  Three pages, one per thing the app can be doing: the list, the passphrase
+  wheel, and a sentence about a join that has finished one way or the other.
+
+  ## The note under each row is where the honesty goes
+
+  A network's row carries its signal, what security it advertises, and
+  whether this device already knows it. Two of the five kinds of security
+  cannot be joined from this screen at all -- enterprise and WEP, see
+  `MayonnaiOS.WiFi` -- and those rows say what they would need where the
+  others say how to join. The same rule as `MayonnaiOS.Scene.Pairing`'s
+  headphone notice: a row that takes a passphrase and then fails is worse
+  than a row that says it cannot take one.
+
+  ## The passphrase is monospaced, and that is load-bearing
+
+  The caret is a rectangle drawn under one character. In a proportional font
+  its position is the measured width of every character before it, which
+  drifts against the glyph it is meant to sit under as the string grows. In a
+  monospaced one it is a multiplication. So the wheel's string is set in
+  `:roboto_mono` at a size and column count that put sixty-three characters
+  -- WPA's maximum -- on two lines that fit the panel.
+
+  ## Building a page is a pure function
+
+  `graph/1` takes the snapshot and needs no viewport, no driver and no
+  framebuffer, which is what lets the host tests assert on an empty list, a
+  row armed for forgetting, a refused passphrase and a machine with no radio
+  at all -- states that would otherwise only be reachable by holding the
+  device in the right room.
+  """
+
+  use Scenic.Scene
+
+  alias MayonnaiOS.Scene.StatusBar
+  alias MayonnaiOS.Theme
+  alias MayonnaiOS.WiFi.App
+  alias MayonnaiOS.WiFi.Editor
+  alias Scenic.Graph
+
+  import Scenic.Primitives
+
+  @width 640
+  @height 480
+
+  # The shared top bar owns the top of the panel on every screen, so
+  # everything here starts below it and the height comes from the bar rather
+  # than being copied.
+  @status_bar StatusBar.height()
+  @title_y @status_bar + 20
+  @rule_y @status_bar + 30
+
+  @connection_y @rule_y + 26
+  @heading_y @connection_y + 30
+
+  @top @heading_y + 22
+  @pitch 34
+  @visible 8
+
+  @left 20
+  @row_width @width - 40
+
+  @footer_rule @height - 44
+  @footer_y @height - 24
+
+  # The passphrase wheel. Forty columns of mono at 20 px fits the panel with
+  # a margin, and two lines of forty covers the sixty-three characters WPA
+  # allows.
+  @mono :roboto_mono
+  @psk_size 20
+  @psk_columns 40
+  @psk_pitch 30
+  @psk_y @rule_y + 92
+
+  # Read at the moment of drawing rather than captured in a module attribute,
+  # so the System menu's Theme row changes this screen too without a
+  # recompile. See `MayonnaiOS.Theme`.
+  defp font, do: Theme.current().font
+  defp bg, do: Theme.current().bg
+  defp title, do: Theme.current().title
+  defp head, do: Theme.current().head
+  defp label, do: Theme.current().label
+  defp pass, do: Theme.current().pass
+  defp fail, do: Theme.current().fail
+  defp wait, do: Theme.current().wait
+  defp dim, do: Theme.current().dim
+  defp row_bg, do: Theme.current().row_bg
+
+  @impl Scenic.Scene
+  def init(scene, _param, _opts) do
+    {:ok, show(scene, watch())}
+  end
+
+  @impl GenServer
+  def handle_info({:wifi_app, snapshot}, scene), do: {:noreply, show(scene, snapshot)}
+  def handle_info(_message, scene), do: {:noreply, scene}
+
+  # The app not running is a state to render rather than crash on: it is what
+  # the launcher shows if starting failed, and the panel is the only place
+  # that is visible.
+  defp watch do
+    App.watch(self())
+  rescue
+    _error -> :stopped
+  catch
+    :exit, _reason -> :stopped
+  end
+
+  defp show(scene, snapshot), do: push_graph(scene, graph(snapshot))
+
+  @doc """
+  The height of the strip this scene leaves for the shared top bar, public so
+  a test can assert that nothing is drawn above it.
+  """
+  @spec status_bar() :: pos_integer()
+  def status_bar, do: @status_bar
+
+  @doc """
+  How many rows of the list are on screen at once, public for the same reason
+  the windowing is tested at all: a cursor past the last visible row has to
+  bring the window with it.
+  """
+  @spec visible() :: pos_integer()
+  def visible, do: @visible
+
+  @doc """
+  Build the page for one snapshot.
+
+  Public because it is the tested surface: `:stopped` is a valid argument and
+  renders the "not running" page.
+  """
+  @spec graph(map() | :stopped) :: Scenic.Graph.t()
+  def graph(snapshot)
+
+  def graph(:stopped) do
+    base()
+    |> text("Not running", font_size: 26, fill: {:color, fail()}, translate: {@left, 120})
+    |> footer("B or Menu goes back.")
+  end
+
+  def graph(%{status: :editing} = snapshot) do
+    base()
+    |> connection_line(snapshot)
+    |> text("Passphrase for #{quoted(snapshot.editor.ssid)}",
+      font_size: 18,
+      fill: {:color, title()},
+      translate: {@left, @heading_y}
+    )
+    |> passphrase(snapshot)
+    |> footer("D-pad picks characters, L1/R1 jump blocks, Y removes, A joins, B cancels.")
+  end
+
+  def graph(%{status: :joining} = snapshot) do
+    base()
+    |> connection_line(snapshot)
+    |> text("Joining #{quoted(ssid_of(snapshot))}...",
+      font_size: 24,
+      fill: {:color, wait()},
+      translate: {@left, @heading_y + 20}
+    )
+    |> text("Waiting for the access point, and then for an address.",
+      font_size: 15,
+      fill: {:color, label()},
+      translate: {@left, @heading_y + 48}
+    )
+    |> lines(@heading_y + 76, [
+      {"The network this device was already on is untouched.", dim()}
+    ])
+    |> footer("B or Menu leaves. The radio carries on joining without this screen.")
+  end
+
+  def graph(%{status: :joined} = snapshot) do
+    base()
+    |> connection_line(snapshot)
+    |> text("Joined #{quoted(ssid_of(snapshot))}",
+      font_size: 26,
+      fill: {:color, pass()},
+      translate: {@left, @heading_y + 20}
+    )
+    |> lines(@heading_y + 52, joined_lines(snapshot))
+    |> footer("A goes back to the list. B or Menu leaves.")
+  end
+
+  def graph(%{status: :failed} = snapshot) do
+    base()
+    |> connection_line(snapshot)
+    |> text(headline(snapshot.error),
+      font_size: 24,
+      fill: {:color, fail()},
+      translate: {@left, @heading_y + 20}
+    )
+    |> lines(@heading_y + 52, explain(snapshot.error, snapshot))
+    |> footer("A goes back to the list. B or Menu leaves.")
+  end
+
+  # :listing, and anything else the app has not got a page of its own for.
+  def graph(snapshot) do
+    base()
+    |> connection_line(snapshot)
+    |> heading(snapshot)
+    |> rows(snapshot)
+    |> footer(bindings(snapshot))
+  end
+
+  # -- the furniture every page shares ----------------------------------------
+
+  defp base do
+    Graph.build(font: font(), font_size: 14)
+    |> rect({@width, @height}, fill: {:color, bg()})
+    |> StatusBar.mount()
+    |> text("WiFi", font_size: 20, fill: {:color, title()}, translate: {@left, @title_y})
+    |> rect({@row_width, 2}, fill: {:color, head()}, translate: {@left, @rule_y})
+  end
+
+  # One line saying where the radio is now, on every page. It is the thing
+  # somebody opening this screen is checking, and it is also the answer to
+  # "did that work" on the pages that follow a join.
+  defp connection_line(graph, %{available?: false}) do
+    text(graph, "No WiFi radio on this machine.",
+      font_size: 15,
+      fill: {:color, dim()},
+      translate: {@left, @connection_y}
+    )
+  end
+
+  defp connection_line(graph, %{connection: connection}) do
+    {words, colour} = connection_words(connection)
+
+    text(graph, words, font_size: 15, fill: {:color, colour}, translate: {@left, @connection_y})
+  end
+
+  defp connection_line(graph, _snapshot), do: graph
+
+  defp connection_words(%{state: state, ssid: ssid, address: address}) do
+    case state do
+      :internet -> {"On #{name(ssid)}#{at(address)}", pass()}
+      # Associated and addressed, with nothing beyond the router answering.
+      # A working join and a separate problem, so it is not drawn as a
+      # failure.
+      :lan -> {"On #{name(ssid)}#{at(address)} -- no route to the internet", wait()}
+      :disconnected -> {"Not connected", fail()}
+      nil -> {"No reading from the radio", dim()}
+      other -> {"Radio says #{inspect(other)}", dim()}
+    end
+  end
+
+  defp name(nil), do: "an unnamed network"
+  defp name(ssid), do: quoted(ssid)
+
+  defp at(nil), do: ""
+  defp at(address), do: ", #{address}"
+
+  defp heading(graph, snapshot) do
+    count = length(snapshot.networks)
+
+    graph
+    |> text("Networks (#{count})",
+      font_size: 15,
+      fill: {:color, head()},
+      translate: {@left, @heading_y}
+    )
+    |> rect({@row_width, 1}, fill: {:color, dim()}, translate: {@left, @heading_y + 6})
+  end
+
+  # -- the list ---------------------------------------------------------------
+
+  defp rows(graph, %{networks: []} = snapshot) do
+    lines(graph, @top, empty_lines(snapshot))
+  end
+
+  defp rows(graph, snapshot) do
+    {start, window} = window(snapshot.networks, snapshot.cursor)
+
+    window
+    |> Enum.with_index(start)
+    |> Enum.reduce(graph, fn {network, index}, acc ->
+      selected? = index == snapshot.cursor
+      y = @top + (index - start) * @pitch
+
+      acc
+      |> highlight(y, selected?)
+      |> text(clip(network.ssid),
+        font_size: 17,
+        fill: {:color, ssid_colour(network, selected?)},
+        translate: {@left + 16, y + 4}
+      )
+      |> text(note(network, selected? and snapshot.armed?),
+        font_size: 12,
+        fill: {:color, note_colour(network, selected? and snapshot.armed?)},
+        translate: {@left + 16, y + 19}
+      )
+    end)
+    |> more(start, length(snapshot.networks))
+  end
+
+  defp empty_lines(%{available?: false}) do
+    [
+      {"There is no radio here to scan with.", label()},
+      {"vintage_net is a target-only dependency, so a host build has none.", dim()},
+      {"The rest of this screen is drawn from whatever the machine can answer.", dim()}
+    ]
+  end
+
+  defp empty_lines(%{scan_error: reason}) when not is_nil(reason) do
+    [
+      {"The scan did not start.", fail()},
+      {inspect(reason), label()}
+    ]
+  end
+
+  defp empty_lines(_snapshot) do
+    [
+      {"Scanning...", wait()},
+      {"Nothing has answered yet. This rescans every few seconds.", dim()}
+    ]
+  end
+
+  # Armed is the loudest thing on the row, because the next Y is the one that
+  # does it and the row is otherwise indistinguishable from a selected one.
+  defp note(_network, true), do: "press Y again to forget this network"
+
+  defp note(network, _armed) do
+    [signal(network.signal), security(network.security), tag(network)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("  ")
+  end
+
+  defp signal(nil), do: nil
+  defp signal(percent), do: "#{percent}%"
+
+  defp security(:open), do: "open"
+  defp security(:wpa_psk), do: "WPA2"
+  defp security(:sae), do: "WPA3"
+  defp security(:wep), do: "WEP -- needs a key this screen cannot enter"
+  defp security(:eap), do: "enterprise -- needs an identity and a certificate"
+  defp security(:unknown), do: nil
+  defp security(other), do: to_string(other)
+
+  defp tag(%{connected?: true}), do: "connected"
+  defp tag(%{saved?: true, in_range?: false}), do: "saved, not in range"
+  defp tag(%{saved?: true}), do: "saved"
+  defp tag(_network), do: nil
+
+  defp ssid_colour(_network, true), do: title()
+  defp ssid_colour(%{connected?: true}, _selected), do: pass()
+  defp ssid_colour(_network, _selected), do: label()
+
+  defp note_colour(_network, true), do: fail()
+  defp note_colour(%{security: security}, _armed) when security in [:eap, :wep], do: wait()
+  defp note_colour(_network, _armed), do: dim()
+
+  defp highlight(graph, _y, false), do: graph
+
+  defp highlight(graph, y, true) do
+    graph
+    |> rect({@row_width, @pitch - 4}, fill: {:color, row_bg()}, translate: {@left, y - 12})
+    |> rect({4, @pitch - 4}, fill: {:color, head()}, translate: {@left, y - 12})
+  end
+
+  # Window the rows so a cursor past the last visible one is still on screen.
+  defp window(rows, cursor) do
+    count = length(rows)
+    start = min(max(0, cursor - @visible + 1), max(0, count - @visible))
+    {start, Enum.slice(rows, start, @visible)}
+  end
+
+  defp more(graph, _start, count) when count <= @visible, do: graph
+
+  defp more(graph, start, count) do
+    text(graph, "#{start + 1}-#{min(start + @visible, count)} of #{count}",
+      font_size: 12,
+      fill: {:color, dim()},
+      translate: {@left, @top + @visible * @pitch}
+    )
+  end
+
+  # -- the passphrase wheel ---------------------------------------------------
+
+  defp passphrase(graph, %{editor: editor} = snapshot) do
+    chars = editor.chars
+    caret = min(editor.caret, length(chars))
+    char_width = Theme.width("0", @psk_size, @mono)
+
+    graph
+    |> psk_lines(chars, char_width)
+    |> psk_caret(caret, char_width, length(chars))
+    |> lines(@psk_y + 2 * @psk_pitch + 24, psk_notes(editor, snapshot))
+  end
+
+  # The string, wrapped at the column count the panel fits. Empty draws a
+  # prompt rather than nothing, because a screen with a caret on an empty line
+  # and no words is a screen that looks broken.
+  defp psk_lines(graph, [], _char_width) do
+    text(graph, "press up or down to start",
+      font_size: 15,
+      fill: {:color, dim()},
+      translate: {@left, @psk_y}
+    )
+  end
+
+  defp psk_lines(graph, chars, _char_width) do
+    chars
+    |> Enum.chunk_every(@psk_columns)
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {chunk, row}, acc ->
+      text(acc, Enum.join(chunk),
+        font: @mono,
+        font_size: @psk_size,
+        fill: {:color, title()},
+        translate: {@left, @psk_y + row * @psk_pitch}
+      )
+    end)
+  end
+
+  # A rectangle under the character the wheel is on. Monospace is what makes
+  # its position a multiplication rather than a measurement; see the
+  # moduledoc.
+  defp psk_caret(graph, caret, char_width, count) do
+    row = div(caret, @psk_columns)
+    column = rem(caret, @psk_columns)
+    x = @left + column * char_width
+    y = @psk_y + row * @psk_pitch + 6
+
+    # Past the end of the string the caret is where the next character goes,
+    # so it is drawn hollow -- a thinner mark than the one sitting under a
+    # character somebody is cycling.
+    thickness = if caret >= count, do: 2, else: 3
+
+    rect(graph, {max(char_width, 1), thickness}, fill: {:color, head()}, translate: {x, y})
+  end
+
+  defp psk_notes(editor, snapshot) do
+    {min, max} = Map.get(snapshot, :passphrase_bounds, {8, 63})
+    length = Editor.length(editor)
+
+    [
+      {"#{length} characters. WPA accepts #{min} to #{max}.", length_colour(length, min, max)},
+      {wheel_line(editor), dim()}
+    ]
+  end
+
+  defp length_colour(length, min, max) when length >= min and length <= max, do: pass()
+  defp length_colour(0, _min, _max), do: dim()
+  defp length_colour(_length, _min, _max), do: wait()
+
+  defp wheel_line(editor) do
+    case Editor.current(editor) do
+      nil -> "The caret is past the end: a direction adds a character there."
+      char -> "Under the caret: #{quoted(char)}"
+    end
+  end
+
+  # -- the pages after a join -------------------------------------------------
+
+  defp joined_lines(%{connection: %{address: address}}) when is_binary(address) do
+    [
+      {"Address #{address}.", label()},
+      {"Saved, so this network is rejoined after a power cut.", dim()}
+    ]
+  end
+
+  defp joined_lines(_snapshot) do
+    [
+      {"Saved, so this network is rejoined after a power cut.", dim()}
+    ]
+  end
+
+  defp headline(:wrong_key), do: "That passphrase was refused"
+  defp headline(:timed_out), do: "No answer"
+  defp headline(:passphrase_too_short), do: "Too short"
+  defp headline(:passphrase_too_long), do: "Too long"
+  defp headline(:eap_unsupported), do: "Enterprise networks cannot be joined here"
+  defp headline(:wep_unsupported), do: "WEP networks cannot be joined here"
+  defp headline(:unavailable), do: "No radio"
+  defp headline(:not_saved), do: "Not saved"
+  defp headline({:forget_failed, _reason}), do: "Could not forget it"
+  defp headline(_other), do: "That did not work"
+
+  defp explain(:wrong_key, snapshot) do
+    [
+      {"#{name(ssid_of(snapshot))} rejected it, and it has been removed again.", label()},
+      {"Nothing else changed: the network this device was already on is", dim()},
+      {"still configured. A goes back to the list; X retries the passphrase.", dim()}
+    ]
+  end
+
+  defp explain(:timed_out, snapshot) do
+    [
+      {"#{name(ssid_of(snapshot))} did not finish connecting in time.", label()},
+      {"It is still configured, so it may yet connect -- the bar at the top", dim()},
+      {"says so if it does. A slow router is the usual reason.", dim()}
+    ]
+  end
+
+  defp explain(:passphrase_too_short, _snapshot) do
+    [{"A WPA passphrase is at least 8 characters. Nothing was changed.", label()}]
+  end
+
+  defp explain(:passphrase_too_long, _snapshot) do
+    [{"A WPA passphrase is at most 63 characters. Nothing was changed.", label()}]
+  end
+
+  defp explain(:eap_unsupported, _snapshot) do
+    [
+      {"802.1X wants an identity, a CA certificate and an inner method.", label()},
+      {"None of that is a passphrase, and none of it can be picked from", dim()},
+      {"a character wheel. Configure it over SSH with VintageNet.", dim()}
+    ]
+  end
+
+  defp explain(:wep_unsupported, _snapshot) do
+    [
+      {"WEP wants a hex or ASCII key in one of four slots, and nothing", label()},
+      {"on this device has associated with a WEP access point to say the", dim()},
+      {"plumbing works. Configure it over SSH if you really have one.", dim()}
+    ]
+  end
+
+  defp explain(:unavailable, _snapshot) do
+    [
+      {"vintage_net is not loaded, so there is nothing to configure.", label()},
+      {"That is the normal state of a host build.", dim()}
+    ]
+  end
+
+  defp explain(:not_saved, _snapshot) do
+    [{"The network is not in the configuration any more. Nothing changed.", label()}]
+  end
+
+  defp explain({:forget_failed, reason}, _snapshot) do
+    [
+      {"The configuration was refused: #{inspect(reason)}.", label()},
+      {"See the log: RingLogger.next", dim()}
+    ]
+  end
+
+  defp explain(other, _snapshot) do
+    [
+      {inspect(other), label()},
+      {"See the log: RingLogger.next", dim()}
+    ]
+  end
+
+  # -- footers ----------------------------------------------------------------
+
+  defp bindings(%{networks: []}), do: "B or Menu goes back."
+
+  defp bindings(%{armed?: true}) do
+    "Y forgets this network. Any direction or B cancels. Menu leaves."
+  end
+
+  defp bindings(snapshot) do
+    case snapshot.selected do
+      nil -> "B or Menu goes back."
+      network -> row_bindings(network)
+    end
+  end
+
+  defp row_bindings(%{security: security}) when security in [:eap, :wep] do
+    "This one cannot be joined from here. B or Menu goes back."
+  end
+
+  defp row_bindings(%{connected?: true}), do: "X retypes the passphrase, Y forgets. B goes back."
+
+  defp row_bindings(%{saved?: true}), do: "A joins, X retypes the passphrase, Y forgets."
+
+  defp row_bindings(%{security: :open}), do: "A joins this open network. B or Menu goes back."
+
+  defp row_bindings(_network), do: "A picks a passphrase and joins. B or Menu goes back."
+
+  defp footer(graph, words) do
+    graph
+    |> rect({@row_width, 1}, fill: {:color, dim()}, translate: {@left, @footer_rule})
+    |> text(words, font_size: 14, fill: {:color, dim()}, translate: {@left, @footer_y})
+  end
+
+  # -- shared bits ------------------------------------------------------------
+
+  # The value/label column the other screens on this device use, so the set
+  # reads as one machine.
+  defp lines(graph, y, rows) do
+    rows
+    |> Enum.with_index()
+    |> Enum.reduce(graph, fn {{words, colour}, index}, acc ->
+      text(acc, words,
+        font_size: 15,
+        fill: {:color, colour},
+        translate: {@left, y + index * 22}
+      )
+    end)
+  end
+
+  defp ssid_of(%{target: %{ssid: ssid}}), do: ssid
+  defp ssid_of(%{connection: %{ssid: ssid}}), do: ssid
+  defp ssid_of(_snapshot), do: nil
+
+  defp quoted(nil), do: "(unnamed)"
+  defp quoted(text), do: "\"#{text}\""
+
+  # A 32-byte SSID -- the maximum -- at font size 17 runs off the panel, and
+  # Scenic will happily draw it over the footer.
+  defp clip(text) when byte_size(text) <= 46, do: text
+  defp clip(text), do: binary_part(text, 0, 45) <> "…"
+end

--- a/lib/mayonnaios/wifi.ex
+++ b/lib/mayonnaios/wifi.ex
@@ -1,0 +1,650 @@
+defmodule MayonnaiOS.WiFi do
+  @moduledoc """
+  The WiFi mechanism behind the settings screen: what is on the air, what
+  this device is configured to join, and the two verbs that change it.
+
+      iex> MayonnaiOS.WiFi.scan()
+      iex> MayonnaiOS.WiFi.list()
+      iex> MayonnaiOS.WiFi.join(%{ssid: "kitchen", security: :wpa_psk}, "a passphrase")
+      iex> MayonnaiOS.WiFi.forget("kitchen")
+
+  `MayonnaiOS.WiFi.App` drives all of it from the panel;
+  `MayonnaiOS.Scene.WiFi` draws it. This module is the only thing here that
+  talks to `VintageNet`.
+
+  ## Joining never replaces the network that already works
+
+  This device's only reliable way in is WiFi -- the USB-C gadget has not been
+  seen enumerating and UART0 is on internal test pads -- so a settings screen
+  that can leave the radio pointed at one wrong network is a settings screen
+  that can cost a card reflash. `config/target.exs` says the same thing about
+  build-time credentials, and this module is the one place a *person holding
+  the device* can point the radio somewhere new.
+
+  So `join/3` appends rather than overwrites. `wpa_supplicant` holds a list of
+  networks and associates with whichever of them is in range, so the network
+  that got the device onto the workbench survives every join made here, and a
+  passphrase picked wrong on a 95-character wheel costs one walk back into
+  range rather than the card.
+
+  What a join does change is *preference*: the newly joined network is put at
+  the head of the list and the whole list is renumbered by position, so
+  `:priority` descends the way the screen reads. The most recently chosen
+  network wins wherever two are in range, which is the only ordering anyone
+  would guess from having just chosen one.
+
+  ## A wrong passphrase is a thing wpa_supplicant says out loud
+
+  `vintage_net_wifi` republishes the supplicant's own control events on
+  `["interface", "wlan0", "wifi", "event"]`, and a passphrase the AP rejects
+  arrives there as `CTRL-EVENT-SSID-TEMP-DISABLED` with
+  `reason: "WRONG_KEY"`. That is a fact rather than an inference from a
+  timeout, which is why `MayonnaiOS.WiFi.App` waits for it: "could not
+  connect" and "you typed it wrong" are different sentences and only one of
+  them tells anyone what to do next.
+
+  It is also why a rejected passphrase is withdrawn from the configuration
+  again. A network known to be wrong is one `wpa_supplicant` keeps retrying
+  and temporarily disabling, and the retries are association attempts that
+  interrupt the network that does work. Not-knowing is treated differently: a
+  join that simply never completes stays configured, because DHCP on a slow
+  router outlasts any deadline worth putting on a panel.
+
+  ## Enterprise and WEP are refused rather than half-offered
+
+  `security/1` classifies what an access point advertises, and `joinable?/1`
+  answers for two of the five with a no:
+
+    * **802.1X / enterprise** needs an identity, a CA certificate and an
+      inner method. None of that is a passphrase, and none of it can be
+      picked from a character wheel.
+    * **WEP** needs a hex or ASCII key in one of four slots, and nothing on
+      this device has ever associated with a WEP AP to say the plumbing
+      works.
+
+  Both appear on the screen with what they need written on the row, on the
+  same reasoning as the Bluetooth screen's headphone notice -- see
+  `MayonnaiOS.Pairing`. A row that accepts a passphrase and then fails is
+  worse than a row that says it cannot.
+
+  ## Every read and write is injectable
+
+  The same seam as `MayonnaiOS.SystemInfo` and for a stronger reason:
+  `VintageNet` is a target-only dependency, so on a development laptop the
+  module is not loaded at all. Every function here takes an options keyword
+  whose defaults are the real calls, so the merging, sorting, classifying and
+  configuration-rewriting are all testable on a machine with no radio -- and
+  on that machine the defaults answer `{:error, :unavailable}` rather than
+  raising, which is a state the panel draws.
+  """
+
+  require Logger
+
+  @interface "wlan0"
+
+  # WPA-PSK's own bounds, from IEEE 802.11i: a passphrase is 8 to 63
+  # printable ASCII characters. Checked here rather than left to
+  # wpa_supplicant, because on a character wheel a rejection that arrives
+  # after the configuration round-trip is a rejection that arrives two
+  # minutes after the mistake.
+  @psk_min 8
+  @psk_max 63
+
+  @typedoc "What an access point's flags say it wants."
+  @type security :: :open | :wpa_psk | :sae | :wep | :eap
+
+  @typedoc """
+  One row of the settings screen.
+
+  `signal` is nil for a saved network that is not currently on the air --
+  which is a row worth drawing, because forgetting a network is something
+  people do from somewhere else in the house.
+  """
+  @type network :: %{
+          ssid: String.t(),
+          security: security(),
+          signal: 0..100 | nil,
+          saved?: boolean(),
+          connected?: boolean(),
+          in_range?: boolean()
+        }
+
+  @typedoc "Where the radio has got to."
+  @type connection :: %{
+          state: :internet | :lan | :disconnected | nil,
+          ssid: String.t() | nil,
+          address: String.t() | nil,
+          error: term() | nil
+        }
+
+  @doc "The interface this device's radio is on."
+  @spec interface() :: String.t()
+  def interface, do: @interface
+
+  # -- reading ----------------------------------------------------------------
+
+  @doc """
+  Whether there is a radio to talk to at all.
+
+  False on a development laptop, where `VintageNet` is not in the release.
+  The screen draws that as a state rather than an error: the UI is worth
+  looking at on a host, and "no radio here" is the honest thing for it to
+  say.
+  """
+  @spec available?(keyword()) :: boolean()
+  def available?(opts \\ []) do
+    Keyword.get(opts, :available?, &vintage_net_loaded?/0).()
+  end
+
+  @doc """
+  Ask the radio for a fresh scan.
+
+  Asynchronous: results land on the access-points property a second or two
+  later, which is why `MayonnaiOS.WiFi.App` calls this on a timer and reads
+  `list/1` on its own clock rather than waiting for anything.
+  """
+  @spec scan(keyword()) :: :ok | {:error, term()}
+  def scan(opts \\ []) do
+    case Keyword.get(opts, :scan, &do_scan/0).() do
+      :ok -> :ok
+      {:ok, _result} -> :ok
+      {:error, reason} -> {:error, reason}
+      other -> {:error, other}
+    end
+  end
+
+  @doc """
+  Where the radio has got to: the connection state, the SSID it is on, and
+  the address it was given.
+
+  The address comes from the kernel's own interface list rather than from a
+  `VintageNet` property, because that read works on a laptop too and this is
+  the one line of the screen worth having there.
+  """
+  @spec connection(keyword()) :: connection()
+  def connection(opts \\ []) do
+    %{
+      state: Keyword.get(opts, :connection_state, &read_connection_state/0).(),
+      ssid: Keyword.get(opts, :current_ssid, &read_current_ssid/0).(),
+      address: Keyword.get(opts, :address, &read_address/0).(),
+      error: nil
+    }
+  end
+
+  @doc """
+  Every network worth a row: what is on the air, plus what is saved and is
+  not.
+
+  Ordered by signal, strongest first, with the saved-but-absent networks
+  after them. Not by "connected first" or "saved first": the list is being
+  read by someone looking for a name they can see on a router in front of
+  them, and a list that reorders itself as the radio wanders between two
+  access points is a list whose rows move under the cursor.
+  """
+  @spec list(keyword()) :: [network()]
+  def list(opts \\ []) do
+    access_points = Keyword.get(opts, :access_points, &read_access_points/0).()
+    saved = Keyword.get(opts, :saved, fn -> saved_ssids(opts) end).()
+    current = Keyword.get(opts, :current_ssid, &read_current_ssid/0).()
+
+    merge(access_points, saved, current)
+  end
+
+  @doc """
+  The SSIDs this device is configured to join, in preference order.
+
+  Read out of the live configuration rather than remembered, so a network
+  added over SSH shows up here the same as one added from the panel.
+  """
+  @spec saved_ssids(keyword()) :: [String.t()]
+  def saved_ssids(opts \\ []) do
+    opts
+    |> configuration()
+    |> networks_of()
+    |> Enum.map(&Map.get(&1, :ssid))
+    |> Enum.reject(&(&1 in [nil, ""]))
+  end
+
+  @doc """
+  Subscribe to the two properties the app watches: the connection state, and
+  the supplicant's own events.
+
+  Messages arrive as `VintageNet`'s own
+  `{VintageNet, property, old, new, meta}`, which is the shape
+  `MayonnaiOS.Status` already handles -- see that module for why a
+  subscription is not enough on its own and this app polls as well.
+  """
+  @spec subscribe(keyword()) :: :ok
+  def subscribe(opts \\ []) do
+    Keyword.get(opts, :subscribe, &do_subscribe/0).()
+  end
+
+  # -- writing ----------------------------------------------------------------
+
+  @doc """
+  Join a network, keeping every network already configured.
+
+  Takes the row the cursor is on rather than an SSID and a security atom
+  separately, because the row is what the screen has and splitting it would
+  let the two drift apart. The passphrase is ignored for an open network.
+
+  Errors, all of them before the radio is touched except the last:
+
+    * `{:error, :eap_unsupported}` and `{:error, :wep_unsupported}` -- see
+      the moduledoc
+    * `{:error, :passphrase_too_short}` / `{:error, :passphrase_too_long}`
+    * `{:error, :unavailable}` -- no radio on this machine
+    * whatever `VintageNet.configure/3` refuses with
+  """
+  @spec join(network() | map(), String.t(), keyword()) :: :ok | {:error, term()}
+  def join(network, passphrase, opts \\ []) do
+    with {:ok, entry} <- network_config(network, passphrase),
+         config when is_map(config) <- configuration(opts) do
+      Logger.info("[wifi] joining #{inspect(entry.ssid)} as #{entry.key_mgmt}")
+      configure(with_network(config, entry), opts)
+    else
+      {:error, reason} -> {:error, reason}
+      nil -> {:error, :unavailable}
+    end
+  end
+
+  @doc """
+  Make a network already in the configuration the preferred one.
+
+  What A does on a saved row: the passphrase is already there, so this is a
+  switch between two known networks rather than a join, and it must not
+  require retyping anything. The entry is carried across untouched -- whatever
+  it holds, including a PSK entered over SSH -- and only its position, and so
+  its priority, changes.
+  """
+  @spec prefer(String.t(), keyword()) :: :ok | {:error, term()}
+  def prefer(ssid, opts \\ []) do
+    case configuration(opts) do
+      config when is_map(config) ->
+        case Enum.find(networks_of(config), &(Map.get(&1, :ssid) == ssid)) do
+          nil ->
+            {:error, :not_saved}
+
+          entry ->
+            Logger.info("[wifi] preferring #{inspect(ssid)}")
+            configure(with_network(config, entry), opts)
+        end
+
+      _absent ->
+        {:error, :unavailable}
+    end
+  end
+
+  @doc """
+  Drop a network from the configuration.
+
+  Persisted, so it stays dropped across the power cut this device is switched
+  off by. Forgetting the network currently associated is allowed and
+  disconnects it -- that is what forgetting means, and refusing would leave
+  the one network nobody can remove being the one they are standing next to.
+  """
+  @spec forget(String.t(), keyword()) :: :ok | {:error, term()}
+  def forget(ssid, opts \\ []) do
+    case configuration(opts) do
+      config when is_map(config) ->
+        Logger.info("[wifi] forgetting #{inspect(ssid)}")
+        configure(without_network(config, ssid), opts)
+
+      _absent ->
+        {:error, :unavailable}
+    end
+  end
+
+  # -- the pure half, which is where the tests are ----------------------------
+
+  @doc """
+  Build the screen's rows from an access-point reading, the saved SSIDs, and
+  whatever is currently associated.
+
+  Access points arrive keyed by BSSID, so one network behind two radios --
+  a mesh, a repeater, a router doing 2.4 and 5 GHz under one name -- is two
+  entries. They collapse to one row on the strongest, because two rows with
+  the same name and different signal is a list nobody can act on.
+  """
+  @spec merge(map() | [map()], [String.t()], String.t() | nil) :: [network()]
+  def merge(access_points, saved, current) do
+    on_air =
+      access_points
+      |> points()
+      # A hidden network beacons an empty SSID. There is nothing to select
+      # and no way to type the real name in, so it is not a row.
+      |> Enum.reject(&(Map.get(&1, :ssid) in [nil, ""]))
+      |> Enum.group_by(&Map.get(&1, :ssid))
+      |> Enum.map(fn {ssid, points} -> strongest(ssid, points, saved, current) end)
+      |> Enum.sort_by(&{-(&1.signal || 0), &1.ssid})
+
+    absent =
+      saved
+      |> Enum.reject(fn ssid -> Enum.any?(on_air, &(&1.ssid == ssid)) end)
+      |> Enum.map(fn ssid ->
+        %{
+          ssid: ssid,
+          # Nothing is on the air to read flags from. The security a saved
+          # network was joined with is in the configuration, but it is the
+          # one field on this row nobody can act on -- the row exists to be
+          # forgotten -- so it is not guessed at.
+          security: :unknown,
+          signal: nil,
+          saved?: true,
+          connected?: ssid == current,
+          in_range?: false
+        }
+      end)
+      |> Enum.sort_by(& &1.ssid)
+
+    on_air ++ absent
+  end
+
+  @doc """
+  What an access point's flags say it wants.
+
+  Read in the order that decides it: enterprise before PSK, because an
+  enterprise AP also advertises the ciphers a PSK one does; SAE only when
+  PSK is absent, because a WPA2/WPA3 transitional AP advertises both and the
+  WPA2 path is the one this radio has actually associated over.
+  """
+  @spec security([atom()]) :: security()
+  def security(flags) do
+    flags = List.wrap(flags)
+
+    cond do
+      :eap in flags -> :eap
+      Enum.any?(flags, &eap_flag?/1) -> :eap
+      :sae in flags and not Enum.any?(flags, &psk_flag?/1) -> :sae
+      Enum.any?(flags, &psk_flag?/1) -> :wpa_psk
+      :wep in flags -> :wep
+      true -> :open
+    end
+  end
+
+  @doc "Whether A on this row can lead anywhere. See the moduledoc."
+  @spec joinable?(network() | map()) :: boolean()
+  def joinable?(%{security: security}), do: security not in [:eap, :wep, :unknown]
+  def joinable?(_network), do: false
+
+  @doc "Whether joining this row needs a passphrase picked first."
+  @spec needs_passphrase?(network() | map()) :: boolean()
+  def needs_passphrase?(%{security: security}), do: security in [:wpa_psk, :sae]
+  def needs_passphrase?(_network), do: false
+
+  @doc """
+  The `vintage_net_wifi` network entry for a row and a passphrase, or why
+  there is not one.
+
+  SAE takes the passphrase under `:psk` too -- `vintage_net_wifi` moves it to
+  `:sae_password` itself -- so the two secured paths differ only in
+  `:key_mgmt` and this function has one shape for both.
+  """
+  @spec network_config(network() | map(), String.t()) :: {:ok, map()} | {:error, atom()}
+  def network_config(network, passphrase)
+
+  def network_config(%{security: :eap}, _passphrase), do: {:error, :eap_unsupported}
+  def network_config(%{security: :wep}, _passphrase), do: {:error, :wep_unsupported}
+  def network_config(%{security: :unknown}, _passphrase), do: {:error, :unknown_security}
+
+  def network_config(%{ssid: ssid, security: :open}, _passphrase) when is_binary(ssid) do
+    {:ok, %{ssid: ssid, key_mgmt: :none}}
+  end
+
+  def network_config(%{ssid: ssid, security: security}, passphrase)
+      when is_binary(ssid) and security in [:wpa_psk, :sae] and is_binary(passphrase) do
+    case String.length(passphrase) do
+      length when length < @psk_min -> {:error, :passphrase_too_short}
+      length when length > @psk_max -> {:error, :passphrase_too_long}
+      _ok -> {:ok, %{ssid: ssid, key_mgmt: security, psk: passphrase}}
+    end
+  end
+
+  def network_config(_network, _passphrase), do: {:error, :not_a_network}
+
+  @doc """
+  Put a network at the head of a configuration's list, renumbering
+  priorities so the list order is the preference order.
+
+  Everything else in the configuration -- the type, the IPv4 method, any
+  root-level supplicant options -- is carried through untouched. This
+  function edits one list inside a map it does not otherwise understand,
+  which is what keeps a join from silently dropping a setting made over SSH.
+  """
+  @spec with_network(map(), map()) :: map()
+  def with_network(config, entry) do
+    kept = Enum.reject(networks_of(config), &(Map.get(&1, :ssid) == entry.ssid))
+    put_networks(config, prioritise([entry | kept]))
+  end
+
+  @doc "Take a network out of a configuration, renumbering what is left."
+  @spec without_network(map(), String.t()) :: map()
+  def without_network(config, ssid) do
+    kept = Enum.reject(networks_of(config), &(Map.get(&1, :ssid) == ssid))
+    put_networks(config, prioritise(kept))
+  end
+
+  @doc """
+  The networks in a configuration, whatever shape it is in.
+
+  A configuration with no WiFi section at all -- an interface configured as
+  something else, or a host's empty answer -- has no networks rather than
+  being an error, because both callers here go on to write a list into it
+  either way.
+  """
+  @spec networks_of(map() | nil) :: [map()]
+  def networks_of(%{vintage_net_wifi: %{networks: networks}}) when is_list(networks), do: networks
+  def networks_of(_config), do: []
+
+  @doc """
+  Whether a supplicant event says a passphrase was rejected for this SSID.
+
+  Two events mean it. `CTRL-EVENT-SSID-TEMP-DISABLED` carries
+  `reason: "WRONG_KEY"`, which is the supplicant saying so in as many words.
+  `CTRL-EVENT-ASSOC-REJECT` is broader -- a full AP and a MAC filter reject
+  too -- so it counts only against the SSID being joined, where it is the
+  overwhelmingly likely reading and the alternative is a screen that says
+  "connecting" until someone gives up.
+  """
+  @spec wrong_key?(map() | nil, String.t()) :: boolean()
+  def wrong_key?(event, ssid)
+
+  def wrong_key?(%{name: "CTRL-EVENT-SSID-TEMP-DISABLED"} = event, ssid) do
+    reason = to_string(Map.get(event, :reason) || "")
+    event_ssid = Map.get(event, :ssid)
+
+    String.upcase(reason) == "WRONG_KEY" and (event_ssid in [nil, ""] or event_ssid == ssid)
+  end
+
+  def wrong_key?(%{name: "CTRL-EVENT-ASSOC-REJECT"} = event, ssid) do
+    Map.get(event, :ssid) == ssid
+  end
+
+  def wrong_key?(_event, _ssid), do: false
+
+  @doc """
+  Whether a connection reading counts as being on the network just joined.
+
+  `:lan` rather than `:internet`, because association and a DHCP lease are
+  what a join is responsible for -- a router with no uplink is a successful
+  join and a separate problem, and a screen that called it a failure would
+  send someone to re-pick a passphrase that was right.
+  """
+  @spec joined?(connection(), String.t()) :: boolean()
+  def joined?(%{state: state, ssid: ssid}, target) do
+    state in [:lan, :internet] and (ssid == target or is_nil(ssid))
+  end
+
+  def joined?(_connection, _target), do: false
+
+  @doc "The passphrase length WPA-PSK accepts, as `{min, max}`."
+  @spec passphrase_bounds() :: {pos_integer(), pos_integer()}
+  def passphrase_bounds, do: {@psk_min, @psk_max}
+
+  # -- putting the two halves together ----------------------------------------
+
+  defp strongest(ssid, points, saved, current) do
+    point = Enum.max_by(points, &(Map.get(&1, :signal_percent) || 0))
+
+    %{
+      ssid: ssid,
+      security: security(Map.get(point, :flags)),
+      signal: Map.get(point, :signal_percent),
+      saved?: ssid in saved,
+      connected?: ssid == current,
+      in_range?: true
+    }
+  end
+
+  # The access-points property is a map keyed by BSSID. A list is accepted
+  # too, because that is the shape a test writes and neither this module nor
+  # the screen cares which it got.
+  defp points(access_points) when is_map(access_points), do: Map.values(access_points)
+  defp points(access_points) when is_list(access_points), do: access_points
+  defp points(_access_points), do: []
+
+  # Highest number wins in wpa_supplicant, so the head of the list gets the
+  # count and the tail gets 1.
+  defp prioritise(networks) do
+    count = length(networks)
+
+    networks
+    |> Enum.with_index()
+    |> Enum.map(fn {network, index} -> Map.put(network, :priority, count - index) end)
+  end
+
+  defp put_networks(config, networks) do
+    wifi = config |> Map.get(:vintage_net_wifi, %{}) |> Map.put(:networks, networks)
+    Map.put(config, :vintage_net_wifi, wifi)
+  end
+
+  defp psk_flag?(flag) do
+    flag == :psk or (is_atom(flag) and String.contains?(Atom.to_string(flag), "psk"))
+  end
+
+  defp eap_flag?(flag) do
+    flag == :eap or (is_atom(flag) and String.contains?(Atom.to_string(flag), "eap"))
+  end
+
+  defp configuration(opts) do
+    Keyword.get(opts, :configuration, &read_configuration/0).()
+  end
+
+  defp configure(config, opts) do
+    Keyword.get(opts, :configure, &write_configuration/1).(config)
+  end
+
+  # -- the VintageNet calls, and the one guard in front of all of them --------
+
+  # VintageNet is a target-only dependency, so on a development laptop the
+  # module is not there to call. The same test `MayonnaiOS.Status` makes, for
+  # the same reason: the screen renders "no radio" rather than the VM
+  # crashing on an undefined function.
+  defp vintage_net_loaded?, do: Code.ensure_loaded?(VintageNet)
+
+  defp do_scan do
+    if vintage_net_loaded?() do
+      apply(VintageNet, :scan, [@interface])
+    else
+      {:error, :unavailable}
+    end
+  rescue
+    error -> {:error, error}
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  defp do_subscribe do
+    if vintage_net_loaded?() do
+      apply(VintageNet, :subscribe, [["interface", @interface, "connection"]])
+      apply(VintageNet, :subscribe, [["interface", @interface, "wifi", "event"]])
+    end
+
+    :ok
+  rescue
+    error ->
+      Logger.warning("[wifi] subscribe failed: #{inspect(error)}")
+      :ok
+  catch
+    :exit, reason ->
+      Logger.warning("[wifi] subscribe failed: #{inspect(reason)}")
+      :ok
+  end
+
+  defp read_connection_state, do: property(["interface", @interface, "connection"])
+
+  defp read_access_points, do: property(["interface", @interface, "wifi", "access_points"]) || %{}
+
+  defp read_current_ssid do
+    case property(["interface", @interface, "wifi", "current_ap"]) do
+      %{ssid: ssid} when is_binary(ssid) and ssid != "" -> ssid
+      _absent -> nil
+    end
+  end
+
+  defp read_configuration do
+    if vintage_net_loaded?() do
+      apply(VintageNet, :get_configuration, [@interface])
+    end
+  rescue
+    # get_configuration/1 raises when the interface has no configuration at
+    # all, which on this device means vintage_net is up and wlan0 is not
+    # something it manages. Nothing to merge into, and nil is what the
+    # callers read as "no radio to configure".
+    _error -> nil
+  catch
+    :exit, _reason -> nil
+  end
+
+  defp write_configuration(config) do
+    if vintage_net_loaded?() do
+      # Persisted, which is the default and is the whole point: a network
+      # chosen on the panel has to survive the power being pulled.
+      apply(VintageNet, :configure, [@interface, config])
+    else
+      {:error, :unavailable}
+    end
+  rescue
+    error -> {:error, error}
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  # An ETS read of a table the vintage_net application owns, so it answers
+  # without a message -- but it is not there to read on a host, and it is
+  # gone for a moment if that application restarts.
+  defp property(path) do
+    if vintage_net_loaded?() do
+      apply(VintageNet, :get, [path])
+    end
+  rescue
+    _error -> nil
+  catch
+    :exit, _reason -> nil
+  end
+
+  # The kernel's own interface list, which works on a host too. The first
+  # non-loopback IPv4 on the WiFi interface; anything else on the machine is
+  # not what this screen is about.
+  defp read_address do
+    case :inet.getifaddrs() do
+      {:ok, interfaces} ->
+        Enum.find_value(interfaces, fn {name, props} ->
+          if List.to_string(name) == @interface, do: first_inet4(props)
+        end)
+
+      {:error, _reason} ->
+        nil
+    end
+  end
+
+  defp first_inet4(props) do
+    Enum.find_value(props, fn
+      {:addr, {a, _b, _c, _d} = addr} when a != 127 ->
+        addr |> :inet.ntoa() |> List.to_string()
+
+      _other ->
+        nil
+    end)
+  end
+end

--- a/lib/mayonnaios/wifi/app.ex
+++ b/lib/mayonnaios/wifi/app.ex
@@ -1,0 +1,596 @@
+defmodule MayonnaiOS.WiFi.App do
+  @moduledoc """
+  The System menu's **WiFi** row: what is on the air, what this device is
+  configured to join, and the buttons that change either.
+
+  An app rather than a program, on the same terms as `MayonnaiOS.Update.App`:
+  a module in this firmware, started in this VM, with a scene of its own and
+  no external process handed the screen. It takes no hardware away from
+  anything -- reading the radio is a property lookup and configuring it is a
+  message to `vintage_net` -- so unlike the two Bluetooth apps nothing stops
+  this one running whenever the row is picked.
+
+  ## The state machine
+
+      :listing   the list is up. The cursor moves, A picks
+      :editing   the passphrase wheel is up for the selected network
+      :joining   the configuration is written; waiting for the radio
+      :joined    associated, with an address
+      :failed    it did not work, and `:error` says what is known
+
+  ## The buttons
+
+      D-pad up/down   move the cursor
+      A               join the selected network -- straight away if it is
+                      open or already saved, through the passphrase wheel if
+                      it is secured and is not
+      X               change the passphrase of a saved network, which is the
+                      one repair a list of saved networks otherwise cannot
+                      make
+      Y               forget a saved network. Twice: the first press arms the
+                      row and the second does it
+      B               cancel the wheel, or the arming. Otherwise the
+                      launcher's, and it leaves
+      Menu            the launcher's, always
+
+  B is claimed dynamically -- see `claims_back?/0`. `MayonnaiOS.Launcher`
+  asks on every report, so the same button cancels an overlay while one is up
+  and leaves the app when none is.
+
+  ## Scanning is on a timer, and the list is read on another
+
+  `VintageNet.scan/1` is a request, not an answer: results appear on a
+  property a second or two later, and adapters vary enough that the advice in
+  `vintage_net`'s own docs is to ask again every ten seconds while somebody is
+  picking a network. So this process asks on one timer and re-reads the list
+  on a faster one, and neither waits for the other.
+
+  ## Waiting for a join, and the two ways it ends badly
+
+  Writing the configuration is where this app's work stops and
+  `wpa_supplicant`'s begins, so `:joining` is a wait on two subscriptions --
+  the connection state, and the supplicant's own events.
+
+  A rejected passphrase arrives as an event, and `MayonnaiOS.WiFi` explains
+  why that is worth waiting for rather than inferring from a clock: the
+  screen can say *the passphrase was refused* instead of *something did not
+  work*. That case also withdraws the network again, because a network known
+  to be wrong is one the supplicant keeps retrying over the top of the one
+  that works.
+
+  Everything else is the deadline, and a deadline expiring leaves the network
+  configured. DHCP on a tired router takes longer than any number worth
+  putting on a panel, and a join that completes thirty seconds after the
+  screen gave up is a join -- the status bar will say so.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias MayonnaiOS.WiFi
+  alias MayonnaiOS.WiFi.Editor
+
+  @sessions MayonnaiOS.WiFi.App.Sessions
+
+  # The buttons as printed on the shell. These atoms name the opposite
+  # button -- :btn_b is physical A -- and `MayonnaiOS.Launcher`'s moduledoc
+  # has the device tree that says so.
+  @a :btn_b
+  @b :btn_a
+  @x :btn_y
+  @y :btn_x
+  @l1 :btn_tl
+  @r1 :btn_tr
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @left :btn_dpad_left
+  @right :btn_dpad_right
+  @menu :btn_mode
+
+  # How often the list is re-read. Fast enough that a network appearing feels
+  # immediate, slow enough that it is not a scene rebuild per frame.
+  @refresh_ms 1_000
+
+  # How often a fresh scan is asked for. vintage_net's own guidance for a
+  # screen somebody is picking a network on.
+  @scan_ms 8_000
+
+  # How long `:joining` waits before calling it. Association takes a second
+  # or two and DHCP is the rest; thirty seconds is long enough that reaching
+  # it means something is wrong rather than slow.
+  @join_timeout_ms 30_000
+
+  # -- the app protocol the Launcher uses --------------------------------------
+
+  @doc """
+  Start the app. Idempotent: picking the row again while it is running shows
+  the same process rather than starting a second one.
+  """
+  @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(opts \\ []) do
+    case DynamicSupervisor.start_child(@sessions, {__MODULE__, opts}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Stop the app."
+  @spec stop() :: :ok
+  def stop do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(@sessions, pid)
+    end
+  end
+
+  @doc """
+  Forward an evdev report from the Launcher.
+
+  A call rather than a cast, so that a test which has just synthesised a
+  press can read the snapshot it produced -- the same reason
+  `MayonnaiOS.Pairing.Cursor.input/1` is one. Nothing here does I/O on the
+  radio that a person is waiting on: `join/3` and `forget/2` are a message to
+  `vintage_net` and a return.
+  """
+  @spec input([tuple()]) :: :ok
+  def input(events) do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, {:input, events}), else: :ok
+  end
+
+  @doc "The scene the launcher shows while this app has the buttons."
+  @spec scene() :: module()
+  def scene, do: MayonnaiOS.Scene.WiFi
+
+  @doc """
+  Whether B belongs to this app right now.
+
+  True while an overlay is up -- the passphrase wheel, or a row armed for
+  forgetting -- and false otherwise, so the one button cancels what is up and
+  then leaves. `MayonnaiOS.Launcher` asks on every report, which is what makes
+  a per-state answer work at all.
+  """
+  @spec claims_back?() :: boolean()
+  def claims_back? do
+    case snapshot() do
+      %{status: :editing} -> true
+      %{armed?: true} -> true
+      _otherwise -> false
+    end
+  end
+
+  @doc """
+  Be told when the state changes, as `{:wifi_app, snapshot}`.
+
+  Same arrangement as `MayonnaiOS.Update.App.watch/1`: the scene calls this
+  instead of polling, and the watcher is monitored so a scene torn down by
+  `set_root/3` drops itself.
+  """
+  @spec watch(pid()) :: map() | :stopped
+  def watch(pid) do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, {:watch, pid}), else: :stopped
+  end
+
+  @doc "Everything the panel needs, as one map. `:stopped` if not running."
+  @spec snapshot() :: map() | :stopped
+  def snapshot do
+    if Process.whereis(__MODULE__), do: GenServer.call(__MODULE__, :snapshot), else: :stopped
+  end
+
+  @doc "The DynamicSupervisor the app runs under, for the application tree."
+  @spec sessions() :: Supervisor.child_spec()
+  def sessions do
+    %{
+      id: @sessions,
+      start: {DynamicSupervisor, :start_link, [[name: @sessions, strategy: :one_for_one]]},
+      type: :supervisor
+    }
+  end
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      # Temporary, like the other app sessions: whatever went wrong is in the
+      # log, and a restart would land on a screen the user already left.
+      restart: :temporary
+    }
+  end
+
+  @doc false
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  # -- state ------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    wifi_opts = Keyword.get(opts, :wifi_opts, [])
+
+    state = %{
+      status: :listing,
+      networks: [],
+      connection: %{state: nil, ssid: nil, address: nil, error: nil},
+      cursor: 0,
+      editor: nil,
+      target: nil,
+      error: nil,
+      armed?: false,
+      available?: WiFi.available?(wifi_opts),
+      scan_error: nil,
+      deadline: nil,
+      wifi_opts: wifi_opts,
+      refresh_ms: Keyword.get(opts, :refresh_ms, @refresh_ms),
+      scan_ms: Keyword.get(opts, :scan_ms, @scan_ms),
+      join_timeout_ms: Keyword.get(opts, :join_timeout_ms, @join_timeout_ms),
+      watchers: []
+    }
+
+    WiFi.subscribe(wifi_opts)
+
+    state = state |> request_scan() |> reread()
+
+    schedule(:refresh, state.refresh_ms)
+    schedule(:rescan, state.scan_ms)
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:snapshot, _from, state), do: {:reply, snapshot_of(state), state}
+
+  def handle_call({:watch, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, snapshot_of(state), %{state | watchers: [pid | state.watchers]}}
+  end
+
+  def handle_call({:input, events}, _from, state) do
+    {:reply, :ok, state |> apply_events(events) |> notify(state)}
+  end
+
+  @impl GenServer
+  def handle_info(:refresh, state) do
+    schedule(:refresh, state.refresh_ms)
+    {:noreply, state |> reread() |> notify(state)}
+  end
+
+  def handle_info(:rescan, state) do
+    schedule(:rescan, state.scan_ms)
+    {:noreply, state |> request_scan() |> notify(state)}
+  end
+
+  # The join deadline. Only bites while still joining the network it was set
+  # for: a later join has its own, and one that already landed has none.
+  def handle_info({:join_deadline, ssid}, %{status: :joining, target: %{ssid: ssid}} = state) do
+    Logger.info("[wifi] gave up waiting for #{inspect(ssid)}")
+    state = %{state | status: :failed, error: :timed_out, deadline: nil}
+    {:noreply, notify(state, nil)}
+  end
+
+  def handle_info({:join_deadline, _ssid}, state), do: {:noreply, state}
+
+  # The connection state changed. Read as a fresh reading of the whole
+  # connection, because the SSID and the address move with it and reading one
+  # property out of three would put the screen half a step behind itself.
+  def handle_info({VintageNet, [_, _ifname, "connection"], _old, _new, _meta}, state) do
+    {:noreply, state |> reread() |> settle() |> notify(state)}
+  end
+
+  # A supplicant control event. The one this app acts on is a passphrase the
+  # access point refused; see `MayonnaiOS.WiFi.wrong_key?/2`.
+  def handle_info({VintageNet, [_, _ifname, "wifi", "event"], _old, event, _meta}, state) do
+    {:noreply, state |> event(event) |> notify(state)}
+  end
+
+  def handle_info({VintageNet, _property, _old, _new, _meta}, state), do: {:noreply, state}
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | watchers: List.delete(state.watchers, pid)}}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # -- reading the radio ------------------------------------------------------
+
+  defp reread(state) do
+    %{
+      state
+      | networks: WiFi.list(state.wifi_opts),
+        connection: WiFi.connection(state.wifi_opts)
+    }
+    |> settle()
+  end
+
+  defp request_scan(state) do
+    case WiFi.scan(state.wifi_opts) do
+      :ok -> %{state | scan_error: nil}
+      {:error, reason} -> %{state | scan_error: reason}
+    end
+  end
+
+  # A join is over when the radio says it is on the network. Checked wherever
+  # a fresh reading arrives rather than only on the subscription, because the
+  # connection property can settle between two messages and a screen that
+  # only believed the message would sit on "joining" next to a working
+  # network.
+  defp settle(%{status: :joining, target: %{ssid: ssid}} = state) do
+    if WiFi.joined?(state.connection, ssid) do
+      Logger.info("[wifi] joined #{inspect(ssid)}")
+      %{state | status: :joined, error: nil, deadline: nil}
+    else
+      state
+    end
+  end
+
+  defp settle(state), do: state
+
+  defp event(%{status: :joining, target: %{ssid: ssid}} = state, event) do
+    if WiFi.wrong_key?(event, ssid) do
+      Logger.info("[wifi] #{inspect(ssid)} refused the passphrase; withdrawing it")
+      WiFi.forget(ssid, state.wifi_opts)
+      %{state | status: :failed, error: :wrong_key, deadline: nil}
+    else
+      state
+    end
+  end
+
+  defp event(state, _event), do: state
+
+  # -- input ------------------------------------------------------------------
+
+  defp apply_events(state, events) do
+    Enum.reduce(events, state, fn
+      # Value 1 is a press. 2 is autorepeat and is dropped, as it is in the
+      # launcher and in `MayonnaiOS.Pairing.Cursor`: every press here is a
+      # scene rebuild, and holding a direction would queue one per repeat.
+      {:ev_key, key, 1}, acc -> press(acc, key)
+      _event, acc -> acc
+    end)
+  end
+
+  # Menu is the launcher's way out and never means anything here.
+  defp press(state, @menu), do: state
+
+  defp press(%{status: :editing} = state, key) do
+    case semantic(key) do
+      nil -> state
+      button -> edit(state, button)
+    end
+  end
+
+  # The two screens that are just a sentence and a way back. A returns to the
+  # list; B is claimed by nobody here, so it leaves the app.
+  defp press(%{status: status} = state, @a) when status in [:joined, :failed] do
+    %{state | status: :listing, error: nil, target: nil, armed?: false}
+  end
+
+  defp press(%{status: status} = state, _key) when status in [:joined, :failed, :joining] do
+    state
+  end
+
+  defp press(state, @up), do: move(state, -1)
+  defp press(state, @down), do: move(state, +1)
+  defp press(state, @a), do: activate(state)
+  defp press(state, @x), do: repass(state)
+  defp press(state, @y), do: forget(state)
+
+  # B while a row is armed takes the question down, and is swallowed rather
+  # than also leaving -- the browser's rule for its delete confirmation. With
+  # nothing armed `claims_back?/0` is false and this is never reached.
+  defp press(%{armed?: true} = state, @b), do: %{state | armed?: false}
+
+  defp press(state, _key), do: state
+
+  # Moving disarms. Anything else leaves the arming alone, because a
+  # confirmation cancelled by a button that does nothing else is a
+  # confirmation someone loses to a twitch.
+  defp move(state, delta) do
+    case length(state.networks) do
+      0 -> %{state | cursor: 0, armed?: false}
+      count -> %{state | cursor: Integer.mod(state.cursor + delta, count), armed?: false}
+    end
+  end
+
+  # A: join the selected network.
+  defp activate(state) do
+    case selected(state) do
+      nil ->
+        state
+
+      # Already on it. There is nothing for A to do and nothing for it to
+      # say; the footer offers Y.
+      %{connected?: true} ->
+        %{state | armed?: false}
+
+      # Saved already, so the passphrase is in the configuration and this is
+      # a switch rather than a join: move it to the head of the list and let
+      # the supplicant re-associate.
+      %{saved?: true} = network ->
+        start_join(state, network, fn -> WiFi.prefer(network.ssid, state.wifi_opts) end)
+
+      network ->
+        cond do
+          not WiFi.joinable?(network) ->
+            %{state | status: :failed, error: refusal(network), target: network}
+
+          WiFi.needs_passphrase?(network) ->
+            %{
+              state
+              | status: :editing,
+                editor: Editor.new(network.ssid),
+                target: network,
+                armed?: false
+            }
+
+          true ->
+            start_join(state, network, fn -> WiFi.join(network, "", state.wifi_opts) end)
+        end
+    end
+  end
+
+  # X: retype the passphrase of a saved network. The one repair the list
+  # cannot otherwise make -- a network saved with the wrong passphrase is
+  # otherwise a row that can only be forgotten and re-added.
+  defp repass(state) do
+    case selected(state) do
+      %{saved?: true, ssid: ssid} = network ->
+        if WiFi.needs_passphrase?(network) or network.security == :unknown do
+          # A saved network that is not on the air has no flags to classify,
+          # so it is treated as secured: retyping a passphrase for one that
+          # turns out to be open is refused by `WiFi.join/3` with a reason
+          # the screen prints, which is better than no way in at all.
+          %{
+            state
+            | status: :editing,
+              editor: Editor.new(ssid),
+              target: secured(network),
+              armed?: false
+          }
+        else
+          state
+        end
+
+      _otherwise ->
+        state
+    end
+  end
+
+  # Y, twice: the first press arms the row and the second forgets it.
+  defp forget(%{armed?: true} = state) do
+    case selected(state) do
+      %{saved?: true, ssid: ssid} ->
+        case WiFi.forget(ssid, state.wifi_opts) do
+          :ok ->
+            # The cursor stays where it is rather than following the row that
+            # has just gone: the list is one shorter, so what is under the
+            # cursor is what was below it, which is what a shrinking list
+            # does everywhere else in this UI.
+            %{state | armed?: false} |> reread()
+
+          {:error, reason} ->
+            %{state | armed?: false, status: :failed, error: {:forget_failed, reason}}
+        end
+
+      _otherwise ->
+        %{state | armed?: false}
+    end
+  end
+
+  defp forget(state) do
+    case selected(state) do
+      %{saved?: true} -> %{state | armed?: true}
+      _otherwise -> state
+    end
+  end
+
+  defp edit(state, button) do
+    case Editor.input(state.editor, button) do
+      {:editing, editor} ->
+        %{state | editor: editor}
+
+      :cancelled ->
+        %{state | status: :listing, editor: nil, target: nil}
+
+      {:done, passphrase} ->
+        target = state.target
+
+        start_join(%{state | editor: nil}, target, fn ->
+          WiFi.join(target, passphrase, state.wifi_opts)
+        end)
+    end
+  end
+
+  # Write the configuration and start waiting. A refusal is immediate and
+  # never enters `:joining`, so the screen never waits thirty seconds for
+  # something that was rejected before the radio was touched.
+  defp start_join(state, network, write) do
+    case write.() do
+      :ok ->
+        deadline =
+          Process.send_after(self(), {:join_deadline, network.ssid}, state.join_timeout_ms)
+
+        %{
+          state
+          | status: :joining,
+            target: network,
+            error: nil,
+            armed?: false,
+            deadline: deadline
+        }
+        # The radio may already be on this network -- re-preferring the one
+        # that is connected is a no-op to the supplicant -- so the state is
+        # settled once here rather than only when a property changes.
+        |> reread()
+
+      {:error, reason} ->
+        %{state | status: :failed, target: network, error: reason, armed?: false}
+    end
+  end
+
+  defp selected(%{networks: []}), do: nil
+
+  defp selected(%{networks: networks, cursor: cursor}) do
+    Enum.at(networks, Integer.mod(cursor, length(networks)))
+  end
+
+  # A saved network off the air carries no flags, so nothing can say which of
+  # the two secured schemes it wants. WPA-PSK is the one every home router
+  # this device will meet uses, and the wrong guess is a join that fails with
+  # a reason on the panel rather than a screen with no button.
+  defp secured(%{security: :unknown} = network), do: %{network | security: :wpa_psk}
+  defp secured(network), do: network
+
+  defp refusal(%{security: :eap}), do: :eap_unsupported
+  defp refusal(%{security: :wep}), do: :wep_unsupported
+  defp refusal(_network), do: :unknown_security
+
+  defp semantic(@up), do: :up
+  defp semantic(@down), do: :down
+  defp semantic(@left), do: :left
+  defp semantic(@right), do: :right
+  defp semantic(@l1), do: :l1
+  defp semantic(@r1), do: :r1
+  defp semantic(@a), do: :a
+  defp semantic(@b), do: :b
+  defp semantic(@x), do: :x
+  defp semantic(@y), do: :y
+  defp semantic(_key), do: nil
+
+  # -- the snapshot the scene draws -------------------------------------------
+
+  defp snapshot_of(state) do
+    %{
+      status: state.status,
+      networks: state.networks,
+      connection: state.connection,
+      # Bounded here rather than trusted: the list is re-read every second
+      # and a network that has gone off the air would otherwise leave the
+      # cursor pointing past the end.
+      cursor: bounded(state.cursor, length(state.networks)),
+      selected: selected(state),
+      editor: state.editor,
+      target: state.target,
+      error: state.error,
+      armed?: state.armed?,
+      available?: state.available?,
+      scan_error: state.scan_error,
+      passphrase_bounds: WiFi.passphrase_bounds()
+    }
+  end
+
+  defp bounded(_cursor, 0), do: 0
+  defp bounded(cursor, count), do: Integer.mod(cursor, count)
+
+  defp notify(state, previous) do
+    if previous != nil and snapshot_of(state) == snapshot_of(previous) do
+      state
+    else
+      snapshot = snapshot_of(state)
+      Enum.each(state.watchers, &send(&1, {:wifi_app, snapshot}))
+      state
+    end
+  end
+
+  defp schedule(message, after_ms), do: Process.send_after(self(), message, after_ms)
+end

--- a/lib/mayonnaios/wifi/editor.ex
+++ b/lib/mayonnaios/wifi/editor.ex
@@ -1,0 +1,223 @@
+defmodule MayonnaiOS.WiFi.Editor do
+  @moduledoc """
+  Typing a WiFi passphrase on a device with no keyboard: a character wheel
+  under a caret, moved with the D-pad.
+
+      left / right   move the caret
+      up / down      change the character under it
+      L1 / R1        jump to the next or previous block of characters
+      Y              remove the character under the caret
+      A              done
+      B              give up
+
+  The same picker `MayonnaiOS.Browser`'s rename editor is, and for the same
+  reason: the alternative is a settings screen that can only be reached over
+  SSH, which is a settings screen for the one situation -- no network -- it
+  exists to fix.
+
+  ## The alphabet is all of printable ASCII, and that is why L1 and R1 exist
+
+  A filename picker can get away with sixty-odd characters because the names
+  on this device are ROMs and directories. A passphrase cannot: it is
+  somebody else's string, chosen for a router, and `wpa_supplicant` takes any
+  of the 95 printable ASCII characters. An alphabet that quietly omitted `#`
+  would be a screen that cannot join a real network and does not say so.
+
+  Ninety-five characters is up to ninety-four presses of one direction, so
+  the wheel is ordered in four blocks -- lowercase, uppercase, digits,
+  symbols -- and the shoulder buttons jump between them. Getting to `Q` is
+  then R1 and a few presses of up rather than a held direction and a count.
+  Blocks are also why the order is not ASCII's: ASCII puts the symbols in
+  three separate runs around the digits and letters, which is four jumps to
+  cross what is conceptually one block.
+
+  ## The passphrase is shown, not masked
+
+  Nothing here is picked blind. Every character is chosen by cycling a wheel
+  that has to be read to be used, so a mask would hide the string from the
+  one person who is already looking at each character as it is chosen -- and
+  make a mistake made twenty presses ago unfindable. The device is in one
+  person's hands at arm's length; that is a different threat model from a
+  login box on a shared screen.
+
+  ## No process and no state of its own
+
+  A map and pure functions, like `MayonnaiOS.Browser`. `MayonnaiOS.WiFi.App`
+  holds one in its state, so the caret survives the scene being torn down and
+  rebuilt by `Scenic.ViewPort.set_root/3` -- which is the same reason the
+  browser's cursor does not live in a scene.
+  """
+
+  @lower String.graphemes("abcdefghijklmnopqrstuvwxyz")
+  @upper String.graphemes("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+  @digits String.graphemes("0123456789")
+  # Every printable ASCII character that is not a letter or a digit, space
+  # included -- a passphrase may contain one and there is no other way to
+  # enter it. Gathered into one block rather than left where ASCII puts them.
+  @symbols String.graphemes(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
+
+  @blocks [@lower, @upper, @digits, @symbols]
+  @alphabet Enum.concat(@blocks)
+
+  # Where each block starts in the concatenated wheel. Computed rather than
+  # written down, so adding a character to a block cannot put the jumps out
+  # of step with it.
+  @starts @blocks
+          |> Enum.scan(0, fn block, offset -> offset + length(block) end)
+          |> then(&[0 | Enum.drop(&1, -1)])
+
+  @typedoc "The editor: which network, the characters so far, and the caret."
+  @type t :: %{
+          ssid: String.t(),
+          chars: [String.t()],
+          caret: non_neg_integer()
+        }
+
+  @typedoc "What a press did."
+  @type outcome :: {:editing, t()} | {:done, String.t()} | :cancelled
+
+  @doc "A fresh editor for one network, empty, caret at the front."
+  @spec new(String.t()) :: t()
+  def new(ssid), do: %{ssid: ssid, chars: [], caret: 0}
+
+  @doc "Everything picked so far."
+  @spec value(t()) :: String.t()
+  def value(%{chars: chars}), do: Enum.join(chars)
+
+  @doc "How many characters have been picked."
+  @spec length(t()) :: non_neg_integer()
+  def length(%{chars: chars}), do: Kernel.length(chars)
+
+  @doc """
+  The character under the caret, or nil when the caret is past the end.
+
+  Nil is the state the caret starts in and the state it returns to at the
+  end of the string: there is a position there, and pressing up puts a
+  character in it.
+  """
+  @spec current(t()) :: String.t() | nil
+  def current(%{chars: chars, caret: caret}), do: Enum.at(chars, caret)
+
+  @doc "The whole wheel, in the order the shoulder buttons jump through."
+  @spec alphabet() :: [String.t()]
+  def alphabet, do: @alphabet
+
+  @doc """
+  Hand the editor one semantic button, as `MayonnaiOS.Launcher` names them.
+
+  Returns `{:done, passphrase}` on A -- whether or not the passphrase is long
+  enough, because the length rule belongs to `MayonnaiOS.WiFi` and a picker
+  that silently swallowed A would be a picker that looks broken. Everything
+  it has no use for leaves it alone.
+  """
+  @spec input(t(), atom()) :: outcome()
+  def input(editor, button)
+
+  def input(editor, :left), do: {:editing, move(editor, -1)}
+  def input(editor, :right), do: {:editing, move(editor, +1)}
+  def input(editor, :up), do: {:editing, step(editor, -1)}
+  def input(editor, :down), do: {:editing, step(editor, +1)}
+  def input(editor, :l1), do: {:editing, jump(editor, -1)}
+  def input(editor, :r1), do: {:editing, jump(editor, +1)}
+  def input(editor, :y), do: {:editing, drop(editor)}
+  def input(editor, :a), do: {:done, value(editor)}
+  def input(_editor, :b), do: :cancelled
+  def input(editor, _button), do: {:editing, editor}
+
+  @doc """
+  Move the caret, bounded rather than wrapping.
+
+  Bounded because the two ends mean something here: the front is where a
+  character was mistyped and the end is where the next one goes. A caret that
+  wrapped from the end to the front would send someone who pressed right once
+  too often back to the start of a passphrase they are in the middle of.
+  """
+  @spec move(t(), integer()) :: t()
+  def move(%{chars: chars, caret: caret} = editor, delta) do
+    %{editor | caret: caret |> Kernel.+(delta) |> max(0) |> min(Kernel.length(chars))}
+  end
+
+  @doc """
+  Change the character under the caret, wrapping around the wheel.
+
+  With the caret past the end this appends: the first press of a direction on
+  an empty passphrase puts a character there and leaves the caret on it, so
+  pressing up again steps that character rather than adding a second one.
+  """
+  @spec step(t(), integer()) :: t()
+  def step(%{chars: chars, caret: caret} = editor, delta) do
+    if caret >= Kernel.length(chars) do
+      %{editor | chars: chars ++ [next(nil, delta)]}
+    else
+      current = Enum.at(chars, caret)
+      %{editor | chars: List.replace_at(chars, caret, next(current, delta))}
+    end
+  end
+
+  @doc """
+  Jump the character under the caret to the head of the next or previous
+  block.
+
+  Past the end this appends the head of the first or last block, so the
+  shoulder buttons start a passphrase as readily as a direction does.
+  """
+  @spec jump(t(), integer()) :: t()
+  def jump(%{chars: chars, caret: caret} = editor, delta) do
+    if caret >= Kernel.length(chars) do
+      %{editor | chars: chars ++ [block_head(nil, delta)]}
+    else
+      current = Enum.at(chars, caret)
+      %{editor | chars: List.replace_at(chars, caret, block_head(current, delta))}
+    end
+  end
+
+  @doc """
+  Remove the character under the caret.
+
+  With the caret past the end it removes the last character, which is what
+  the button means to someone who has just added one too many and has not
+  moved.
+  """
+  @spec drop(t()) :: t()
+  def drop(%{chars: []} = editor), do: editor
+
+  def drop(%{chars: chars, caret: caret} = editor) do
+    at = min(caret, Kernel.length(chars) - 1)
+    chars = List.delete_at(chars, at)
+    %{editor | chars: chars, caret: min(at, Kernel.length(chars))}
+  end
+
+  # A character the wheel does not know about has no position to step from,
+  # so the first press replaces it with one end of the wheel rather than
+  # doing nothing at all.
+  defp next(current, delta) do
+    case Enum.find_index(@alphabet, &(&1 == current)) do
+      nil -> if delta < 0, do: List.last(@alphabet), else: hd(@alphabet)
+      index -> Enum.at(@alphabet, Integer.mod(index + delta, Kernel.length(@alphabet)))
+    end
+  end
+
+  # No character to jump from -- the caret is past the end, or on something
+  # the wheel does not know -- so the two directions take the two ends: R1
+  # starts at the first block, L1 at the last.
+  defp block_head(current, delta) when is_nil(current) or delta == 0 do
+    block_start(if delta < 0, do: Kernel.length(@starts) - 1, else: 0)
+  end
+
+  defp block_head(current, delta) do
+    case block_of(current) do
+      nil -> block_start(if delta < 0, do: Kernel.length(@starts) - 1, else: 0)
+      block -> block_start(Integer.mod(block + delta, Kernel.length(@starts)))
+    end
+  end
+
+  defp block_start(block), do: Enum.at(@alphabet, Enum.at(@starts, block))
+
+  # Which block a character is in, or nil for one that is not on the wheel.
+  defp block_of(current) do
+    case Enum.find_index(@alphabet, &(&1 == current)) do
+      nil -> nil
+      index -> @starts |> Enum.take_while(&(&1 <= index)) |> Kernel.length() |> Kernel.-(1)
+    end
+  end
+end

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -62,6 +62,7 @@ defmodule MayonnaiOS.BrowserTest do
         %{name: "RetroArch", path: "/nonexistent/retroarch"},
         %{name: "Bluetooth controller", app: MayonnaiOS.Controller, category: :apps},
         %{name: "Bluetooth devices", app: MayonnaiOS.Pairing},
+        %{name: "WiFi", app: MayonnaiOS.WiFi.App},
         %{name: "Paint", app: {MayonnaiOS.Pickles.App, "paint"}},
         %{name: "Power off", action: :poweroff}
       ])
@@ -92,6 +93,7 @@ defmodule MayonnaiOS.BrowserTest do
 
       assert names(system) == [
                "Bluetooth devices",
+               "WiFi",
                "Diagnostics",
                "Sleep",
                "Theme",
@@ -105,7 +107,7 @@ defmodule MayonnaiOS.BrowserTest do
       actions =
         for node <- List.last(system.levels).entries, do: node.program.action
 
-      assert actions == [nil, :diagnostics, :sleep, :cycle_theme, :poweroff]
+      assert actions == [nil, nil, :diagnostics, :sleep, :cycle_theme, :poweroff]
     end
   end
 

--- a/test/wifi/app_test.exs
+++ b/test/wifi/app_test.exs
@@ -1,0 +1,859 @@
+defmodule MayonnaiOS.WiFi.AppTest do
+  # Not async: the app is a named process.
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Scene.WiFi, as: Scene
+  alias MayonnaiOS.WiFi.App
+  alias MayonnaiOS.WiFi.Editor
+
+  # The buttons as printed on the shell; see MayonnaiOS.Launcher for the
+  # device tree that names them the other way round.
+  @a :btn_b
+  @b :btn_a
+  @x :btn_y
+  @y :btn_x
+  @up :btn_dpad_up
+  @down :btn_dpad_down
+  @right :btn_dpad_right
+  @menu :btn_mode
+
+  # A fake radio: an Agent holding what the property table would say and the
+  # configuration a write would land in. Everything `MayonnaiOS.WiFi` reads
+  # or writes is one of its injected functions, so this is the whole world
+  # the app can see -- and the saved networks come out of the same
+  # configuration a write goes into, which is what makes forgetting a row
+  # actually remove it here.
+  defp world(overrides) do
+    state =
+      Map.merge(
+        %{
+          access_points: [],
+          config: %{type: VintageNetWiFi, vintage_net_wifi: %{networks: []}, ipv4: %{}},
+          connection_state: :disconnected,
+          current_ssid: nil,
+          address: nil,
+          scan_result: :ok,
+          scans: 0
+        },
+        overrides
+      )
+
+    {:ok, agent} = Agent.start_link(fn -> state end)
+    agent
+  end
+
+  defp ap(ssid, opts \\ []) do
+    %{
+      bssid: "aa:bb:cc:dd:ee:0#{Keyword.get(opts, :n, 1)}",
+      ssid: ssid,
+      signal_percent: Keyword.get(opts, :signal, 60),
+      flags: Keyword.get(opts, :flags, [:psk, :ccmp, :wpa2])
+    }
+  end
+
+  defp network(ssid, extra \\ %{}), do: Map.merge(%{ssid: ssid, key_mgmt: :wpa_psk}, extra)
+
+  defp wifi_opts(agent) do
+    parent = self()
+
+    [
+      available?: fn -> true end,
+      subscribe: fn -> :ok end,
+      scan: fn ->
+        Agent.get_and_update(agent, fn s -> {s.scan_result, %{s | scans: s.scans + 1}} end)
+      end,
+      access_points: fn -> Agent.get(agent, & &1.access_points) end,
+      current_ssid: fn -> Agent.get(agent, & &1.current_ssid) end,
+      connection_state: fn -> Agent.get(agent, & &1.connection_state) end,
+      address: fn -> Agent.get(agent, & &1.address) end,
+      configuration: fn -> Agent.get(agent, & &1.config) end,
+      configure: fn config ->
+        Agent.update(agent, &%{&1 | config: config})
+        send(parent, {:configured, config})
+        :ok
+      end
+    ]
+  end
+
+  # Timers off unless a test asks for them: every transition here is driven
+  # by a press or a property message, and a refresh landing between the two
+  # would be a race in the test rather than in the app.
+  defp start(agent, opts \\ []) do
+    opts =
+      Keyword.merge(
+        [
+          wifi_opts: wifi_opts(agent),
+          refresh_ms: 60_000,
+          scan_ms: 60_000,
+          join_timeout_ms: 60_000
+        ],
+        opts
+      )
+
+    {:ok, pid} = App.start(opts)
+    on_exit(fn -> App.stop() end)
+    pid
+  end
+
+  defp press(key), do: App.input([{:ev_key, key, 1}])
+
+  defp ssids, do: Enum.map(App.snapshot().networks, & &1.ssid)
+
+  defp saved(agent) do
+    agent
+    |> Agent.get(& &1.config)
+    |> get_in([:vintage_net_wifi, :networks])
+    |> Enum.map(& &1.ssid)
+  end
+
+  # The property message vintage_net sends. `VintageNet` is a target-only
+  # module, but in a pattern and in a tuple it is just an atom, so a host
+  # test can produce the real message.
+  defp connection_changed(state, ssid \\ nil) do
+    send(App, {VintageNet, ["interface", "wlan0", "connection"], :disconnected, state, %{}})
+    _ = ssid
+    :ok
+  end
+
+  defp supplicant_event(event) do
+    send(App, {VintageNet, ["interface", "wlan0", "wifi", "event"], nil, event, %{}})
+    :ok
+  end
+
+  describe "opening the screen" do
+    test "lists what is on the air, strongest first, and asks for a scan" do
+      agent =
+        world(%{
+          access_points: [ap("shed", signal: 20, n: 1), ap("kitchen", signal: 90, n: 2)]
+        })
+
+      start(agent)
+
+      assert ssids() == ["kitchen", "shed"]
+      assert Agent.get(agent, & &1.scans) == 1
+    end
+
+    test "reads where the radio already is" do
+      agent =
+        world(%{
+          access_points: [ap("kitchen")],
+          connection_state: :internet,
+          current_ssid: "kitchen",
+          address: "192.168.1.42"
+        })
+
+      start(agent)
+
+      snapshot = App.snapshot()
+
+      assert snapshot.connection == %{
+               state: :internet,
+               ssid: "kitchen",
+               address: "192.168.1.42",
+               error: nil
+             }
+
+      assert [%{ssid: "kitchen", connected?: true}] = snapshot.networks
+    end
+
+    test "a saved network out of range is a row that can still be forgotten" do
+      agent =
+        world(%{
+          access_points: [ap("kitchen")],
+          config: %{vintage_net_wifi: %{networks: [network("away")]}}
+        })
+
+      start(agent)
+
+      assert ssids() == ["kitchen", "away"]
+      assert %{in_range?: false, saved?: true} = Enum.at(App.snapshot().networks, 1)
+    end
+
+    test "a scan that will not start says so instead of looking empty" do
+      agent = world(%{scan_result: {:error, :enodev}})
+      start(agent)
+
+      assert App.snapshot().scan_error == :enodev
+      assert Enum.any?(texts(Scene.graph(App.snapshot())), &(&1 =~ "did not start"))
+    end
+  end
+
+  describe "the cursor" do
+    setup do
+      agent =
+        world(%{
+          access_points: [
+            ap("a", signal: 90, n: 1),
+            ap("b", signal: 50, n: 2),
+            ap("c", signal: 10, n: 3)
+          ]
+        })
+
+      start(agent)
+      %{agent: agent}
+    end
+
+    test "moves down and wraps" do
+      assert App.snapshot().cursor == 0
+
+      press(@down)
+      assert App.snapshot().cursor == 1
+
+      press(@down)
+      press(@down)
+      assert App.snapshot().cursor == 0
+    end
+
+    test "moves up from the top to the bottom" do
+      press(@up)
+      assert App.snapshot().cursor == 2
+      assert App.snapshot().selected.ssid == "c"
+    end
+
+    test "Menu never means anything here -- it is the launcher's way out" do
+      press(@menu)
+      assert App.snapshot().cursor == 0
+    end
+  end
+
+  describe "joining an open network" do
+    test "A joins it with no passphrase asked for" do
+      agent = world(%{access_points: [ap("cafe", flags: [:ess])]})
+      start(agent)
+
+      assert App.snapshot().selected.security == :open
+
+      press(@a)
+
+      assert_received {:configured, _config}
+      assert saved(agent) == ["cafe"]
+      assert App.snapshot().status == :joining
+    end
+  end
+
+  describe "joining a secured network" do
+    setup do
+      agent = world(%{access_points: [ap("kitchen")]})
+      start(agent)
+      %{agent: agent}
+    end
+
+    test "A opens the passphrase wheel rather than joining" do
+      press(@a)
+
+      snapshot = App.snapshot()
+
+      assert snapshot.status == :editing
+      assert snapshot.editor.ssid == "kitchen"
+      refute_received {:configured, _config}
+    end
+
+    test "the wheel types, and A joins with what was typed" do
+      press(@a)
+
+      # a, right, b -- the wheel adds a character when the caret moves, so
+      # this is "ab" and then enough more to clear WPA's eight.
+      for _n <- 1..1, do: press(@down)
+      press(@right)
+      for _n <- 1..2, do: press(@down)
+
+      assert Editor.value(App.snapshot().editor) == "ab"
+
+      # Still too short, so A comes back with a reason rather than a write.
+      press(@a)
+      assert App.snapshot().status == :failed
+      assert App.snapshot().error == :passphrase_too_short
+      refute_received {:configured, _config}
+    end
+
+    test "a passphrase long enough is written, and the wheel is gone" do
+      press(@a)
+      type("hunter2!!")
+      press(@a)
+
+      assert_received {:configured, config}
+
+      assert [%{ssid: "kitchen", psk: "hunter2!!", key_mgmt: :wpa_psk}] =
+               get_in(config, [:vintage_net_wifi, :networks])
+
+      assert App.snapshot().status == :joining
+      assert App.snapshot().editor == nil
+    end
+
+    test "B cancels the wheel and writes nothing" do
+      press(@a)
+      type("hunter2!!")
+      press(@b)
+
+      snapshot = App.snapshot()
+
+      assert snapshot.status == :listing
+      assert snapshot.editor == nil
+      refute_received {:configured, _config}
+    end
+
+    test "while the wheel is up B belongs to this app, and otherwise it does not" do
+      # `MayonnaiOS.Launcher` asks on every report, so the same button
+      # cancels the overlay and then leaves.
+      refute App.claims_back?()
+
+      press(@a)
+      assert App.claims_back?()
+
+      press(@b)
+      refute App.claims_back?()
+    end
+  end
+
+  describe "a network already saved" do
+    setup do
+      agent =
+        world(%{
+          access_points: [ap("kitchen", signal: 80, n: 1), ap("shed", signal: 30, n: 2)],
+          config: %{
+            vintage_net_wifi: %{
+              networks: [network("shed", %{psk: "shedpass"}), network("kitchen", %{psk: "kit"})]
+            }
+          }
+        })
+
+      start(agent)
+      %{agent: agent}
+    end
+
+    test "A switches to it without asking for the passphrase again" do
+      press(@down)
+      assert App.snapshot().selected.ssid == "shed"
+
+      press(@a)
+
+      assert_received {:configured, config}
+      networks = get_in(config, [:vintage_net_wifi, :networks])
+
+      # Moved to the head, and its passphrase carried across untouched.
+      assert Enum.map(networks, & &1.ssid) == ["shed", "kitchen"]
+      assert hd(networks).psk == "shedpass"
+      assert App.snapshot().status == :joining
+    end
+
+    test "X retypes the passphrase, which is the one repair the list cannot otherwise make" do
+      press(@x)
+
+      assert App.snapshot().status == :editing
+      assert App.snapshot().editor.ssid == "kitchen"
+
+      type("newpassphrase")
+      press(@a)
+
+      assert_received {:configured, config}
+      networks = get_in(config, [:vintage_net_wifi, :networks])
+
+      assert hd(networks) == %{
+               ssid: "kitchen",
+               key_mgmt: :wpa_psk,
+               psk: "newpassphrase",
+               priority: 2
+             }
+    end
+  end
+
+  describe "the connected network" do
+    test "A does nothing, because there is nothing for it to do" do
+      agent =
+        world(%{
+          access_points: [ap("kitchen")],
+          config: %{vintage_net_wifi: %{networks: [network("kitchen")]}},
+          connection_state: :internet,
+          current_ssid: "kitchen"
+        })
+
+      start(agent)
+
+      assert App.snapshot().selected.connected?
+
+      press(@a)
+
+      refute_received {:configured, _config}
+      assert App.snapshot().status == :listing
+    end
+  end
+
+  describe "forgetting a network" do
+    setup do
+      agent =
+        world(%{
+          access_points: [ap("kitchen")],
+          config: %{vintage_net_wifi: %{networks: [network("kitchen")]}}
+        })
+
+      start(agent)
+      %{agent: agent}
+    end
+
+    test "Y twice: the first arms the row and the second does it", %{agent: agent} do
+      press(@y)
+      assert App.snapshot().armed?
+
+      press(@y)
+
+      refute App.snapshot().armed?
+      assert saved(agent) == []
+      # The row is still on the air, so it stays -- it is just no longer
+      # saved.
+      assert [%{ssid: "kitchen", saved?: false}] = App.snapshot().networks
+    end
+
+    test "moving the cursor disarms" do
+      press(@y)
+      assert App.snapshot().armed?
+
+      press(@down)
+      refute App.snapshot().armed?
+    end
+
+    test "B while armed takes the question down and does not also leave" do
+      press(@y)
+      assert App.claims_back?()
+
+      press(@b)
+
+      refute App.snapshot().armed?
+      refute App.claims_back?()
+    end
+
+    test "Y on a network that is not saved is not a question" do
+      press(@y)
+      press(@y)
+
+      # Now unsaved: pressing Y again arms nothing.
+      press(@y)
+      refute App.snapshot().armed?
+    end
+  end
+
+  describe "the kinds this screen refuses" do
+    test "an enterprise network says what it would need instead of taking a passphrase" do
+      agent = world(%{access_points: [ap("corp", flags: [:eap, :ccmp, :wpa2])]})
+      start(agent)
+
+      press(@a)
+
+      assert App.snapshot().status == :failed
+      assert App.snapshot().error == :eap_unsupported
+      refute_received {:configured, _config}
+    end
+
+    test "a WEP network the same" do
+      agent = world(%{access_points: [ap("old", flags: [:wep])]})
+      start(agent)
+
+      press(@a)
+
+      assert App.snapshot().error == :wep_unsupported
+      refute_received {:configured, _config}
+    end
+  end
+
+  describe "waiting for the radio" do
+    setup do
+      agent = world(%{access_points: [ap("kitchen")]})
+      start(agent)
+
+      press(@a)
+      type("hunter2!!")
+      press(@a)
+
+      assert_received {:configured, _config}
+      assert App.snapshot().status == :joining
+
+      %{agent: agent}
+    end
+
+    test "a lease on the network just joined finishes it", %{agent: agent} do
+      Agent.update(agent, fn s ->
+        %{s | connection_state: :lan, current_ssid: "kitchen", address: "192.168.1.42"}
+      end)
+
+      connection_changed(:lan)
+
+      assert App.snapshot().status == :joined
+      assert App.snapshot().connection.address == "192.168.1.42"
+    end
+
+    test "a lease on a different network does not", %{agent: agent} do
+      # The old network coming back is not the new one working.
+      Agent.update(agent, fn s -> %{s | connection_state: :lan, current_ssid: "workbench"} end)
+
+      connection_changed(:lan)
+
+      assert App.snapshot().status == :joining
+    end
+
+    test "the access point refusing the passphrase says so, and withdraws it", %{agent: agent} do
+      supplicant_event(%{
+        name: "CTRL-EVENT-SSID-TEMP-DISABLED",
+        ssid: "kitchen",
+        reason: "WRONG_KEY",
+        auth_failures: 1
+      })
+
+      assert App.snapshot().status == :failed
+      assert App.snapshot().error == :wrong_key
+
+      # A network known to be wrong is one the supplicant keeps retrying over
+      # the top of the one that works, so it does not stay configured.
+      assert saved(agent) == []
+    end
+
+    test "an unrelated supplicant event is not a verdict" do
+      supplicant_event(%{name: "CTRL-EVENT-CONNECTED"})
+
+      assert App.snapshot().status == :joining
+    end
+
+    test "A on the page after a join goes back to the list", %{agent: agent} do
+      Agent.update(agent, fn s -> %{s | connection_state: :lan, current_ssid: "kitchen"} end)
+      connection_changed(:lan)
+
+      assert App.snapshot().status == :joined
+
+      press(@a)
+
+      assert App.snapshot().status == :listing
+      assert App.snapshot().error == nil
+    end
+  end
+
+  describe "the join deadline" do
+    test "gives up, and leaves the network configured" do
+      agent = world(%{access_points: [ap("kitchen")]})
+      start(agent, join_timeout_ms: 20)
+
+      press(@a)
+      type("hunter2!!")
+      press(@a)
+
+      assert App.snapshot().status == :joining
+
+      # DHCP on a tired router outlasts any deadline worth putting on a
+      # panel, so a deadline reached is not a reason to undo anything.
+      assert eventually(fn -> App.snapshot().status == :failed end)
+      assert App.snapshot().error == :timed_out
+      assert saved(agent) == ["kitchen"]
+    end
+  end
+
+  describe "watch/1" do
+    test "pushes a snapshot when something changes" do
+      agent = world(%{access_points: [ap("a", n: 1), ap("b", n: 2)]})
+      start(agent)
+
+      assert %{status: :listing} = App.watch(self())
+
+      press(@down)
+
+      assert_receive {:wifi_app, %{cursor: 1}}, 1_000
+    end
+
+    test "is :stopped when the app is not running" do
+      assert App.watch(self()) == :stopped
+      assert App.snapshot() == :stopped
+      refute App.claims_back?()
+    end
+  end
+
+  describe "the scene" do
+    # graph/1 is the tested surface: no viewport, no driver, no framebuffer.
+    # The same helper the other scene tests use.
+    defp texts(graph) do
+      Scenic.Graph.reduce(graph, [], fn
+        %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+        _primitive, acc -> acc
+      end)
+    end
+
+    defp snapshot(overrides) do
+      Map.merge(
+        %{
+          status: :listing,
+          networks: [],
+          connection: %{state: :disconnected, ssid: nil, address: nil, error: nil},
+          cursor: 0,
+          selected: nil,
+          editor: nil,
+          target: nil,
+          error: nil,
+          armed?: false,
+          available?: true,
+          scan_error: nil,
+          passphrase_bounds: {8, 63}
+        },
+        overrides
+      )
+    end
+
+    defp row(ssid, overrides \\ %{}) do
+      Map.merge(
+        %{
+          ssid: ssid,
+          security: :wpa_psk,
+          signal: 70,
+          saved?: false,
+          connected?: false,
+          in_range?: true
+        },
+        overrides
+      )
+    end
+
+    test "not running" do
+      assert Enum.member?(texts(Scene.graph(:stopped)), "Not running")
+    end
+
+    test "nothing draws above the shared top bar" do
+      assert Scene.status_bar() > 0
+    end
+
+    test "an empty list says it is scanning rather than looking broken" do
+      assert Enum.any?(texts(Scene.graph(snapshot(%{}))), &(&1 =~ "Scanning"))
+    end
+
+    test "a machine with no radio says so" do
+      texts = texts(Scene.graph(snapshot(%{available?: false})))
+
+      assert Enum.any?(texts, &(&1 =~ "No WiFi radio"))
+      assert Enum.any?(texts, &(&1 =~ "target-only"))
+    end
+
+    test "the connection line names the network and the address" do
+      texts =
+        texts(
+          Scene.graph(
+            snapshot(%{
+              connection: %{
+                state: :internet,
+                ssid: "kitchen",
+                address: "192.168.1.42",
+                error: nil
+              }
+            })
+          )
+        )
+
+      assert Enum.any?(texts, &(&1 =~ "kitchen" and &1 =~ "192.168.1.42"))
+    end
+
+    test "a lan-only connection is not drawn as a failure" do
+      texts =
+        texts(
+          Scene.graph(
+            snapshot(%{
+              connection: %{state: :lan, ssid: "kitchen", address: "10.0.0.5", error: nil}
+            })
+          )
+        )
+
+      assert Enum.any?(texts, &(&1 =~ "no route to the internet"))
+    end
+
+    test "a row carries its signal, its security and whether it is known" do
+      networks = [row("kitchen", %{saved?: true, signal: 84})]
+      texts = texts(Scene.graph(snapshot(%{networks: networks, selected: hd(networks)})))
+
+      assert Enum.member?(texts, "kitchen")
+      assert Enum.any?(texts, &(&1 =~ "84%" and &1 =~ "WPA2" and &1 =~ "saved"))
+    end
+
+    test "an enterprise row says what it would need where the others say how to join" do
+      networks = [row("corp", %{security: :eap})]
+      texts = texts(Scene.graph(snapshot(%{networks: networks, selected: hd(networks)})))
+
+      assert Enum.any?(texts, &(&1 =~ "identity and a certificate"))
+      assert Enum.any?(texts, &(&1 =~ "cannot be joined from here"))
+    end
+
+    test "an armed row shouts, because the next press is the one that does it" do
+      networks = [row("kitchen", %{saved?: true})]
+
+      texts =
+        texts(Scene.graph(snapshot(%{networks: networks, selected: hd(networks), armed?: true})))
+
+      assert Enum.any?(texts, &(&1 =~ "press Y again to forget"))
+      assert Enum.any?(texts, &(&1 =~ "Y forgets this network"))
+    end
+
+    test "the footer offers what the selected row can actually do" do
+      open = [row("cafe", %{security: :open})]
+      saved = [row("kitchen", %{saved?: true})]
+
+      assert Enum.any?(
+               texts(Scene.graph(snapshot(%{networks: open, selected: hd(open)}))),
+               &(&1 =~ "A joins this open network")
+             )
+
+      assert Enum.any?(
+               texts(Scene.graph(snapshot(%{networks: saved, selected: hd(saved)}))),
+               &(&1 =~ "X retypes the passphrase")
+             )
+    end
+
+    test "the wheel shows the passphrase, the length rule and where the caret is" do
+      editor = Editor.new("kitchen")
+      editor = %{editor | chars: String.graphemes("hunter2"), caret: 3}
+
+      texts = texts(Scene.graph(snapshot(%{status: :editing, editor: editor})))
+
+      assert Enum.member?(texts, "hunter2")
+      assert Enum.any?(texts, &(&1 =~ "Passphrase for" and &1 =~ "kitchen"))
+      # Seven characters, so the rule is worth saying out loud.
+      assert Enum.any?(texts, &(&1 =~ "7 characters" and &1 =~ "8 to 63"))
+      assert Enum.any?(texts, &(&1 =~ "Under the caret"))
+      assert Enum.any?(texts, &(&1 =~ "L1/R1 jump blocks"))
+    end
+
+    test "an empty wheel prompts rather than drawing a bare caret" do
+      texts = texts(Scene.graph(snapshot(%{status: :editing, editor: Editor.new("kitchen")})))
+
+      assert Enum.any?(texts, &(&1 =~ "press up or down to start"))
+    end
+
+    test "a full-length passphrase wraps onto a second line" do
+      editor = %{Editor.new("k") | chars: String.graphemes(String.duplicate("a", 63)), caret: 63}
+
+      texts = texts(Scene.graph(snapshot(%{status: :editing, editor: editor})))
+      lines = Enum.filter(texts, &(&1 =~ ~r/^a+$/))
+
+      assert length(lines) == 2
+      assert Enum.map(lines, &String.length/1) |> Enum.sum() == 63
+    end
+
+    test "joining says what it is waiting for and that nothing was lost" do
+      texts =
+        texts(Scene.graph(snapshot(%{status: :joining, target: row("kitchen")})))
+
+      assert Enum.any?(texts, &(&1 =~ "Joining" and &1 =~ "kitchen"))
+      assert Enum.any?(texts, &(&1 =~ "untouched"))
+    end
+
+    test "joined names the network and the address it was given" do
+      texts =
+        texts(
+          Scene.graph(
+            snapshot(%{
+              status: :joined,
+              target: row("kitchen"),
+              connection: %{state: :lan, ssid: "kitchen", address: "10.0.0.9", error: nil}
+            })
+          )
+        )
+
+      assert Enum.any?(texts, &(&1 =~ "Joined" and &1 =~ "kitchen"))
+      assert Enum.any?(texts, &(&1 =~ "10.0.0.9"))
+      assert Enum.any?(texts, &(&1 =~ "power cut"))
+    end
+
+    test "a refused passphrase says so, and says what was not changed" do
+      texts =
+        texts(
+          Scene.graph(snapshot(%{status: :failed, error: :wrong_key, target: row("kitchen")}))
+        )
+
+      assert Enum.any?(texts, &(&1 =~ "passphrase was refused"))
+      assert Enum.any?(texts, &(&1 =~ "removed again"))
+      assert Enum.any?(texts, &(&1 =~ "Nothing else changed"))
+    end
+
+    test "a deadline reached is not the same sentence as a refusal" do
+      texts =
+        texts(
+          Scene.graph(snapshot(%{status: :failed, error: :timed_out, target: row("kitchen")}))
+        )
+
+      assert Enum.any?(texts, &(&1 =~ "No answer"))
+      assert Enum.any?(texts, &(&1 =~ "still configured"))
+    end
+
+    test "every error the app can produce has words rather than a term" do
+      for error <- [
+            :wrong_key,
+            :timed_out,
+            :passphrase_too_short,
+            :passphrase_too_long,
+            :eap_unsupported,
+            :wep_unsupported,
+            :unavailable,
+            :not_saved,
+            {:forget_failed, :eacces},
+            :something_new
+          ] do
+        texts = texts(Scene.graph(snapshot(%{status: :failed, error: error})))
+
+        assert length(texts) > 3, "no page for #{inspect(error)}"
+      end
+    end
+
+    test "an SSID at its maximum length does not run off the panel" do
+      long = String.duplicate("x", 60)
+      networks = [row(long)]
+
+      texts = texts(Scene.graph(snapshot(%{networks: networks, selected: hd(networks)})))
+
+      assert Enum.any?(texts, &(String.length(&1) <= 46 and &1 =~ "xxx"))
+    end
+
+    test "more rows than fit says which of them are showing" do
+      networks = for n <- 1..20, do: row("network-#{n}")
+
+      texts =
+        texts(Scene.graph(snapshot(%{networks: networks, cursor: 0, selected: hd(networks)})))
+
+      assert Enum.any?(texts, &(&1 =~ "of 20"))
+      assert Scene.visible() < 20
+    end
+
+    test "a cursor past the last visible row brings the window with it" do
+      networks = for n <- 1..20, do: row("network-#{n}")
+      last = List.last(networks)
+
+      texts =
+        texts(Scene.graph(snapshot(%{networks: networks, cursor: 19, selected: last})))
+
+      assert Enum.member?(texts, "network-20")
+      refute Enum.member?(texts, "network-1")
+    end
+  end
+
+  # -- helpers ----------------------------------------------------------------
+
+  # Type a passphrase on the wheel through the app, the way somebody would:
+  # cycle to a character, move the caret right, cycle to the next.
+  defp type(string) do
+    string
+    |> String.graphemes()
+    |> Enum.each(fn char ->
+      wheel_to(char)
+      press(@right)
+    end)
+  end
+
+  defp wheel_to(char) do
+    press(@down)
+
+    Enum.reduce_while(1..95, nil, fn _n, _acc ->
+      if Editor.current(App.snapshot().editor) == char do
+        {:halt, :ok}
+      else
+        press(@down)
+        {:cont, nil}
+      end
+    end)
+  end
+
+  defp eventually(check, tries \\ 200) do
+    cond do
+      check.() -> true
+      tries > 0 -> Process.sleep(5) && eventually(check, tries - 1)
+      true -> false
+    end
+  end
+end

--- a/test/wifi/editor_test.exs
+++ b/test/wifi/editor_test.exs
@@ -1,0 +1,254 @@
+defmodule MayonnaiOS.WiFi.EditorTest do
+  # Async: a map and pure functions, no process and no globals.
+  use ExUnit.Case, async: true
+
+  alias MayonnaiOS.WiFi.Editor
+
+  defp press(editor, button) do
+    {:editing, editor} = Editor.input(editor, button)
+    editor
+  end
+
+  defp pressed(editor, buttons), do: Enum.reduce(buttons, editor, &press(&2, &1))
+
+  # Type a string the way somebody holding the device would: cycle the wheel
+  # to a character, move the caret right, cycle to the next. Moving is the
+  # part that adds a position -- see the test below that pins that down --
+  # so a helper that only pressed a direction would type one character and
+  # spin it.
+  defp type(editor, string) do
+    string
+    |> String.graphemes()
+    |> Enum.reduce(editor, fn char, acc -> acc |> wheel_to(char) |> press(:right) end)
+  end
+
+  defp wheel_to(editor, char) do
+    Enum.reduce_while(1..length(Editor.alphabet()), press(editor, :down), fn _n, acc ->
+      if Editor.current(acc) == char, do: {:halt, acc}, else: {:cont, press(acc, :down)}
+    end)
+  end
+
+  describe "the wheel" do
+    test "is every printable ASCII character, exactly once" do
+      # A passphrase is somebody else's string, chosen for a router. An
+      # alphabet quietly missing `#` is a screen that cannot join a real
+      # network and does not say so.
+      wheel = MapSet.new(Editor.alphabet())
+      printable = MapSet.new(for code <- 32..126, do: <<code>>)
+
+      assert wheel == printable
+      assert length(Editor.alphabet()) == 95
+      assert length(Enum.uniq(Editor.alphabet())) == 95
+    end
+
+    test "starts at the lowercase letters, which is what a passphrase mostly is" do
+      assert hd(Editor.alphabet()) == "a"
+    end
+  end
+
+  describe "new/1" do
+    test "is empty, with the caret at the front" do
+      editor = Editor.new("kitchen")
+
+      assert editor.ssid == "kitchen"
+      assert Editor.value(editor) == ""
+      assert Editor.length(editor) == 0
+      assert editor.caret == 0
+      assert Editor.current(editor) == nil
+    end
+  end
+
+  describe "step/2" do
+    test "the first press past the end adds a character and leaves the caret on it" do
+      editor = Editor.step(Editor.new("x"), +1)
+
+      assert Editor.value(editor) == "a"
+      assert editor.caret == 0
+    end
+
+    test "pressing the same direction again steps that character rather than adding one" do
+      # The property the typing helper above is built around, and the
+      # browser's rename editor behaves the same way: a position is added by
+      # moving the caret, not by picking another character.
+      editor = pressed(Editor.new("x"), [:down, :down, :down])
+
+      assert Editor.value(editor) == "c"
+      assert Editor.length(editor) == 1
+    end
+
+    test "the other direction starts at the far end of the wheel" do
+      assert Editor.value(Editor.step(Editor.new("x"), -1)) == "~"
+    end
+
+    test "wraps around the wheel rather than stopping at either end" do
+      editor = Editor.new("x") |> Editor.step(+1) |> Editor.step(-1)
+
+      assert Editor.value(editor) == "~"
+    end
+
+    test "changes the character under the caret, not the last one" do
+      editor = Editor.new("x") |> type("abc") |> Editor.move(-3)
+
+      assert Editor.value(editor) == "abc"
+      assert Editor.value(Editor.step(editor, +1)) == "bbc"
+    end
+  end
+
+  describe "move/2" do
+    test "is bounded rather than wrapping" do
+      # The two ends mean something: the front is where a character was
+      # mistyped and the end is where the next one goes. A caret that wrapped
+      # would send someone who pressed right once too often back to the start
+      # of a passphrase they are in the middle of.
+      editor = Editor.new("x") |> type("ab")
+
+      assert Editor.move(editor, -5).caret == 0
+      assert Editor.move(editor, +5).caret == 2
+    end
+
+    test "the caret may sit one past the last character" do
+      editor = Editor.new("x") |> type("a")
+
+      assert editor.caret == 1
+      assert Editor.current(editor) == nil
+    end
+  end
+
+  describe "jump/2" do
+    test "moves the character under the caret to the head of the next block" do
+      editor = Editor.new("x") |> Editor.jump(+1)
+      assert Editor.value(editor) == "a"
+
+      editor = Editor.jump(editor, +1)
+      assert Editor.value(editor) == "A"
+
+      editor = Editor.jump(editor, +1)
+      assert Editor.value(editor) == "0"
+
+      editor = Editor.jump(editor, +1)
+      assert Editor.value(editor) == " "
+
+      # Four blocks, so the fifth jump is back to the first.
+      assert Editor.value(Editor.jump(editor, +1)) == "a"
+    end
+
+    test "backwards from the first block wraps to the last" do
+      editor = Editor.new("x") |> Editor.jump(+1)
+
+      assert Editor.value(Editor.jump(editor, -1)) == " "
+    end
+
+    test "from nothing the two directions take the two ends" do
+      assert Editor.value(Editor.jump(Editor.new("x"), +1)) == "a"
+      assert Editor.value(Editor.jump(Editor.new("x"), -1)) == " "
+    end
+
+    test "a jump lands on a block head, not on the same offset in the next block" do
+      editor = Editor.new("x") |> type("abcd") |> Editor.move(-2)
+
+      assert Editor.current(editor) == "c"
+      assert Editor.value(Editor.jump(editor, +1)) == "abAd"
+    end
+
+    test "getting to an uppercase letter is a jump and a few presses" do
+      # The reason the shoulder buttons exist: ninety-five characters is up
+      # to ninety-four presses of one direction.
+      editor = pressed(Editor.new("x"), [:r1, :r1])
+
+      assert Editor.value(editor) == "A"
+      assert Editor.value(pressed(editor, [:down, :down])) == "C"
+    end
+  end
+
+  describe "drop/1" do
+    test "removes the character under the caret" do
+      editor = Editor.new("x") |> type("abc") |> Editor.move(-3) |> Editor.drop()
+
+      assert Editor.value(editor) == "bc"
+      assert editor.caret == 0
+    end
+
+    test "past the end it removes the last character" do
+      editor = Editor.new("x") |> type("ab")
+
+      assert editor.caret == 2
+      assert Editor.value(Editor.drop(editor)) == "a"
+    end
+
+    test "on an empty passphrase it does nothing" do
+      assert Editor.drop(Editor.new("x")) == Editor.new("x")
+    end
+
+    test "the caret never ends up past the end of what is left" do
+      editor = Editor.new("x") |> type("a") |> Editor.drop()
+
+      assert Editor.value(editor) == ""
+      assert editor.caret == 0
+    end
+  end
+
+  describe "input/2" do
+    test "the D-pad works the wheel and the caret" do
+      editor = Editor.new("kitchen")
+
+      assert {:editing, %{chars: ["a"]}} = Editor.input(editor, :down)
+      assert {:editing, %{chars: ["~"]}} = Editor.input(editor, :up)
+      assert {:editing, %{caret: 0}} = Editor.input(editor, :left)
+      assert {:editing, %{caret: 1}} = Editor.input(type(editor, "a"), :right)
+    end
+
+    test "the shoulders jump blocks" do
+      editor = Editor.new("kitchen")
+
+      assert {:editing, %{chars: ["a"]}} = Editor.input(editor, :r1)
+      assert {:editing, %{chars: [" "]}} = Editor.input(editor, :l1)
+    end
+
+    test "Y removes, the same button it removes with in the rename editor" do
+      editor = Editor.new("x") |> type("ab")
+
+      assert {:editing, dropped} = Editor.input(editor, :y)
+      assert Editor.value(dropped) == "a"
+    end
+
+    test "A is done and hands back what was picked" do
+      editor = Editor.new("x") |> type("ab")
+
+      assert Editor.input(editor, :a) == {:done, "ab"}
+    end
+
+    test "A hands back a passphrase too short to be accepted" do
+      # The length rule belongs to `MayonnaiOS.WiFi`, which says so on the
+      # panel. A picker that silently swallowed A would look broken.
+      assert Editor.input(Editor.new("x"), :a) == {:done, ""}
+    end
+
+    test "B gives up" do
+      assert Editor.input(Editor.new("x"), :b) == :cancelled
+    end
+
+    test "anything it has no use for leaves it alone" do
+      editor = Editor.new("x") |> type("a")
+
+      assert {:editing, ^editor} = Editor.input(editor, :x)
+      assert {:editing, ^editor} = Editor.input(editor, :start)
+    end
+  end
+
+  test "a real passphrase, with symbols and capitals, comes back as it was picked" do
+    passphrase = "Correct-Horse 42!"
+
+    editor = Editor.new("kitchen") |> type(passphrase)
+
+    assert Editor.value(editor) == passphrase
+    assert Editor.length(editor) == String.length(passphrase)
+  end
+
+  test "a full-length passphrase fits" do
+    # Sixty-three characters is WPA's maximum, and two lines on the panel.
+    editor = Editor.new("kitchen") |> type(String.duplicate("a", 63))
+
+    assert Editor.length(editor) == 63
+    assert Editor.value(editor) == String.duplicate("a", 63)
+  end
+end

--- a/test/wifi_test.exs
+++ b/test/wifi_test.exs
@@ -1,0 +1,459 @@
+defmodule MayonnaiOS.WiFiTest do
+  # Async: every read and write is an injected function, so nothing here
+  # touches a radio, a property table or the application environment.
+  use ExUnit.Case, async: true
+
+  alias MayonnaiOS.WiFi
+
+  # An access point in the shape the property table publishes, minus the
+  # fields nothing here reads. A plain map rather than a
+  # `VintageNetWiFi.AccessPoint` struct on purpose: that module is a
+  # target-only dependency and does not exist on the machine this test runs
+  # on, which is exactly the constraint `MayonnaiOS.WiFi` is built around.
+  defp ap(ssid, opts \\ []) do
+    %{
+      bssid: Keyword.get(opts, :bssid, "aa:bb:cc:dd:ee:#{:rand.uniform(99)}"),
+      ssid: ssid,
+      signal_percent: Keyword.get(opts, :signal, 50),
+      flags: Keyword.get(opts, :flags, [:psk, :ccmp, :wpa2])
+    }
+  end
+
+  # A configuration in the shape `VintageNet.get_configuration/1` answers
+  # with, carrying a network and an unrelated setting that must survive
+  # every edit.
+  defp config(networks) do
+    %{
+      type: VintageNetWiFi,
+      vintage_net_wifi: %{networks: networks},
+      ipv4: %{method: :dhcp}
+    }
+  end
+
+  # Captures whatever a write is handed, so a test can assert on the
+  # configuration that would have gone to the radio.
+  defp recorder do
+    parent = self()
+
+    fn written ->
+      send(parent, {:configured, written})
+      :ok
+    end
+  end
+
+  describe "security/1" do
+    test "classifies what an access point advertises" do
+      assert WiFi.security([]) == :open
+      assert WiFi.security([:ess]) == :open
+      assert WiFi.security([:psk, :ccmp, :wpa2]) == :wpa_psk
+      assert WiFi.security([:sae, :ccmp, :rsn_ccmp]) == :sae
+      assert WiFi.security([:wep]) == :wep
+      assert WiFi.security([:eap, :ccmp, :wpa2]) == :eap
+    end
+
+    test "the old-style combined flags are classified too" do
+      # vintage_net_wifi still reports these for compatibility, so a screen
+      # that only knew the split flags would call an enterprise network open.
+      assert WiFi.security([:wpa2_psk_ccmp]) == :wpa_psk
+      assert WiFi.security([:wpa_psk_ccmp_tkip]) == :wpa_psk
+      assert WiFi.security([:wpa2_eap_ccmp]) == :eap
+      assert WiFi.security([:wpa_eap_ccmp_tkip]) == :eap
+    end
+
+    test "a transitional WPA2/WPA3 access point is joined over WPA2" do
+      # Both flags are advertised, and the PSK path is the one this radio has
+      # actually associated over. See the function's own comment.
+      assert WiFi.security([:psk, :sae, :ccmp]) == :wpa_psk
+    end
+
+    test "enterprise wins over the ciphers it shares with a PSK network" do
+      assert WiFi.security([:eap, :psk]) == :eap
+    end
+  end
+
+  describe "merge/3" do
+    test "orders by signal, strongest first" do
+      points = [ap("weak", signal: 20), ap("strong", signal: 90), ap("middling", signal: 55)]
+
+      assert Enum.map(WiFi.merge(points, [], nil), & &1.ssid) == ["strong", "middling", "weak"]
+    end
+
+    test "one network behind two radios is one row, on the stronger" do
+      points = [
+        ap("mesh", bssid: "a", signal: 30),
+        ap("mesh", bssid: "b", signal: 80)
+      ]
+
+      assert [%{ssid: "mesh", signal: 80}] = WiFi.merge(points, [], nil)
+    end
+
+    test "a hidden network is not a row" do
+      # There is nothing to select and no way to type the real name in.
+      assert WiFi.merge([ap(""), ap(nil), ap("named")], [], nil) |> Enum.map(& &1.ssid) ==
+               ["named"]
+    end
+
+    test "the property table's map is accepted as readily as a list" do
+      points = %{"aa" => ap("kitchen", signal: 70), "bb" => ap("shed", signal: 10)}
+
+      assert Enum.map(WiFi.merge(points, [], nil), & &1.ssid) == ["kitchen", "shed"]
+    end
+
+    test "saved and connected are marked on the rows they belong to" do
+      points = [ap("home", signal: 80), ap("guest", signal: 40)]
+
+      assert [home, guest] = WiFi.merge(points, ["home"], "home")
+
+      assert home.saved? and home.connected? and home.in_range?
+      refute guest.saved?
+      refute guest.connected?
+    end
+
+    test "a saved network that is not on the air is still a row" do
+      # Forgetting a network is something people do from somewhere else in
+      # the house, so the row has to exist out of range.
+      assert [on_air, absent] = WiFi.merge([ap("here", signal: 60)], ["here", "away"], nil)
+
+      assert on_air.ssid == "here"
+      assert absent.ssid == "away"
+      assert absent.signal == nil
+      refute absent.in_range?
+      assert absent.saved?
+      # Nothing is on the air to read flags from, and the security of a row
+      # that exists to be forgotten is not guessed at.
+      assert absent.security == :unknown
+    end
+
+    test "the absent rows come after everything on the air, alphabetically" do
+      points = [ap("b", signal: 10)]
+
+      assert Enum.map(WiFi.merge(points, ["z", "a"], nil), & &1.ssid) == ["b", "a", "z"]
+    end
+  end
+
+  describe "joinable?/1 and needs_passphrase?/1" do
+    test "the two kinds this screen refuses" do
+      refute WiFi.joinable?(%{ssid: "corp", security: :eap})
+      refute WiFi.joinable?(%{ssid: "old", security: :wep})
+      refute WiFi.joinable?(%{ssid: "gone", security: :unknown})
+    end
+
+    test "the three it accepts" do
+      assert WiFi.joinable?(%{ssid: "a", security: :open})
+      assert WiFi.joinable?(%{ssid: "b", security: :wpa_psk})
+      assert WiFi.joinable?(%{ssid: "c", security: :sae})
+    end
+
+    test "only the secured ones want a passphrase" do
+      refute WiFi.needs_passphrase?(%{security: :open})
+      assert WiFi.needs_passphrase?(%{security: :wpa_psk})
+      assert WiFi.needs_passphrase?(%{security: :sae})
+    end
+  end
+
+  describe "network_config/2" do
+    test "an open network needs no passphrase" do
+      assert {:ok, %{ssid: "cafe", key_mgmt: :none}} =
+               WiFi.network_config(%{ssid: "cafe", security: :open}, "")
+    end
+
+    test "WPA-PSK carries the passphrase" do
+      assert {:ok, entry} = WiFi.network_config(%{ssid: "home", security: :wpa_psk}, "hunter2!!")
+
+      assert entry == %{ssid: "home", key_mgmt: :wpa_psk, psk: "hunter2!!"}
+    end
+
+    test "WPA3 differs only in key_mgmt" do
+      # vintage_net_wifi moves :psk to :sae_password itself, so this module
+      # has one shape for both secured schemes.
+      assert {:ok, %{key_mgmt: :sae, psk: "hunter2!!"}} =
+               WiFi.network_config(%{ssid: "new", security: :sae}, "hunter2!!")
+    end
+
+    test "the length bounds are checked here, not by wpa_supplicant" do
+      network = %{ssid: "home", security: :wpa_psk}
+
+      assert WiFi.network_config(network, "short") == {:error, :passphrase_too_short}
+
+      assert WiFi.network_config(network, String.duplicate("x", 7)) ==
+               {:error, :passphrase_too_short}
+
+      assert WiFi.network_config(network, String.duplicate("x", 8)) |> elem(0) == :ok
+      assert WiFi.network_config(network, String.duplicate("x", 63)) |> elem(0) == :ok
+
+      assert WiFi.network_config(network, String.duplicate("x", 64)) ==
+               {:error, :passphrase_too_long}
+    end
+
+    test "the refused kinds say which they are" do
+      assert WiFi.network_config(%{ssid: "corp", security: :eap}, "x") ==
+               {:error, :eap_unsupported}
+
+      assert WiFi.network_config(%{ssid: "old", security: :wep}, "x") ==
+               {:error, :wep_unsupported}
+
+      assert WiFi.network_config(%{ssid: "gone", security: :unknown}, "x") ==
+               {:error, :unknown_security}
+    end
+  end
+
+  describe "with_network/2" do
+    test "the new network goes to the head and the old ones stay" do
+      # The property this device's only way in depends on: joining never
+      # drops the network that already works.
+      existing = %{ssid: "workbench", key_mgmt: :wpa_psk, psk: "buildtime"}
+      entry = %{ssid: "kitchen", key_mgmt: :wpa_psk, psk: "new"}
+
+      written = WiFi.with_network(config([existing]), entry)
+
+      assert Enum.map(WiFi.networks_of(written), & &1.ssid) == ["kitchen", "workbench"]
+      assert Enum.find(WiFi.networks_of(written), &(&1.ssid == "workbench")).psk == "buildtime"
+    end
+
+    test "priorities descend with the list, so the newest wins" do
+      written =
+        config([%{ssid: "a"}, %{ssid: "b"}])
+        |> WiFi.with_network(%{ssid: "c"})
+
+      assert Enum.map(WiFi.networks_of(written), &{&1.ssid, &1.priority}) ==
+               [{"c", 3}, {"a", 2}, {"b", 1}]
+    end
+
+    test "rejoining a network replaces its entry rather than duplicating it" do
+      written =
+        config([%{ssid: "home", key_mgmt: :wpa_psk, psk: "old"}])
+        |> WiFi.with_network(%{ssid: "home", key_mgmt: :wpa_psk, psk: "new"})
+
+      assert [%{ssid: "home", psk: "new"}] = WiFi.networks_of(written)
+    end
+
+    test "everything else in the configuration is carried through untouched" do
+      written = WiFi.with_network(config([]), %{ssid: "x"})
+
+      assert written.type == VintageNetWiFi
+      assert written.ipv4 == %{method: :dhcp}
+    end
+
+    test "a configuration with no WiFi section gets one" do
+      written = WiFi.with_network(%{type: VintageNetWiFi}, %{ssid: "x"})
+
+      assert Enum.map(WiFi.networks_of(written), & &1.ssid) == ["x"]
+    end
+  end
+
+  describe "without_network/2" do
+    test "removes one and renumbers what is left" do
+      written = WiFi.without_network(config([%{ssid: "a"}, %{ssid: "b"}, %{ssid: "c"}]), "b")
+
+      assert Enum.map(WiFi.networks_of(written), &{&1.ssid, &1.priority}) ==
+               [{"a", 2}, {"c", 1}]
+    end
+
+    test "removing what is not there changes nothing but the priorities" do
+      written = WiFi.without_network(config([%{ssid: "a"}]), "absent")
+
+      assert Enum.map(WiFi.networks_of(written), & &1.ssid) == ["a"]
+    end
+  end
+
+  describe "join/3" do
+    test "writes a configuration that keeps the network already there" do
+      existing = %{ssid: "workbench", key_mgmt: :wpa_psk, psk: "buildtime"}
+
+      assert :ok =
+               WiFi.join(%{ssid: "kitchen", security: :wpa_psk}, "hunter2!!",
+                 configuration: fn -> config([existing]) end,
+                 configure: recorder()
+               )
+
+      assert_received {:configured, written}
+      assert Enum.map(WiFi.networks_of(written), & &1.ssid) == ["kitchen", "workbench"]
+    end
+
+    test "a refusal never reaches the radio" do
+      never = fn _config -> flunk("the radio was configured for a refused join") end
+
+      assert WiFi.join(%{ssid: "home", security: :wpa_psk}, "sixchr",
+               configuration: fn -> config([]) end,
+               configure: never
+             ) == {:error, :passphrase_too_short}
+
+      assert WiFi.join(%{ssid: "corp", security: :eap}, "whatever",
+               configuration: fn -> config([]) end,
+               configure: never
+             ) == {:error, :eap_unsupported}
+    end
+
+    test "no radio to configure is an error rather than an exception" do
+      assert WiFi.join(%{ssid: "home", security: :open}, "",
+               configuration: fn -> nil end,
+               configure: recorder()
+             ) == {:error, :unavailable}
+
+      refute_received {:configured, _written}
+    end
+  end
+
+  describe "prefer/2" do
+    test "moves a saved network to the head with its passphrase intact" do
+      saved = [
+        %{ssid: "workbench", key_mgmt: :wpa_psk, psk: "one"},
+        %{ssid: "kitchen", key_mgmt: :wpa_psk, psk: "two"}
+      ]
+
+      assert :ok =
+               WiFi.prefer("kitchen",
+                 configuration: fn -> config(saved) end,
+                 configure: recorder()
+               )
+
+      assert_received {:configured, written}
+      networks = WiFi.networks_of(written)
+
+      assert Enum.map(networks, & &1.ssid) == ["kitchen", "workbench"]
+      # Switching networks must never mean retyping one.
+      assert hd(networks).psk == "two"
+    end
+
+    test "a network that is not saved cannot be preferred" do
+      assert WiFi.prefer("absent",
+               configuration: fn -> config([%{ssid: "home"}]) end,
+               configure: recorder()
+             ) == {:error, :not_saved}
+
+      refute_received {:configured, _written}
+    end
+  end
+
+  describe "forget/2" do
+    test "drops the network and leaves the rest" do
+      assert :ok =
+               WiFi.forget("kitchen",
+                 configuration: fn -> config([%{ssid: "kitchen"}, %{ssid: "workbench"}]) end,
+                 configure: recorder()
+               )
+
+      assert_received {:configured, written}
+      assert Enum.map(WiFi.networks_of(written), & &1.ssid) == ["workbench"]
+    end
+
+    test "forgetting the last network leaves an empty list rather than no list" do
+      assert :ok =
+               WiFi.forget("only",
+                 configuration: fn -> config([%{ssid: "only"}]) end,
+                 configure: recorder()
+               )
+
+      assert_received {:configured, written}
+      assert WiFi.networks_of(written) == []
+      assert written.ipv4 == %{method: :dhcp}
+    end
+  end
+
+  describe "wrong_key?/2" do
+    test "the supplicant saying so in as many words" do
+      event = %{
+        name: "CTRL-EVENT-SSID-TEMP-DISABLED",
+        ssid: "kitchen",
+        reason: "WRONG_KEY",
+        auth_failures: 1
+      }
+
+      assert WiFi.wrong_key?(event, "kitchen")
+    end
+
+    test "a temporary disable for another reason is not a wrong passphrase" do
+      event = %{name: "CTRL-EVENT-SSID-TEMP-DISABLED", ssid: "kitchen", reason: "CONN_FAILED"}
+
+      refute WiFi.wrong_key?(event, "kitchen")
+    end
+
+    test "an association reject counts only against the network being joined" do
+      event = %{name: "CTRL-EVENT-ASSOC-REJECT", ssid: "kitchen", status_code: "1"}
+
+      assert WiFi.wrong_key?(event, "kitchen")
+      refute WiFi.wrong_key?(event, "shed")
+    end
+
+    test "anything else, and nothing at all, is not a verdict" do
+      refute WiFi.wrong_key?(%{name: "CTRL-EVENT-CONNECTED"}, "kitchen")
+      refute WiFi.wrong_key?(nil, "kitchen")
+      refute WiFi.wrong_key?(%{}, "kitchen")
+    end
+  end
+
+  describe "joined?/2" do
+    test "a lease from the router is enough" do
+      # :lan rather than :internet, because a router with no uplink is a
+      # successful join and a separate problem.
+      assert WiFi.joined?(%{state: :lan, ssid: "kitchen"}, "kitchen")
+      assert WiFi.joined?(%{state: :internet, ssid: "kitchen"}, "kitchen")
+    end
+
+    test "being on a different network is not being on this one" do
+      refute WiFi.joined?(%{state: :internet, ssid: "workbench"}, "kitchen")
+    end
+
+    test "disconnected is never joined" do
+      refute WiFi.joined?(%{state: :disconnected, ssid: nil}, "kitchen")
+      refute WiFi.joined?(%{state: nil, ssid: nil}, "kitchen")
+    end
+
+    test "an unreported SSID with a lease counts, because the alternative is waiting forever" do
+      assert WiFi.joined?(%{state: :lan, ssid: nil}, "kitchen")
+    end
+  end
+
+  describe "reading through the injected seam" do
+    test "list/1 merges what it is handed" do
+      networks =
+        WiFi.list(
+          access_points: fn -> [ap("kitchen", signal: 70)] end,
+          saved: fn -> ["kitchen"] end,
+          current_ssid: fn -> "kitchen" end
+        )
+
+      assert [%{ssid: "kitchen", saved?: true, connected?: true}] = networks
+    end
+
+    test "saved_ssids/1 reads the live configuration and skips the nameless" do
+      assert WiFi.saved_ssids(
+               configuration: fn -> config([%{ssid: "a"}, %{ssid: ""}, %{other: 1}]) end
+             ) == ["a"]
+    end
+
+    test "connection/1 assembles the three readings" do
+      assert WiFi.connection(
+               connection_state: fn -> :internet end,
+               current_ssid: fn -> "kitchen" end,
+               address: fn -> "192.168.1.42" end
+             ) == %{state: :internet, ssid: "kitchen", address: "192.168.1.42", error: nil}
+    end
+
+    test "scan/1 normalises the three shapes VintageNet.scan/1 can answer with" do
+      assert WiFi.scan(scan: fn -> :ok end) == :ok
+      assert WiFi.scan(scan: fn -> {:ok, :whatever} end) == :ok
+      assert WiFi.scan(scan: fn -> {:error, :enodev} end) == {:error, :enodev}
+    end
+
+    test "on a machine with no radio the defaults answer rather than raise" do
+      # The state a host build is in, and the one the screen has to draw.
+      refute WiFi.available?()
+      assert WiFi.scan() == {:error, :unavailable}
+      assert WiFi.list() == []
+      assert WiFi.saved_ssids() == []
+      assert %{state: nil, ssid: nil} = WiFi.connection()
+      assert WiFi.subscribe() == :ok
+      assert WiFi.forget("anything") == {:error, :unavailable}
+      assert WiFi.prefer("anything") == {:error, :unavailable}
+    end
+  end
+
+  test "the interface is the one this board's radio is on" do
+    assert WiFi.interface() == "wlan0"
+  end
+
+  test "the passphrase bounds are WPA's own" do
+    assert WiFi.passphrase_bounds() == {8, 63}
+  end
+end


### PR DESCRIPTION
## Summary

The network was fixed at build time: credentials came from `RG40XXV_WIFI_SSID`/`_PSK` into `config/target.exs`, so putting the device on a different WiFi meant a rebuild or an SSH session — the two things you can't do when the reason you're looking is that WiFi is down. This adds a **WiFi** row under System that scans, lists what's on the air alongside the saved networks, and joins one with a passphrase typed on a character wheel.

The wheel is the browser's rename picker widened to all 95 printable ASCII characters, with L1/R1 jumping between lowercase, uppercase, digits and symbols — a passphrase is somebody else's string chosen for a router, so an alphabet that omitted `#` would be a screen that can't join a real network and doesn't say so.

## Approach

Two choices that aren't obvious from the diff, both falling out of the same constraint — this device's only reliable way in is the radio being reconfigured:

**Joining appends rather than replaces.** `wpa_supplicant` holds a list and associates with whichever network is in range, so the build-time credentials keep working forever and the newly chosen network only wins on `:priority`. The alternative — overwrite the list — makes a passphrase mistyped on a 95-character wheel cost a card reflash, which has already happened once on this device for a related reason.

**A refused passphrase is detected, not inferred from a clock.** `vintage_net_wifi` republishes the supplicant's control events, and a rejected key arrives as `CTRL-EVENT-SSID-TEMP-DISABLED` with `reason: "WRONG_KEY"`. That's worth waiting for because *"the access point refused that passphrase"* and *"something didn't work"* are different sentences and only one tells anyone what to do next. That case also withdraws the network again — one known to be wrong is one the supplicant keeps retrying over the top of the one that works. A join that merely times out stays configured, because DHCP on a tired router outlasts any deadline worth putting on a panel.

Every read and write is injectable (the `MayonnaiOS.SystemInfo` seam), which is what makes the merging, priority renumbering, wrong-key detection and all the scene's states testable on a host where `vintage_net` isn't loaded at all. The per-module reasoning is in the moduledocs rather than repeated here.

## Follow-ups for reviewer

- **Nothing here has run on the hardware.** The `VintageNet` calls and property paths are checked against the dependency's source, not a radio, and the host UI renders blank on this machine so the scene is verified only by its graph tests. The two things only the device can answer: does `scan/1` on the RTL8821CS populate `access_points` on the 8s timer, and does this supplicant build actually emit `reason=WRONG_KEY`? Worth a hardware pass before merge — happy to do it if you can flash.
- **Enterprise and WEP are refused outright**, listed with what they'd need written on the row (the Bluetooth screen's headphone-notice reasoning). WEP would be cheap to add — `wep_key0` and a key index — but nothing here has associated with a WEP AP to say the plumbing works. Refuse, or add it untested?
- **A WPA2/WPA3 transitional AP is joined over WPA2**, because that's the path this radio has actually associated over. Would you rather it tried `key_mgmt: [:wpa_psk, :sae]` and let the supplicant pick?
- **The join deadline is 30s and the rescan interval 8s**, both from `vintage_net`'s own guidance rather than measurement. Fine to tune once someone's held it.