### PR TITLE
Surface network time synchronization

### DIFF
--- a/lib/mayonnaios/clock.ex
+++ b/lib/mayonnaios/clock.ex
@@ -1,0 +1,36 @@
+defmodule MayonnaiOS.Clock do
+  @moduledoc """
+  Reports whether network time has synchronized in this boot.
+
+  `nerves_time` is a target dependency through `nerves_pack`; the module is
+  absent on a host development machine. Keeping that distinction explicit
+  lets Diagnostics say `unavailable` on a laptop and `never synchronized` on
+  a device whose clock has not yet been established.
+  """
+
+  @type status :: :synchronized | :never_synchronized | :unavailable
+
+  @spec status((-> boolean() | :unavailable)) :: status()
+  def status(checker \\ &nerves_time_status/0) do
+    case checker.() do
+      true -> :synchronized
+      false -> :never_synchronized
+      :unavailable -> :unavailable
+    end
+  end
+
+  @spec synchronized?((-> boolean() | :unavailable)) :: boolean()
+  def synchronized?(checker \\ &nerves_time_status/0), do: status(checker) == :synchronized
+
+  defp nerves_time_status do
+    if Code.ensure_loaded?(NervesTime) and function_exported?(NervesTime, :synchronized?, 0) do
+      apply(NervesTime, :synchronized?, [])
+    else
+      :unavailable
+    end
+  rescue
+    _error -> false
+  catch
+    :exit, _reason -> false
+  end
+end

--- a/lib/mayonnaios/diagnostics.ex
+++ b/lib/mayonnaios/diagnostics.ex
@@ -57,6 +57,7 @@ defmodule MayonnaiOS.Diagnostics do
   use GenServer
   require Logger
 
+  alias MayonnaiOS.Clock
   alias MayonnaiOS.Bluetooth.HCISocket
 
   # Looked up by name at startup, and by name only -- no numbered fallbacks.
@@ -82,6 +83,7 @@ defmodule MayonnaiOS.Diagnostics do
   defstruct battery: %{},
             thermal: [],
             rtc: %{},
+            time_sync: :unavailable,
             bluetooth: %{},
             audio: %{},
             gpu: %{client: nil, engines: %{}},
@@ -223,6 +225,7 @@ defmodule MayonnaiOS.Diagnostics do
       | battery: read_battery(),
         thermal: read_thermal(),
         rtc: read_rtc(),
+        time_sync: Clock.status(),
         bluetooth: read_bluetooth(state.rtl, state.bt_probe),
         audio: audio,
         gpu: gpu,

--- a/lib/mayonnaios/scene/diagnostics.ex
+++ b/lib/mayonnaios/scene/diagnostics.ex
@@ -157,7 +157,7 @@ defmodule MayonnaiOS.Scene.Diagnostics do
       thermal_rows(s.thermal) ++
       [{:head, "GPU"}] ++
       gpu_rows(s.gpu) ++
-      [{:head, "REAL-TIME CLOCK"}] ++ rtc_rows(s.rtc)
+      [{:head, "TIME"}] ++ time_rows(s.rtc, s.time_sync)
   end
 
   defp battery_rows(b) do
@@ -213,12 +213,20 @@ defmodule MayonnaiOS.Scene.Diagnostics do
     [{:row, "client", name, @pass}] ++ rows
   end
 
-  defp rtc_rows(r) do
+  defp time_rows(r, sync) do
+    {sync_text, sync_colour} =
+      case sync do
+        :synchronized -> {"synchronized", @pass}
+        :never_synchronized -> {"never synchronized", @fail}
+        :unavailable -> {"unavailable", @dim}
+      end
+
     [
-      {:row, "clock", "#{r[:date] || "--"} #{r[:time] || ""}",
+      {:row, "RTC", "#{r[:date] || "--"} #{r[:time] || ""}",
        if(r[:date], do: @pass, else: @fail)},
       {:row, "set at boot", if(r[:hctosys], do: "yes", else: "no"),
-       if(r[:hctosys], do: @pass, else: @fail)}
+       if(r[:hctosys], do: @pass, else: @fail)},
+      {:row, "network time", sync_text, sync_colour}
     ]
   end
 

--- a/lib/mayonnaios/scene/update.ex
+++ b/lib/mayonnaios/scene/update.ex
@@ -228,6 +228,10 @@ defmodule MayonnaiOS.Scene.Update do
     do: "Not enough free space on #{path} (need #{bytes(needed)})."
 
   defp reason({:http, _}), do: "Could not reach GitHub. Check the network connection."
+
+  defp reason({:clock_unsynchronized, _reason}),
+    do: "The clock has never synchronized. Connect to the internet and try again."
+
   defp reason({:http_status, status}), do: "GitHub returned an unexpected status (#{status})."
   defp reason({:fwup_failed, status, _output}), do: "fwup exited with status #{status}."
   defp reason(:fwup_not_found), do: "fwup is missing from this image."

--- a/lib/mayonnaios/update/app.ex
+++ b/lib/mayonnaios/update/app.ex
@@ -49,7 +49,7 @@ defmodule MayonnaiOS.Update.App do
 
   use GenServer
 
-  alias MayonnaiOS.Update
+  alias MayonnaiOS.{Clock, Update}
 
   @sessions MayonnaiOS.Update.App.Sessions
 
@@ -159,6 +159,7 @@ defmodule MayonnaiOS.Update.App do
       check_opts: Keyword.get(opts, :check_opts, []),
       download_opts: Keyword.get(opts, :download_opts, []),
       apply_opts: Keyword.get(opts, :apply_opts, []),
