### PR TITLE
Show splash before immediate shutdown

### DIFF
--- a/lib/mayonnaios/browser/view.ex
+++ b/lib/mayonnaios/browser/view.ex
@@ -381,8 +381,7 @@ defmodule MayonnaiOS.Browser.View do
   defp program_lines(%{action: :poweroff}) do
     [
       "A verb of the launcher's own.",
-      "A puts the question on the panel;",
-      "Y -- and only Y -- switches off."
+      "A shows the splash, then switches off."
     ]
   end
 

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -100,9 +100,8 @@ defmodule MayonnaiOS.Launcher do
                       the readout app, which is that row's detailed view
       Y               the second verb, and the panel says what it is: the
                       actions sheet in a directory -- Y and only Y, A never
-                      opens it -- the delete on its confirmation,
-                      remove-a-character in the rename editor, and the
-                      answer to the Power off row's question
+                      opens it -- the delete on its confirmation, and
+                      remove-a-character in the rename editor
       Menu            go back to the home screen, at its root column
       Power           sleep -- backlight off, and any press wakes it
       Select+Menu     power off
@@ -126,14 +125,11 @@ defmodule MayonnaiOS.Launcher do
   is never split across keys by which kind of thing you are in.
 
   Select+Menu powers off, so the chord is checked before the plain press.
-  Switching off is not undoable and this is a handheld that gets carried in a
-  pocket, which is the argument that shapes how the menu's Power off row
-  answers as well. Pressing A on it does nothing but put a
-  question on the bottom line; Y -- the button that did not ask -- switches
-  off, and any other press takes the question down and is swallowed, so a
-  cancel cannot also launch what the cursor is on. That is the browser's
-  delete rule, applied to the other irreversible thing on the device. Both
-  routes end in the same `Nerves.Runtime.poweroff/0`.
+  Switching off from the menu is immediate: the launcher replaces the UI with
+  the boot splash and then calls `Nerves.Runtime.poweroff/0`. The splash makes
+  the accepted press visible during the short orderly-shutdown interval and
+  avoids leaving a live-looking menu on a device that is already going down.
+  Select+Menu reaches the same power-off function without redrawing first.
 
   ## Sleep, and the press that wakes it
 
@@ -205,7 +201,7 @@ defmodule MayonnaiOS.Launcher do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.{Browser, Input, Led, Panel, Sleep, Theme}
+  alias MayonnaiOS.{Browser, Input, Led, Panel, Sleep, Splash, Theme}
 
   # The name the driver gives the gamepad, which is the only thing this module
   # knows about which device it is. There is no numbered fallback: /dev/input
@@ -234,11 +230,9 @@ defmodule MayonnaiOS.Launcher do
   # So :btn_x below really is the Y button, and :btn_y -- physical X -- is
   # bound to nothing.
   #
-  # Y (:btn_x) is the second verb, and the panel says what it is. While the
-  # Power off row's question is up it is the answer -- the confirming clause
-  # is tested before everything else here, so that can never collide -- and
-  # otherwise it belongs to the browser: the actions sheet in a directory,
-  # the delete on a confirmation, remove-a-character in the rename editor.
+  # Y (:btn_x) is the second verb, and the panel says what it is: the actions
+  # sheet in a directory, the delete on a confirmation, and
+  # remove-a-character in the rename editor.
   @confirm_button :btn_x
   @actions_button :btn_x
 
@@ -465,11 +459,6 @@ defmodule MayonnaiOS.Launcher do
       # each cursor is on, and how many columns the panel draws. Here rather
       # than in the scene so it survives every repaint; see the moduledoc.
       browser: Browser.new(),
-      # Whether the Power off row has asked its question and is waiting for
-      # Y. Armed by `start_program/2`, answered or dismissed by `press/2`,
-      # and never true while anything is running -- the row can only be
-      # activated from an idle menu.
-      confirming: false,
       # The last few lines the running program wrote, kept so that if it dies
       # they can be put on the panel and not only in the ring logger. Reset
       # on every launch; capped, because a chatty program earns no more rows.
