### PR TITLE
Blink the LED red on low battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Software:
 - Orderly power off: the Select+Menu chord, or the **Power off** row under
   System
 - An indicator LED that means something: quick flashing green while starting,
-  solid green running, slow flashing green asleep, blinking red when the
-  application fails to start. The yellow light in the other window is the
-  PMIC's charge indicator and keeps its own counsel; `MayonnaiOS.Led`'s
-  moduledoc has the color map
+  solid green running, slow flashing green asleep, slow blinking red at 20%
+  battery, and quick blinking red when the application fails to start. Low
+  battery clears at 30% or while charging; failure always wins. The yellow
+  light in the other window is the PMIC's charge indicator and keeps its own
+  counsel; `MayonnaiOS.Led`'s moduledoc has the color map
 
 ## Building and flashing
 

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -20,6 +20,7 @@ defmodule MayonnaiOS.Application do
     children =
       signs_of_life() ++
         [status()] ++
+        led_monitor() ++
         viewport() ++
         [controller_sessions(), pairing_sessions(), pickle_sessions()] ++
         [top_sessions(), update_sessions(), moonlight_sessions(), wifi_sessions()] ++
@@ -120,6 +121,7 @@ defmodule MayonnaiOS.Application do
   # List all child processes to be supervised
   if Mix.target() == :host do
     defp signs_of_life(), do: []
+    defp led_monitor(), do: []
 
     defp target_children() do
       [
@@ -131,6 +133,11 @@ defmodule MayonnaiOS.Application do
       ]
     end
   else
+    # Starts after Status so its first subscription gets a battery reading.
+    # The direct :starting write remains ahead of both in signs_of_life/0;
+    # this process is the arbiter once normal supervision is available.
+    defp led_monitor(), do: [MayonnaiOS.Led.Monitor]
+
     # The two children that say the software is alive, at the very front of
     # the tree -- ahead of Scenic and ahead of every poller.
     #

--- a/lib/mayonnaios/led.ex
+++ b/lib/mayonnaios/led.ex
@@ -1,6 +1,6 @@
 defmodule MayonnaiOS.Led do
   @moduledoc """
-  The indicator LED, driven as a five-state signal.
+  The indicator LED, driven as a six-state signal.
 
   The window nearest the HDMI port holds two emitters behind one hole, and
   sysfs names both after colors the device tree assigned, not the colors they
@@ -22,6 +22,7 @@ defmodule MayonnaiOS.Led do
   | `:starting` | quick flashing green       | BEAM up, supervision tree rising |
   | `:running`  | solid green                | the whole tree came up           |
   | `:sleeping` | slow flashing green        | backlight off, still running     |
+  | `:low_battery` | slow blinking red       | 20% or less and not charging     |
   | `:failure`  | blinking red               | the application failed to start  |
   | `:off`      | dark                       | (also what a powered-off board shows) |
 
@@ -35,6 +36,13 @@ defmodule MayonnaiOS.Led do
   `CONFIG_LEDS_GPIO` and `CONFIG_LEDS_TRIGGER_TIMER` are built in, so all of
   this is sysfs writes: `timer` with `delay_on`/`delay_off` for the flashing
   states, `none` plus a brightness for solid and dark.
+
+  `MayonnaiOS.Led.Monitor` arbitrates the states once supervision is running:
+  failure wins over low battery, low battery wins over running and sleeping,
+  and starting/off remain explicit. Low battery enters at 20%, clears at 30%,
+  and clears immediately while charging or full. `set/1` routes through that
+  process when it exists and writes directly before it starts or after the
+  supervision tree has failed.
 
   ## On a laptop
 
@@ -60,8 +68,9 @@ defmodule MayonnaiOS.Led do
   @quick {100, 100}
   @slow {1000, 1000}
   @blink {250, 250}
+  @low_battery_blink {1000, 1000}
 
-  @type state :: :starting | :running | :sleeping | :failure | :off
+  @type state :: :starting | :running | :sleeping | :low_battery | :failure | :off
 
   @doc false
   # Two entries in the supervision tree, one state each: `{MayonnaiOS.Led,
@@ -94,6 +103,15 @@ defmodule MayonnaiOS.Led do
   """
   @spec set(state()) :: :ok | {:error, File.posix()}
   def set(state) do
