### PR TITLE
Run the full launcher in host development

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,15 +361,24 @@ tests run:
 
 No hardware required.
 
-The UI runs on the laptop too, in a window at the panel's own 640×480 — a scene
-that looks right at some other size is not evidence about the device:
+The complete development runtime runs on the laptop too, in a window at the
+panel's own 640×480 — a scene that looks right at some other size is not
+evidence about the device:
 
     iex -S mix
-    iex> MayonnaiOS.start_ui()
 
     # ... edit a scene ...
     iex> recompile()
     iex> MayonnaiOS.reload_ui()
+
+In `dev`, that one command starts Scenic, the real launcher, the keyboard
+controller bridge, the web UI on <http://localhost:4000>, and the same Elixir
+and Luerl app supervisors used by the device. A short shell command stands in
+for an external KMS program so the display-handoff path can be exercised
+without installing RetroArch or Moonlight. The Files column is rooted at
+`tmp/host/files`, and the worked `hello` pickle is copied once into the
+gitignored `.pickles` state so its graphical Lua app is present immediately.
+`mix test` stays headless and starts none of these development-only children.
 
 `recompile/0` alone changes nothing on screen. A scene is a process holding an
 already-built graph, and swapping the module's code does not rebuild it;

--- a/config/host.exs
+++ b/config/host.exs
@@ -2,10 +2,37 @@ import Config
 
 # Add configuration that is only needed when running on the host here.
 
-# Pickles on the host go under the working directory rather than /root, so
-# `iex -S mix` can exercise the whole install/run loop on a laptop. Tests
-# override this per-test with a tmp directory.
-config :mayonnaios, pickles_root: ".pickles"
+# Host development state is isolated from both the repository sources and the
+# device paths. HostRuntime creates these paths before the launcher starts.
+host_files = Path.expand("tmp/host/files")
+host_backlight = Path.expand("tmp/host/brightness")
+
+config :mayonnaios,
+  pickles_root: Path.expand(".pickles"),
+  file_roots: [%{key: "host", path: host_files, note: "host development scratch files"}],
+  backlight_brightness: host_backlight,
+  web_port: 4000,
+  # `mix test` stays headless. `iex -S mix` and `mix run --no-halt` in dev
+  # start the complete host launcher automatically.
+  autostart_ui: config_env() == :dev,
+  host_runtime: config_env() == :dev
+
+# One external-process stand-in exercises the same panel handoff and obituary
+# path as RetroArch without requiring a host RetroArch build. The remaining
+# rows are device-independent Elixir apps; installed UI pickles are appended
+# dynamically by MayonnaiOS.Programs.
+config :mayonnaios, :programs, [
+  %{
+    name: "Host program (launcher handoff)",
+    path: "/bin/sh",
+    args: ["-c", "printf 'host program running\\n'; sleep 1"]
+  },
+  %{name: "Moonlight settings", app: MayonnaiOS.Moonlight.App},
+  %{name: "BEAM processes", app: {MayonnaiOS.Top, :beam}},
+  %{name: "OS processes", app: {MayonnaiOS.Top, :os}},
+  %{name: "WiFi", app: MayonnaiOS.WiFi.App},
+  %{name: "Software update", app: MayonnaiOS.Update.App}
+]
 
 config :nerves_runtime,
   kv_backend:

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -122,13 +122,11 @@ defmodule MayonnaiOS.Application do
     defp signs_of_life(), do: []
 
     defp target_children() do
-      [
-        # Children that only run on the host during development or test.
-        # In general, prefer using `config/host.exs` for differences.
-        #
-        # Starts a worker by calling: Host.Worker.start_link(arg)
-        # {Host.Worker, arg},
-      ]
+      if Application.get_env(:mayonnaios, :host_runtime, false) do
+        MayonnaiOS.HostRuntime.children()
+      else
+        []
+      end
     end
   else
     # The two children that say the software is alive, at the very front of