@@ -484,6 +473,10 @@ defmodule MayonnaiOS.Launcher do
       # one cannot be called on a laptop and a confirmation flow nobody can
       # test is a confirmation flow that silently rots.
       poweroff: Keyword.get(opts, :poweroff, &Nerves.Runtime.poweroff/0),
+      # Drawn synchronously before the menu's orderly power-off, so the last
+      # visible frame acknowledges the selection. Injectable to make the
+      # ordering testable without a framebuffer.
+      shutdown_splash: Keyword.get(opts, :shutdown_splash, fn -> Splash.run(timeout: 0) end),
       # The seam the stop path is tested against: signalling an OS process and
       # asking whether it is still there. Injectable because the one case that
       # matters most cannot be produced for real -- a process that survives
@@ -800,9 +793,6 @@ defmodule MayonnaiOS.Launcher do
         {_result, state} = enter_sleep(state)
         state
 
-      state.confirming ->
-        answer_poweroff(state, key)
-
       Browser.busy?(state.browser) ->
         overlay(state, key)
 
@@ -859,19 +849,6 @@ defmodule MayonnaiOS.Launcher do
   defp semantic(@confirm_button), do: :y
   defp semantic(@full_button), do: :x
   defp semantic(_key), do: :other
-
-  # The Power off row's question, answered the way `MayonnaiOS.Files` answers
-  # a delete: A asked, so A cannot also be the answer. Y -- and only Y --
-  # switches off; anything else keeps the device on, is swallowed rather than
-  # dispatched, and takes the question off the panel. Swallowed matters: the
-  # cancelling press must not also launch whatever the cursor is on.
-  defp answer_poweroff(state, @confirm_button), do: poweroff(state, "the menu")
-
-  defp answer_poweroff(state, _key) do
-    state = %{state | confirming: false}
-    show(:home, state)
-    state
-  end
 
   # Entering sleep only counts if the backlight write landed. A dark-panel
   # flag over a lit screen would swallow the next press for nothing, which is
@@ -1095,14 +1072,12 @@ defmodule MayonnaiOS.Launcher do
     state
   end
 
-  # The Power off row. Not a program and not an app: pressing A here only
-  # asks, and the repaint puts the question on the panel. `press/2` owns the
-  # answer -- Y switches off, anything else keeps the device on -- because A
-  # opened the question and the answer must not be the button that asked.
+  # The Power off row. Draw the splash before asking the runtime to shut down,
+  # so the panel immediately acknowledges the selection while services and
+  # filesystems stop.
   defp start_program(%{action: :poweroff}, state) do
-    state = %{state | confirming: true}
-    show(:home, state)
-    state
+    state.shutdown_splash.()
+    poweroff(state, "the menu")
   end
 
   # The Diagnostics row: the readout that makes the physical checks --
@@ -1408,7 +1383,6 @@ defmodule MayonnaiOS.Launcher do
   defp show(_home, state) do
     set_root(default_scene(), %{
       browser: state.browser,
-      confirming: state.confirming,
       obituary: state.obituary
     })
   end

--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -46,8 +46,7 @@ defmodule MayonnaiOS.Scene.Home do
   browsing, the delete on a confirmation, remove-a-character in the rename
   editor -- and a handheld has no tooltips and no manual. So the bottom line
   spells the buttons out for the state on screen, and the same line carries
-  the power-off question and a program's obituary when there is one: the
-  panel asking or reporting outranks it labelling.
+  a program's obituary when there is one: reporting outranks labelling.
   """
 
   use Scenic.Scene
@@ -142,15 +141,13 @@ defmodule MayonnaiOS.Scene.Home do
         _ -> Browser.new()
       end
 
-    confirming = match?(%{confirming: true}, param)
-
     obituary =
       case param do
         %{obituary: %{} = obituary} -> obituary
         _ -> nil
       end
 
-    {:ok, push_graph(scene, graph(browser, confirming, obituary))}
+    {:ok, push_graph(scene, graph(browser, obituary))}
   end
 
   @doc """