+    case Process.whereis(MayonnaiOS.Led.Monitor) do
+      nil -> write_state(state)
+      _pid -> MayonnaiOS.Led.Monitor.set(state)
+    end
+  end
+
+  @doc false
+  @spec write_state(state()) :: :ok | {:error, File.posix()}
+  def write_state(state) do
     if File.dir?(dir()) do
       apply_state(state)
     else
@@ -105,6 +123,7 @@ defmodule MayonnaiOS.Led do
   defp apply_state(:starting), do: combine(off(@red), flash(@green, @quick))
   defp apply_state(:running), do: combine(off(@red), solid(@green))
   defp apply_state(:sleeping), do: combine(off(@red), flash(@green, @slow))
+  defp apply_state(:low_battery), do: combine(off(@green), flash(@red, @low_battery_blink))
   defp apply_state(:failure), do: combine(off(@green), flash(@red, @blink))
   defp apply_state(:off), do: combine(off(@red), off(@green))
 

--- a/lib/mayonnaios/led/monitor.ex
+++ b/lib/mayonnaios/led/monitor.ex
@@ -1,0 +1,83 @@
+defmodule MayonnaiOS.Led.Monitor do
+  @moduledoc """
+  Arbitrates the requested LED state with battery state.
+
+  The launcher still asks for `:running` and `:sleeping`; this process keeps
+  that request while `MayonnaiOS.Status` supplies battery readings. Entering
+  low battery at 20% and leaving it at 30% prevents a fuel-gauge reading near
+  the boundary from changing the LED every poll.
+  """
+
+  use GenServer
+
+  alias MayonnaiOS.{Led, Power, Status}
+
+  @low_percent 20
+  @clear_percent 30
+
+  defstruct base: :starting, low_battery: false, drawn: nil, status: Status
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec set(Led.state()) :: :ok | {:error, File.posix()}
+  def set(state), do: GenServer.call(__MODULE__, {:set, state})
+
+  @impl GenServer
+  def init(opts) do
+    status = Keyword.get(opts, :status, Status)
+    if status, do: Status.subscribe(status)
+
+    state = %__MODULE__{status: status}
+    {_result, state} = draw(state)
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:set, base}, _from, state) do
+    {result, state} = state |> Map.put(:base, base) |> draw()
+    {:reply, result, state}
+  end
+
+  @impl GenServer
+  def handle_info({:mayonnaios_status, reading}, state) do
+    state = %{state | low_battery: low_battery?(state.low_battery, reading)}
+    {_result, state} = draw(state)
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  defp low_battery?(was_low, %{battery: %{value: values, error: nil}})
+       when is_map(values) do
+    case {Power.state(values), Map.get(values, :capacity)} do
+      {state, capacity}
+      when state in [:discharging, :not_charging] and is_integer(capacity) ->
+        if was_low, do: capacity < @clear_percent, else: capacity <= @low_percent
+
+      _other ->
+        false
+    end
+  end
+
+  defp low_battery?(_was_low, _reading), do: false
+
+  defp effective(%{base: :failure}), do: :failure
+
+  defp effective(%{base: base, low_battery: true}) when base in [:running, :sleeping],
+    do: :low_battery
+
+  defp effective(%{base: base}), do: base
+
+  defp draw(state) do
+    next = effective(state)
+
+    if next == state.drawn do
+      {:ok, state}
+    else
+      {Led.write_state(next), %{state | drawn: next}}
+    end
+  end
+end

