### PR TITLE
Make the launcher button legend concise

### DIFF
--- a/lib/mayonnaios/scene/home.ex
+++ b/lib/mayonnaios/scene/home.ex
@@ -40,14 +40,14 @@ defmodule MayonnaiOS.Scene.Home do
   cap, no Scenic running, a file the decoder refuses -- and the box then
   says so instead of drawing nothing.
 
-  ## Why the footer says what the buttons do, on every screen
+  ## Why the footer only says what changes
 
-  Y means a different thing in each state -- the actions sheet while
-  browsing, the delete on a confirmation, remove-a-character in the rename
-  editor -- and a handheld has no tooltips and no manual. So the bottom line
-  spells the buttons out for the state on screen, and the same line carries
-  the power-off question and a program's obituary when there is one: the
-  panel asking or reporting outranks it labelling.
+  A opens and B goes back throughout the firmware; repeating those bindings
+  on every screen made the footer's longest line mostly noise. The bottom
+  line instead names the controls that vary with state: Y's file action,
+  delete, or editor meaning; X's inspection toggle; and paging only when the
+  current list can page. The same line carries the power-off question and a
+  program's obituary when there is one: asking or reporting outranks hints.
   """
 
   use Scenic.Scene
@@ -889,19 +889,28 @@ defmodule MayonnaiOS.Scene.Home do
     |> text(headline, font_size: 18, fill: {:color, wait()}, translate: {@left, @footer_y})
   end
 
-  defp hint(%{full: full}) when full != nil,
-    do: "B goes back. Up/Down scroll, L1/R1 page. X also closes."
+  defp hint(%{full: full}) when full != nil do
+    if length(Map.get(full, :lines, [])) > Browser.full_rows() do
+      "Up/Down scroll. L1/R1 page. X closes."
+    else
+      "X closes."
+    end
+  end
 
-  defp hint(%{overlay: {:actions, _actions, _cursor}}), do: "A does it. B goes back."
+  defp hint(%{overlay: {:actions, _actions, _cursor}}), do: "Up/Down chooses."
   defp hint(%{overlay: {:confirm, _pending}}), do: "Y deletes. Anything else cancels."
-  defp hint(%{overlay: {:rename, _rename}}), do: "A saves. B cancels. Y removes a character."
+  defp hint(%{overlay: {:rename, _rename}}), do: "Y removes a character."
 
   defp hint(browser) do
-    if Browser.focused(browser).location == nil do
-      "A opens. B closes a column. X inspects. L1/R1 page. Menu goes to the top."
-    else
-      "A opens. B closes. X inspects. Y for file actions. Menu goes to the top."
-    end
+    level = Browser.focused(browser)
+
+    [
+      "X inspects.",
+      if(level.location != nil, do: "Y file actions."),
+      if(length(level.entries) > @visible, do: "L1/R1 page.")
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("  ")
   end
 
   defp footer_rule(graph) do

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -167,17 +167,67 @@ defmodule MayonnaiOS.LauncherTest do
       says = texts(Home.graph(browser))
 
       assert Enum.any?(says, &(&1 =~ "/a"))
-      assert Enum.any?(says, &(&1 =~ "B goes back"))
+      assert "X closes." in says
       # The columns give way to the one wide view.
       refute "Games" in says
     end
 
-    test "the footer labels the buttons for the state on screen" do
+    test "the footer only labels controls that vary with the state" do
       idle = texts(Home.graph(Browser.new()))
-      assert Enum.any?(idle, &(&1 =~ "A opens."))
+      assert "X inspects." in idle
+      refute Enum.any?(idle, &(&1 =~ "A opens"))
+      refute Enum.any?(idle, &(&1 =~ "B closes"))
+      refute Enum.any?(idle, &(&1 =~ "L1/R1"))
 
       sheet = put_in(Browser.new().overlay, {:actions, [%{id: :delete, label: "Delete x"}], 0})
-      assert Enum.any?(texts(Home.graph(sheet)), &(&1 =~ "A does it."))
+      assert "Up/Down chooses." in texts(Home.graph(sheet))
+    end
+
+    test "the footer mentions paging only when the current content can page" do
+      entries =
+        for i <- 1..11 do
+          %{
+            kind: :file,
+            name: "file#{i}",
+            entry: %{type: :regular, size: 1, link: nil, broken?: false}
+          }
+        end
+
+      browser =
+        Browser.new()
+        |> put_in(
+          [
+            Access.key!(:levels),
+            Access.at(0)
+          ],
+          %{
+            title: "Files",
+            entries: entries,
+            cursor: 0,
+            note: nil,
+            location: %{root: "r", path: []},
+            readable?: true,
+            space: nil
+          }
+        )
+
+      assert "X inspects.  Y file actions.  L1/R1 page." in texts(Home.graph(browser))
+
+      short_full =
+        put_in(browser.full, %{kind: :text, title: "short", lines: ["one"], offset: 0, note: nil})
+
+      assert "X closes." in texts(Home.graph(short_full))
+
+      long_full =
+        put_in(browser.full, %{
+          kind: :text,
+          title: "long",
+          lines: Enum.map(1..30, &Integer.to_string/1),
+          offset: 0,
+          note: nil
+        })
+
+      assert "Up/Down scroll. L1/R1 page. X closes." in texts(Home.graph(long_full))
     end
 
     # Every text primitive's string, so a test can assert what the panel says


### PR DESCRIPTION
Closes #46.

The home footer now omits the invariant A/B instructions and shows only state-specific controls:
- X inspection/close behavior
- Y file, delete, and rename actions
- paging only when the current column or full view actually exceeds one page
- selection movement while the actions sheet is open

This removes the ~70-character repeated browsing legends and keeps the changing information in a predictable, short line.

Verification:
- `mix test test/launcher_test.exs:44` (14 passed)
- `mix format --check-formatted`
- `git diff --check`