+      time_synchronized?: Keyword.get(opts, :time_synchronized?, &Clock.synchronized?/0),
       # Injectable for the tests, the same way `MayonnaiOS.Launcher`'s
       # `:poweroff` is: the real thing is `no_return()` and cannot run on a
       # laptop, or in a test, without ending the process running it.
@@ -238,7 +239,7 @@ defmodule MayonnaiOS.Update.App do
     do: %{state | status: :up_to_date, result: result, error: nil, worker: nil}
 
   defp apply_check_result({:error, reason}, state),
-    do: %{state | status: :error, result: nil, error: reason, worker: nil}
+    do: %{state | status: :error, result: nil, error: diagnose(reason, state), worker: nil}
 
   defp start_transfer(%{result: %{asset: nil}} = state) do
     %{state | status: :error, error: :no_asset}
@@ -281,7 +282,13 @@ defmodule MayonnaiOS.Update.App do
     do: %{state | status: :done, error: nil, worker: nil}
 
   defp apply_transfer_result({:error, reason}, state),
-    do: %{state | status: :error, error: reason, worker: nil}
+    do: %{state | status: :error, error: diagnose(reason, state), worker: nil}
+
+  defp diagnose({:http, _reason} = reason, state) do
+    if state.time_synchronized?.(), do: reason, else: {:clock_unsynchronized, reason}
+  end
+
+  defp diagnose(reason, _state), do: reason
 
   defp schedule_progress(state), do: Process.send_after(self(), :poll_progress, state.poll_ms)
 

--- a/test/clock_test.exs
+++ b/test/clock_test.exs
@@ -1,0 +1,31 @@
+defmodule MayonnaiOS.ClockTest do
+  use ExUnit.Case, async: true
+
+  alias MayonnaiOS.{Clock, Diagnostics}
+  alias MayonnaiOS.Scene.Diagnostics, as: DiagnosticsScene
+
+  test "distinguishes synchronized, never synchronized, and unavailable" do
+    assert Clock.status(fn -> true end) == :synchronized
+    assert Clock.status(fn -> false end) == :never_synchronized
+    assert Clock.status(fn -> :unavailable end) == :unavailable
+
+    assert Clock.synchronized?(fn -> true end)
+    refute Clock.synchronized?(fn -> false end)
+    refute Clock.synchronized?(fn -> :unavailable end)
+  end
+
+  test "diagnostics says whether network time has ever synchronized" do
+    synchronized = texts(DiagnosticsScene.graph(%Diagnostics{time_sync: :synchronized}))
+    waiting = texts(DiagnosticsScene.graph(%Diagnostics{time_sync: :never_synchronized}))
+
+    assert "synchronized" in synchronized
+    assert "never synchronized" in waiting
+  end
+
+  defp texts(graph) do
+    Scenic.Graph.reduce(graph, [], fn
+      %Scenic.Primitive{module: Scenic.Primitive.Text, data: data}, acc -> [data | acc]
+      _primitive, acc -> acc
+    end)
+  end
+end

--- a/test/update/app_test.exs
+++ b/test/update/app_test.exs
@@ -79,10 +79,18 @@ defmodule MayonnaiOS.Update.AppTest do
 
     test "a check failure is shown rather than raised" do
       fetch = fn _url -> {:error, :timeout} end
-      start_supervised!({App, check_opts: [fetch: fetch]})
+      start_supervised!({App, check_opts: [fetch: fetch], time_synchronized?: fn -> true end})
 
       snapshot = await_status([:error])
       assert snapshot.error == {:http, :timeout}
+    end
+
+    test "an HTTPS failure diagnoses a clock that has never synchronized" do
+      fetch = fn _url -> {:error, :timeout} end
+      start_supervised!({App, check_opts: [fetch: fetch], time_synchronized?: fn -> false end})
+
+      snapshot = await_status([:error])
+      assert snapshot.error == {:clock_unsynchronized, {:http, :timeout}}
     end
 
     test "a release with no matching firmware asset is still available" do
@@ -284,6 +292,16 @@ defmodule MayonnaiOS.Update.AppTest do
     test "an error names what went wrong" do
       texts = texts(Scene.graph(%{status: :error, error: :no_releases}))
       assert Enum.any?(texts, &String.contains?(&1, "no published releases"))
+
+      clock =
+        texts(
+          Scene.graph(%{
+            status: :error,
+            error: {:clock_unsynchronized, {:http, :timeout}}
+          })
+        )
+
+      assert Enum.any?(clock, &String.contains?(&1, "clock has never synchronized"))
     end
 
     test "nothing is drawn above the shared status bar" do


### PR DESCRIPTION
## Summary

- keep the existing status-bar clock explicitly UTC
- report synchronized, never synchronized, or unavailable network time in Diagnostics
- distinguish an unsynchronized target from a host where nerves_time is unavailable
- turn connection-level update failures into a clear clock diagnosis when time has never synchronized
- preserve ordinary HTTP/server and local update errors

## Verification

- mix compile --warnings-as-errors
- RG40XXV target compile succeeded with the local BSP checkout and placeholder build-time Wi-Fi values
- mix test test/clock_test.exs test/update_test.exs test/update/app_test.exs test/status_bar_test.exs (72 passed)

Hardware follow-up: confirm Diagnostics changes from never synchronized to synchronized after Wi-Fi gains internet access.

Closes #49