### PR TITLE
Sleep the launcher after an idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Software:
 - Pickles: small sandboxed Lua apps, installed over the network like games,
   for things like controlling lamps on the LAN or polling a web API. See
   [docs/pickles.md](docs/pickles.md)
-- Sleep on the power button: the backlight goes off and any button brings it
-  back. Not suspend — this board's only suspend mode would save almost
-  nothing, and `MayonnaiOS.Sleep`'s moduledoc has the analysis
+- Sleep on the power button, or after three minutes idle in the launcher: the
+  backlight goes off and any button brings it back. The idle timer pauses
+  while charging and while a program or app is active. Not suspend — this
+  board's only suspend mode would save almost nothing, and
+  `MayonnaiOS.Sleep`'s moduledoc has the analysis
 - A NeXTSTEP-style column launcher: Games, Files, Apps and System open
   as columns, three on screen, and Files browses the whole filesystem in
   place

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -137,6 +137,12 @@ defmodule MayonnaiOS.Launcher do
   mechanism and the choice of key, including why it is that button and why
   sleep is not suspend.
 
+  The same mechanism runs after three minutes without a real button press on
+  the home launcher. Autorepeat does not buy another interval, charging does
+  not time out, and neither an external program nor a BEAM app has an idle
+  timer: still controls can be active use in all three cases. Returning to the
+  launcher starts a fresh interval rather than inheriting time spent away.
+
   What belongs here is the other half: while the panel is dark, **the next
   press is consumed**. Waking is not a binding of its own -- any button wakes,
   which is the only thing someone holding a dark handheld can be expected to
@@ -201,7 +207,7 @@ defmodule MayonnaiOS.Launcher do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.{Browser, Input, Led, Panel, Sleep, Splash, Theme}
+  alias MayonnaiOS.{Browser, Input, Led, Panel, Power, Sleep, Splash, Theme}
 
   # The name the driver gives the gamepad, which is the only thing this module
   # knows about which device it is. There is no numbered fallback: /dev/input
@@ -298,6 +304,11 @@ defmodule MayonnaiOS.Launcher do
   # path is not noticeably slower than fire-and-forget.
   @poll_ms 50
 