@@ -159,17 +156,17 @@ defmodule MayonnaiOS.Scene.Home do
   Public because it is the tested surface: it needs no viewport, no driver
   and no framebuffer, so a host test can assert what the panel says for the
   root column, a deep descent, the actions sheet, the delete confirmation,
-  the rename editor, the power-off question and an obituary -- the shapes
+  the rename editor and an obituary -- the shapes
   that would otherwise only be found by looking at the device.
   """
-  @spec graph(Browser.t(), boolean(), map() | nil) :: Scenic.Graph.t()
-  def graph(browser, confirming \\ false, obituary \\ nil) do
+  @spec graph(Browser.t(), map() | nil) :: Scenic.Graph.t()
+  def graph(browser, obituary \\ nil) do
     base()
     |> breadcrumb(browser)
     |> held(browser)
     |> body(browser)
     |> status_line(browser)
-    |> notice(browser, confirming, obituary)
+    |> notice(browser, obituary)
   end
 
   defp base do
@@ -838,33 +835,20 @@ defmodule MayonnaiOS.Scene.Home do
 
   # -- the bottom line -------------------------------------------------------------
 
-  # One notice at a time, on the footer line. The power-off question wins
-  # over an obituary: it is the panel asking for a decision, and the obituary
-  # keeps -- it is still in the Launcher's state, and comes back the moment
-  # the question is answered. With nothing to ask or report, the line labels
-  # the buttons for the state on screen.
-  defp notice(graph, _browser, true, _obituary) do
-    graph
-    |> footer_rule()
-    |> text("Power off? Y switches off. Any other button keeps it on.",
-      font_size: 18,
-      fill: {:color, wait()},
-      translate: {@left, @footer_y}
-    )
-  end
-
-  defp notice(graph, browser, false, nil) do
+  # One notice at a time, on the footer line. With nothing to report, the line
+  # labels the buttons for the state on screen.
+  defp notice(graph, browser, nil) do
     graph
     |> footer_rule()
     |> text(hint(browser), font_size: 15, fill: {:color, dim()}, translate: {@left, @footer_y})
   end
 
   # Why the last program died, quoted from its own last words. The headline
-  # is amber like the power-off question -- the panel reporting, not asking --
-  # and the quoted lines are dim so the reason reads before the evidence.
+  # is amber -- the panel reporting -- and the quoted lines are dim so the
+  # reason reads before the evidence.
   # Status nil is a spawn that raised rather than a program that exited; the
   # words are then the exception's, and "exited" would be a lie.
-  defp notice(graph, _browser, false, %{name: name, status: status, lines: lines}) do
+  defp notice(graph, _browser, %{name: name, status: status, lines: lines}) do
     headline =
       case status do
         nil -> "#{name} would not start. B clears this."

--- a/test/browser_view_test.exs
+++ b/test/browser_view_test.exs
@@ -118,11 +118,11 @@ defmodule MayonnaiOS.Browser.ViewTest do
       assert Enum.any?(preview.lines, &(&1 =~ "Not installed"))
     end
 
-    test "the power-off verb says Y answers" do
+    test "the power-off verb says A acts immediately" do
       [program] = MayonnaiOS.Programs.list([%{name: "Power off", action: :poweroff}])
       preview = View.preview(%{kind: :program, name: "Power off", program: program}, nil)
 
-      assert Enum.any?(preview.lines, &(&1 =~ "only Y"))
+      assert Enum.any?(preview.lines, &(&1 =~ "A shows the splash"))
     end
 
     test "a process monitor previews as a narrow list by memory" do

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -118,18 +118,10 @@ defmodule MayonnaiOS.LauncherTest do
       assert Enum.any?(texts(graph), &(&1 =~ "Nothing to run"))
     end
 
-    test "the power-off question is on the panel only while it is being asked" do
-      asked = texts(Home.graph(Browser.new(), true))
-      assert Enum.any?(asked, &(&1 =~ "Power off? Y switches off"))
-
-      idle = texts(Home.graph(Browser.new()))
-      refute Enum.any?(idle, &(&1 =~ "Y switches off"))
-    end
-
     test "an obituary quotes the program's dying words" do
       obituary = %{name: "Moonlight", status: 1, lines: ["Can't open configuration file"]}
 
-      says = texts(Home.graph(Browser.new(), false, obituary))
+      says = texts(Home.graph(Browser.new(), obituary))
       assert Enum.any?(says, &(&1 =~ "Moonlight exited (1)"))
       assert Enum.any?(says, &(&1 =~ "Can't open configuration file"))
 
@@ -139,17 +131,9 @@ defmodule MayonnaiOS.LauncherTest do
 
     test "a spawn that raised says would not start, not exited" do
       obituary = %{name: "Doom", status: nil, lines: ["enoent"]}
-      says = texts(Home.graph(Browser.new(), false, obituary))
+      says = texts(Home.graph(Browser.new(), obituary))
 
       assert Enum.any?(says, &(&1 =~ "Doom would not start"))
-      refute Enum.any?(says, &(&1 =~ "exited"))
-    end
-
-    test "the power-off question outranks the obituary" do
-      obituary = %{name: "Moonlight", status: 1, lines: ["nope"]}
-      says = texts(Home.graph(Browser.new(), true, obituary))
-
-      assert Enum.any?(says, &(&1 =~ "Power off?"))
       refute Enum.any?(says, &(&1 =~ "exited"))
     end
 
@@ -477,7 +461,10 @@ defmodule MayonnaiOS.LauncherTest do
       test = self()
 
       start_supervised!(
-        {Launcher, device: "/nonexistent/event0", poweroff: fn -> send(test, :powered_off) end}
+        {Launcher,
+         device: "/nonexistent/event0",
+         shutdown_splash: fn -> send(test, :splash_drawn) end,
+         poweroff: fn -> send(test, :powered_off) end}
       )
 
       # Into System -- the last category -- and down past Diagnostics, Sleep
@@ -492,37 +479,13 @@ defmodule MayonnaiOS.LauncherTest do
       :ok
     end
 
-    test "A only asks; Y answers" do
+    test "A draws the splash and immediately powers off" do
       tap(:btn_b)
-      refute_received :powered_off
-
-      tap(:btn_x)
+      assert_receive :splash_drawn
       assert_receive :powered_off
     end
 
-    test "any other button keeps the device on, and Y afterwards does not switch off" do
-      tap(:btn_b)
-      tap(:btn_a)
-
-      # The question is gone, so the button that would have answered it is
-      # back to its day job of cycling columns.
-      tap(:btn_x)
-      refute_received :powered_off
-    end
-
-    test "the cancelling press is swallowed, not dispatched" do
-      tap(:btn_b)
-      # A again would re-open the question if it were dispatched -- the cursor
-      # is still on the Power off row; here it may only cancel. Y proving no
-      # question is up also proves no second question was opened.
-      tap(:btn_b)
-      tap(:btn_x)
-      refute_received :powered_off
-    end
-
-    test "Y with no question pending does nothing here" do
-      # Settings is not a directory column, so the second verb has nothing to
-      # offer -- and it must not switch the device off.
+    test "Y remains the browser's second verb" do
       before = Launcher.browser()
       tap(:btn_x)
 


### PR DESCRIPTION
Closes #50.

Selecting **Power off** now draws the existing boot splash synchronously and immediately starts the orderly shutdown. The obsolete Y-confirmation state and footer prompt have been removed, and the program preview describes the new behavior.

Verification:
- `mix test test/launcher_test.exs:482 test/browser_view_test.exs:121 test/splash_test.exs` (15 passed)
- `mix format --check-formatted`
- `git diff --check`

The broader focused run passed 83/84 tests; the one failure is the pre-existing OS-process timing test at `test/launcher_test.exs:674`, where the macOS shell exited before the test observed it alive.