--- a/lib/mayonnaios/host_runtime.ex
+++ b/lib/mayonnaios/host_runtime.ex
@@ -1,0 +1,76 @@
+defmodule MayonnaiOS.HostRuntime do
+  @moduledoc """
+  Prepares and starts the complete host development runtime.
+
+  The host uses the real Launcher, Scenic scenes, Elixir apps and Luerl pickle
+  runner. Only the hardware edges are substituted: keyboard events become the
+  gamepad's evdev reports, one short shell command stands in for an external
+  KMS program, and writable state lives in ignored development directories.
+  """
+
+  use GenServer
+
+  @doc false
+  def children do
+    [__MODULE__, MayonnaiOS.Web, MayonnaiOS.Launcher, MayonnaiOS.Keyboard]
+  end
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    paths = %{
+      files: Keyword.get(opts, :files, host_file_root()),
+      backlight: Keyword.get(opts, :backlight, MayonnaiOS.Sleep.path()),
+      pickles: Keyword.get(opts, :pickles, MayonnaiOS.Pickles.root()),
+      example: Keyword.get(opts, :example, Path.expand("pickles/hello"))
+    }
+
+    case prepare(paths) do
+      :ok -> {:ok, paths}
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  @doc false
+  def prepare(paths) do
+    with :ok <- File.mkdir_p(paths.files),
+         :ok <- seed_file(Path.join(paths.files, "README.txt"), host_readme()),
+         :ok <- File.mkdir_p(Path.dirname(paths.backlight)),
+         :ok <- seed_file(paths.backlight, "1"),
+         :ok <- File.mkdir_p(paths.pickles),
+         :ok <- seed_pickle(paths.example, Path.join(paths.pickles, "hello")) do
+      :ok
+    end
+  end
+
+  defp host_file_root do
+    case Application.get_env(:mayonnaios, :file_roots, []) do
+      [%{path: path} | _] -> path
+      _ -> Path.expand("tmp/host/files")
+    end
+  end
+
+  defp seed_file(path, contents) do
+    if File.exists?(path), do: :ok, else: File.write(path, contents)
+  end
+
+  defp seed_pickle(source, destination) do
+    if File.dir?(destination) do
+      :ok
+    else
+      case File.cp_r(source, destination) do
+        {:ok, _paths} -> :ok
+        {:error, reason, _path} -> {:error, reason}
+      end
+    end
+  end
+
+  defp host_readme do
+    "This directory is MayonnaiOS host-development scratch space.\n" <>
+      "Use the Files column to exercise copy, move, rename and delete safely.\n"
+  end
+end

--- a/test/host_runtime_test.exs
+++ b/test/host_runtime_test.exs
@@ -1,0 +1,55 @@
+defmodule MayonnaiOS.HostRuntimeTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.{HostRuntime, Programs}
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "host-runtime-#{System.unique_integer([:positive])}")
+    files = Path.join(root, "files")
+    pickles = Path.join(root, "pickles")
+    backlight = Path.join(root, "brightness")
+    previous_pickles = Application.get_env(:mayonnaios, :pickles_root)
+
+    Application.put_env(:mayonnaios, :pickles_root, pickles)
+
+    on_exit(fn ->
+      Application.put_env(:mayonnaios, :pickles_root, previous_pickles)
+      File.rm_rf(root)
+    end)
+
+    %{files: files, pickles: pickles, backlight: backlight}
+  end
+
+  test "prepares safe writable state and a graphical Luerl example", context do
+    assert :ok =
+             HostRuntime.prepare(%{
+               files: context.files,
+               pickles: context.pickles,
+               backlight: context.backlight,
+               example: Path.expand("pickles/hello")
+             })
+
+    assert File.exists?(Path.join(context.files, "README.txt"))
+    assert File.read!(context.backlight) == "1"
+    assert File.exists?(Path.join([context.pickles, "hello", "pickle.json"]))
+    assert File.exists?(Path.join([context.pickles, "hello", "main.lua"]))
+
+    programs = Programs.list()
+    assert Enum.any?(programs, &(&1.name == "Host program (launcher handoff)" and &1.installed?))
+    assert Enum.any?(programs, &(&1.app == {MayonnaiOS.Top, :beam}))
+    assert Enum.any?(programs, &(&1.app == {MayonnaiOS.Pickles.App, "hello"}))
+  end
+
+  test "dev children use the real launcher and keyboard controller bridge" do
+    assert HostRuntime.children() == [
+             MayonnaiOS.HostRuntime,
+             MayonnaiOS.Web,
+             MayonnaiOS.Launcher,
+             MayonnaiOS.Keyboard
+           ]
+
+    # The test environment remains headless for CI.
+    refute Application.get_env(:mayonnaios, :host_runtime)
+    refute Application.get_env(:mayonnaios, :autostart_ui)
+  end
+end


### PR DESCRIPTION
Closes #51

## Summary
- make `iex -S mix` start Scenic, the real launcher, keyboard bridge, and web UI automatically in development
- seed a safe scratch Files root and the graphical `hello` Luerl pickle
- expose real Elixir apps plus a host-safe external-process handoff stand-in
- keep the test environment headless

## Verification
- `mix compile --warnings-as-errors`
- `mix test test/host_runtime_test.exs test/mayonnaios_test.exs test/pickles/ui_test.exs test/keyboard_test.exs` (11 tests, 0 failures)
- headless host smoke: `%{hello: true, keyboard: true, launcher: true, web: true}`