### PR TITLE
Document the on-device data layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ a scratch directory and start `MayonnaiOS.Web` under a supervisor.
 |---|---|
 | [Pickles](docs/pickles.md) | Writing and deploying sandboxed Lua apps |
 | [The Bluetooth controller](docs/bluetooth-controller.md) | The borrowed identity and its trade-offs, the no-BlueZ stack, recovery, what is not built yet |
+| [On-device data layout](docs/data-layout.md) | Which writable paths belong to MayonnaiOS, players, and removable media |
 | [RetroArch internals](docs/retroarch-internals.md) | How cores, config and saves are kept honest across upgrades and pulled power |
 
 ## The three repositories

--- a/docs/data-layout.md
+++ b/docs/data-layout.md
@@ -1,0 +1,50 @@
+# On-device data layout
+
+The writable application partition is mounted at `/root`. MayonnaiOS keeps
+its own visible data directly below that directory, keeps third-party player
+settings under the players' conventional `.config` paths, and keeps removable
+media below `/root/mnt`. These names are part of the user interface because
+the Files column exposes them.
+
+The current paths are intentionally retained. Renaming them would require a
+boot-time migration on every existing device and would make stock-formatted
+games cards less interchangeable, without changing what any directory means.
+
+## Canonical paths
+
+| Path | Owner | Contents and rule |
+|---|---|---|
+| `/root/ROMS/<system>` | player | Internal ROM library. `ROMS` stays uppercase to match stock-formatted games cards. |
+| `/root/mnt/games` | system | Mount point for the second SD card. A mount point is infrastructure, not application data. |
+| `/root/mnt/games/ROMS/<system>` | player | Removable ROM library, with the same layout as the internal library. |
+| `/root/bundles/<name>/<version>` | MayonnaiOS | Versioned native application bundles. `current` selects the active version and `installed.json` records it. |
+| `/root/cores/<name>/<version>` | MayonnaiOS | Versioned installed libretro cores, using the same bundle mechanism and `current` link. |
+| `/root/pickles/<name>` | player and MayonnaiOS | Installed Lua applications and their application-owned files. Pickle formats may define their own versioning. |
+| `/root/bluetooth/bonds.bin` | MayonnaiOS | Unversioned paired-host keys. |
+| `/root/.config/retroarch` | RetroArch | Player-owned configuration and support files, including the `cores` compatibility directory. MayonnaiOS manages only the documented generated files and core symlinks inside it. |
+| `/root/.config/moonlight` | Moonlight | Player-owned Moonlight configuration. |
+
+## Rules
+
+- Visible top-level names are data MayonnaiOS owns or deliberately exposes to
+  the player. Dot-directories are reserved for another program's conventional
+  configuration paths; MayonnaiOS does not hide its own data merely because it
+  is internal.
+- The two cards use the same `ROMS/<system>` shape. Code may merge those roots
+  for browsing, but must preserve which card owns each file. Other MayonnaiOS
+  data is not mirrored onto the removable card unless a feature explicitly
+  defines that behavior.
+- Downloaded executable content is versioned by directory and activated with a
+  `current` symlink. Mutable player data—ROMs, saves, settings, bonds, and
+  Pickle state—is unversioned and updated in place with the durability rules of
+  the component that owns it.
+- `bundles` and `cores` deliberately remain siblings. They share the same
+  versioned installer, but core discovery and synchronization have a separate
+  lifecycle from runnable application bundles; nesting one under the other
+  would make their ownership less clear without enabling shared behavior.
+- `/root/mnt` contains mount points only. New removable filesystems belong
+  there; persistent application directories do not.
+- A future rename is a data migration, not a config-only edit. It must be
+  idempotent, preserve old data when either side is ambiguous, survive loss of
+  power, and ship before readers switch to the new path. Until such a migration
+  exists, these paths are stable compatibility interfaces.


### PR DESCRIPTION
Closes #43.

This records the current layout as the stable policy rather than renaming existing device data:
- MayonnaiOS-owned visible paths, third-party `.config` paths, and mount points have explicit ownership rules
- both cards keep the same `ROMS/<system>` shape
- bundles and cores remain separate sibling roots with documented lifecycle reasoning
- versioned executable content is distinguished from mutable player data
- any future rename is required to ship as an idempotent, power-loss-safe migration

The README links the new document. No runtime paths change, so existing devices and stock-formatted games cards require no migration.

Verification:
- documentation links and referenced paths checked against `config/target.exs`
- `git diff --check`