--- a/test/led_test.exs
+++ b/test/led_test.exs
@@ -65,10 +65,81 @@ defmodule MayonnaiOS.LedTest do
       assert read(dir, @green, "brightness") == "0"
     end
 
+    test "low battery blinks red more slowly than failure", %{dir: dir} do
+      assert Led.set(:low_battery) == :ok
+      assert read(dir, @red, "trigger") == "timer"
+      assert read(dir, @red, "delay_on") == "1000"
+      assert read(dir, @red, "delay_off") == "1000"
+      assert read(dir, @green, "brightness") == "0"
+    end
+
     test "off darkens both", %{dir: dir} do
       assert Led.set(:off) == :ok
       assert read(dir, @green, "brightness") == "0"
       assert read(dir, @red, "brightness") == "0"
+    end
+  end
+
+  describe "battery arbitration" do
+    test "enters at 20 percent, holds through hysteresis, and clears at 30", %{dir: dir} do
+      start_supervised!({Led.Monitor, status: nil})
+      assert Led.set(:running) == :ok
+
+      battery(20, "Discharging")
+      assert read(dir, @red, "delay_on") == "1000"
+      assert :sys.get_state(Led.Monitor).low_battery
+
+      battery(25, "Discharging")
+      assert :sys.get_state(Led.Monitor).low_battery
+      assert read(dir, @red, "delay_on") == "1000"
+
+      battery(30, "Discharging")
+      refute :sys.get_state(Led.Monitor).low_battery
+      assert read(dir, @green, "brightness") == "1"
+      assert read(dir, @red, "brightness") == "0"
+    end
+
+    test "charging and unavailable readings clear low battery", %{dir: dir} do
+      start_supervised!({Led.Monitor, status: nil})
+      Led.set(:sleeping)
+
+      battery(10, "Not charging")
+      assert :sys.get_state(Led.Monitor).low_battery
+
+      battery(10, "Charging")
+      refute :sys.get_state(Led.Monitor).low_battery
+      assert read(dir, @green, "delay_on") == "1000"
+
+      battery(10, "Discharging")
+      assert :sys.get_state(Led.Monitor).low_battery
+
+      send(Led.Monitor, {:mayonnaios_status, %{battery: %{value: nil, error: :unavailable}}})
+      refute :sys.get_state(Led.Monitor).low_battery
+      assert read(dir, @green, "delay_on") == "1000"
+    end
+
+    test "failure outranks low battery", %{dir: dir} do
+      start_supervised!({Led.Monitor, status: nil})
+      Led.set(:running)
+      battery(5, "Discharging")
+
+      assert Led.set(:failure) == :ok
+      assert read(dir, @red, "delay_on") == "250"
+      assert read(dir, @red, "delay_off") == "250"
+
+      battery(4, "Discharging")
+      assert read(dir, @red, "delay_on") == "250"
+      assert :sys.get_state(Led.Monitor).drawn == :failure
+    end
+
+    defp battery(capacity, status) do
+      send(
+        Led.Monitor,
+        {:mayonnaios_status,
+         %{battery: %{value: %{capacity: capacity, status: status}, error: nil}}}
+      )
+
+      :sys.get_state(Led.Monitor)
     end
   end
 


### PR DESCRIPTION
## Summary

- add an LED monitor that consumes the existing Status battery feed
- enter low-battery at 20%, retain it through hysteresis, and clear at 30%
- clear immediately while charging/full or when battery data is unavailable
- use a slow red blink for low battery while preserving the fast red failure signal
- arbitrate failure above low battery and low battery above running/sleeping

## Verification

- mix compile --warnings-as-errors
- RG40XXV target compile succeeded with the local BSP checkout and placeholder build-time Wi-Fi values
- mix test test/led_test.exs test/status_bar_test.exs test/sleep_test.exs (52 passed)
- full suite: 1034/1035 passed; the existing process-liveness timing test at launcher_test.exs:724 did not observe the short-lived process before it exited

Closes #45