+  # The launcher is the only screen where inactivity means nobody is using
+  # the device. Programs and BEAM apps can sit untouched while somebody
+  # watches or uses another controller, so they disable this timer entirely.
+  @idle_sleep_ms :timer.minutes(3)
+
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
   @doc """
@@ -381,7 +392,7 @@ defmodule MayonnaiOS.Launcher do
     Panel.release()
 
     Enum.each(devices(opts), &watch/1)
-    {:ok, new_state(opts)}
+    {:ok, opts |> new_state() |> reset_idle_timer()}
   end
 
   # The gamepad, the analog stick, and whatever device the sleep key is on.
@@ -485,6 +496,12 @@ defmodule MayonnaiOS.Launcher do
       term_timeout: Keyword.get(opts, :term_timeout, @term_timeout),
       kill_timeout: Keyword.get(opts, :kill_timeout, @kill_timeout),
       poll_ms: Keyword.get(opts, :poll_ms, @poll_ms),
+      idle_sleep_ms: Keyword.get(opts, :idle_sleep_ms, @idle_sleep_ms),
+      idle_timer: nil,
+      power_state:
+        Keyword.get(opts, :power_state, fn ->
+          Power.values() |> Power.state()
+        end),
       # Pushing the save files onto the card, at the only moments it is safe
       # to: after the program that owns them is confirmed gone. Injectable
       # because what a test can check is that it happens then and not when a
@@ -511,14 +528,17 @@ defmodule MayonnaiOS.Launcher do
     end
   end
 
-  def handle_call(:launch, _from, state), do: {:reply, :ok, do_launch(state)}
+  def handle_call(:launch, _from, state) do
+    state = state |> do_launch() |> reset_idle_timer()
+    {:reply, :ok, state}
+  end
 
   # The reply is the result rather than a cheerful `:ok`, because there is now
   # an outcome worth having: `{:error, {:still_running, pid}}` means the
   # program is still on the display and this process could not shift it.
   def handle_call(:stop, _from, state) do
     {result, state} = do_stop(state)
-    {:reply, result, state}
+    {:reply, result, reset_idle_timer(state)}
   end
 
   def handle_call(:selected, _from, state) do
@@ -602,7 +622,9 @@ defmodule MayonnaiOS.Launcher do
 
     state = if leaving?, do: state |> stop_app() |> go_home(), else: state
 
-    {:noreply, leave_app(state, events)}
+    state = leave_app(state, events)
+    state = if real_press?(events), do: reset_idle_timer(state), else: state
+    {:noreply, state}
   end
 
   def handle_info({:input_event, _device, events}, state) do
@@ -620,8 +642,30 @@ defmodule MayonnaiOS.Launcher do
         _, acc -> acc
       end)
 
+    state = if real_press?(events), do: reset_idle_timer(state), else: state
     {:noreply, state}
   end
+
+  # Only the newest timeout is authoritative. Button presses cancel and
+  # replace timers, but a message already delivered to this mailbox cannot be
+  # recalled; the token makes that stale message harmless.
+  def handle_info({:idle_sleep, token}, %{idle_timer: {_timer, token}} = state) do
+    state = %{state | idle_timer: nil}
+
+    cond do
+      not idle_eligible?(state) ->
+        {:noreply, state}
+
+      state.power_state.() in [:charging, :full] ->
+        {:noreply, reset_idle_timer(state)}
+
+      true ->
+        {_result, state} = enter_sleep(state)
+        {:noreply, if(state.asleep, do: state, else: reset_idle_timer(state))}
+    end
+  end
+
+  def handle_info({:idle_sleep, _stale_token}, state), do: {:noreply, state}
 
   # The program exited on its own. Name it from `running` rather than from the
   # cursor: the cursor may well have moved while the program had the screen,
@@ -650,7 +694,8 @@ defmodule MayonnaiOS.Launcher do
     # before this clause returns, so the panel comes back first.
     state.flush_saves.()
 
-    {:noreply, %{state | port: nil, running: nil, output: []}}
+    state = %{state | port: nil, running: nil, output: []}
+    {:noreply, reset_idle_timer(state)}
   end
 
   # Log what the program says, rather than dropping it.
@@ -706,6 +751,31 @@ defmodule MayonnaiOS.Launcher do
 
   defp hold(state, key), do: %{state | held: MapSet.put(state.held, key)}
   defp release(state, key), do: %{state | held: MapSet.delete(state.held, key)}
+
+  defp real_press?(events),
+    do: Enum.any?(events, &match?({:ev_key, _key, 1}, &1))
+
+  defp idle_eligible?(state),
+    do: not state.asleep and state.port == nil and state.app == nil and state.scene == :home
+
+  defp reset_idle_timer(state) do
+    state = cancel_idle_timer(state)
+
+    if idle_eligible?(state) and is_integer(state.idle_sleep_ms) and state.idle_sleep_ms > 0 do
+      token = make_ref()
+      timer = Process.send_after(self(), {:idle_sleep, token}, state.idle_sleep_ms)
+      %{state | idle_timer: {timer, token}}
+    else
+      state
+    end
+  end
+
+  defp cancel_idle_timer(%{idle_timer: nil} = state), do: state
+
+  defp cancel_idle_timer(%{idle_timer: {timer, _token}} = state) do
+    Process.cancel_timer(timer)
+    %{state | idle_timer: nil}
+  end
 
   # The held set is folded one event at a time and the trigger is asked after
   # each press, exactly as the ordinary path does it, so that a `@binding` with
@@ -861,7 +931,7 @@ defmodule MayonnaiOS.Launcher do
         # write landed, for the same reason as the flag -- a sleep signal over
         # a lit screen would be the LED lying about the panel.
         Led.set(:sleeping)
-        {:ok, %{state | asleep: true}}
+        {:ok, state |> Map.put(:asleep, true) |> cancel_idle_timer()}
 
       {:error, reason} ->
         {{:error, reason}, state}
@@ -881,7 +951,8 @@ defmodule MayonnaiOS.Launcher do
     # the flag: this process now treats the device as awake, and the LED
     # reports what this process does with button presses, not the panel.
     Led.set(:running)
-    {Sleep.wake(), %{state | asleep: false, held: MapSet.new()}}
+    state = %{state | asleep: false, held: MapSet.new()}
+    {Sleep.wake(), reset_idle_timer(state)}
   end
 
   defp bound(state, @launch_button), do: do_launch(state)

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -502,6 +502,103 @@ defmodule MayonnaiOS.LauncherTest do
     end
   end
 
+  describe "idle sleep" do
+    setup do
+      path =
+        Path.join(System.tmp_dir!(), "launcher-idle-sleep-#{System.unique_integer([:positive])}")
+
+      File.write!(path, "1")
+      Application.put_env(:mayonnaios, :backlight_brightness, path)
+
+      on_exit(fn ->
+        Application.delete_env(:mayonnaios, :backlight_brightness)
+        File.rm(path)
+        Application.delete_env(:mayonnaios, :programs)
+      end)
+
+      {:ok, backlight: path}
+    end
+
+    test "sleeps after three minutes of launcher inactivity", %{backlight: path} do
+      start_idle_launcher(:discharging)
+
+      fire_idle_timeout()
+
+      assert Launcher.asleep?()
+      assert File.read!(path) == "0"
+      assert :sys.get_state(Launcher).idle_timer == nil
+    end
+
+    test "stays awake while charging and checks again later" do
+      start_idle_launcher(:charging)
+      {_timer, first_token} = :sys.get_state(Launcher).idle_timer
+
+      fire_idle_timeout()
+
+      refute Launcher.asleep?()
+      assert {_timer, next_token} = :sys.get_state(Launcher).idle_timer
+      assert next_token != first_token
+    end
+
+    test "a real press resets the timer but autorepeat does not" do
+      start_idle_launcher(:discharging)
+      {_timer, first_token} = :sys.get_state(Launcher).idle_timer
+
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, :btn_dpad_down, 2}]})
+      Launcher.selected()
+      assert {_timer, ^first_token} = :sys.get_state(Launcher).idle_timer
+
+      idle_press(:btn_dpad_down)
+      assert {_timer, next_token} = :sys.get_state(Launcher).idle_timer
+      assert next_token != first_token
+
+      # A timeout already delivered before the cancellation is harmless.
+      send(Launcher, {:idle_sleep, first_token})
+      refute Launcher.asleep?()
+    end
+
+    test "the timer is disabled while a BEAM app owns the launcher" do
+      Application.put_env(:mayonnaios, :programs, [
+        %{name: "Readout", app: FakeReadout, category: :apps}
+      ])
+
+      start_idle_launcher(:discharging)
+
+      # Apps is the third root row. A opens the category, then the app.
+      idle_press(:btn_dpad_down)
+      idle_press(:btn_dpad_down)
+      idle_press(:btn_b)
+      idle_press(:btn_b)
+
+      assert :sys.get_state(Launcher).app == FakeReadout
+      assert :sys.get_state(Launcher).idle_timer == nil
+
+      # B leaves the app and starts a fresh launcher-idle interval.
+      idle_press(:btn_a)
+      assert :sys.get_state(Launcher).app == nil
+      assert {_timer, _token} = :sys.get_state(Launcher).idle_timer
+    end
+
+    defp start_idle_launcher(power_state) do
+      start_supervised!(
+        {Launcher,
+         device: "/nonexistent/event0", idle_sleep_ms: 60_000, power_state: fn -> power_state end}
+      )
+    end
+
+    defp fire_idle_timeout do
+      {_timer, token} = :sys.get_state(Launcher).idle_timer
+      send(Launcher, {:idle_sleep, token})
+      Launcher.asleep?()
+    end
+
+    defp idle_press(key) do
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 1}]})
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 0}]})
+      Launcher.selected()
+    end
+  end
+
   describe "the Power off row" do
     setup do
       programs = [%{path: "/a"}, %{name: "Power off", action: :poweroff}]


### PR DESCRIPTION
## Summary

- sleep after three minutes without a real launcher button press
- pause the timeout while charging and disable it for external programs and BEAM apps
- ignore autorepeat and stale timer messages, and restart a fresh interval after wake or returning home
- document the behavior and cover timeout, charging, app handoff, and timer-reset cases

## Verification

- mix compile --warnings-as-errors
- mix test test/sleep_test.exs test/launcher_test.exs:505 (22 passed)
- full launcher suite: 53/54 passed; the existing process-liveness timing test at launcher_test.exs:821 did not observe the short-lived process before it exited

Closes #47