### PR TITLE
Move board assumptions into validated device profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ network the device joins on a fresh card; more can be added on the device
 afterwards, from the **WiFi** screen below. Set them, pick the target, and
 build:
 
-    export RG40XXV_WIFI_SSID="your-ssid"
-    export RG40XXV_WIFI_PSK="your-psk"
+    export MAYONNAIOS_WIFI_SSID="your-ssid"
+    export MAYONNAIOS_WIFI_PSK="your-psk"
     export MIX_TARGET=rg40xxv
 
     mix deps.get
@@ -84,6 +84,14 @@ If `mix deps.get` starts compiling Buildroot instead of downloading a system,
 your tree does not match any published release and you are in for a full
 system build, which takes a while. That is usually a sign you changed something
 under `nerves_system_rg40xxv` — a comment is enough.
+
+Board facts live in `config/<target>.exs` as one validated
+`MayonnaiOS.Device` profile: the display name and size, input device names,
+physical-button mapping, LEDs, power supplies, games-card node, backlight, lid
+switch and RTC presence. Shared bundles, cores, systems and writable paths stay
+in `config/target.exs`. Adding a target requires a bootable Nerves system and a
+complete profile; the application fails at startup when either the profile or
+its panel/viewport agreement is incomplete.
 
 ## Changing which WiFi it joins
 

--- a/config/host.exs
+++ b/config/host.exs
@@ -7,6 +7,43 @@ import Config
 # override this per-test with a tmp directory.
 config :mayonnaios, pickles_root: ".pickles"
 
+# A complete profile keeps host development and tests on the same application
+# seams as a target without pretending the laptop has any of this hardware.
+config :mayonnaios, :device, %{
+  id: :host,
+  name: "MayonnaiOS host",
+  panel_size: {640, 480},
+  inputs: %{
+    gamepad: "host-gamepad",
+    stick: "host-stick",
+    volume: "host-volume",
+    headphone: "host-headphone",
+    power: "host-power"
+  },
+  buttons: %{
+    launch: :btn_b,
+    confirm: :btn_x,
+    actions: :btn_x,
+    full: :btn_y,
+    poweroff_modifier: :btn_select,
+    home: :btn_mode,
+    up: :btn_dpad_up,
+    down: :btn_dpad_down,
+    left: :btn_dpad_left,
+    right: :btn_dpad_right,
+    page_up: :btn_tl,
+    page_down: :btn_tr,
+    back: :btn_a,
+    sleep: :key_power
+  },
+  leds: %{green: "green:power", red: "green:status"},
+  power_supplies: %{battery: "/nonexistent/battery", usb: "/nonexistent/usb"},
+  games_card_device: "/nonexistent/games-card",
+  backlight: Path.expand("tmp/host/brightness"),
+  lid_switch: nil,
+  rtc?: true
+}
+
 config :nerves_runtime,
   kv_backend:
     {Nerves.Runtime.KVBackend.InMemory,

--- a/config/rg40xxv.exs
+++ b/config/rg40xxv.exs
@@ -1,0 +1,46 @@
+import Config
+
+# This board has no external RTC, so erlinit advances a stale clock at boot.
+config :nerves, :erlinit, update_clock: true
+
+# Facts specific to the physical RG40XXV. Shared application paths, bundles,
+# cores, systems and release behaviour remain in target.exs.
+config :mayonnaios, :device, %{
+  id: :rg40xxv,
+  name: "RG40XXV",
+  panel_size: {640, 480},
+  inputs: %{
+    gamepad: "gpio-keys-gamepad",
+    stick: "adc-joystick",
+    volume: "gpio-keys-volume",
+    headphone: "H616 Audio Codec Headphone Jack",
+    power: "axp20x-pek"
+  },
+  # These are physical verbs mapped to the atoms InputEvent emits. The
+  # RG40XXV device tree swaps both A/B and X/Y for this shell.
+  buttons: %{
+    launch: :btn_b,
+    confirm: :btn_x,
+    actions: :btn_x,
+    full: :btn_y,
+    poweroff_modifier: :btn_select,
+    home: :btn_mode,
+    up: :btn_dpad_up,
+    down: :btn_dpad_down,
+    left: :btn_dpad_left,
+    right: :btn_dpad_right,
+    page_up: :btn_tl,
+    page_down: :btn_tr,
+    back: :btn_a,
+    sleep: :key_power
+  },
+  leds: %{green: "green:power", red: "green:status"},
+  power_supplies: %{
+    battery: "/sys/class/power_supply/axp20x-battery",
+    usb: "/sys/class/power_supply/axp20x-usb"
+  },
+  games_card_device: "/dev/mmcblk2p1",
+  backlight: "/sys/class/backlight/backlight/brightness",
+  lid_switch: nil,
+  rtc?: false
+}

--- a/config/target.exs
+++ b/config/target.exs
@@ -23,9 +23,6 @@ config :nerves_runtime, startup_guard_enabled: true
 # https://github.com/nerves-project/erlinit/ for more information on
 # configuring erlinit.
 
-# Advance the system clock on devices without a real-time clock.
-config :nerves, :erlinit, update_clock: true
-
 # Configure the device for SSH IEx prompt access and firmware updates
 #
 # * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
@@ -56,8 +53,8 @@ wifi = fn var ->
     UART0 is on internal test pads, so firmware that boots without working
     WiFi credentials has to be recovered by reflashing the card.
 
-        export RG40XXV_WIFI_SSID="your-ssid"
-        export RG40XXV_WIFI_PSK="your-psk"
+        export MAYONNAIOS_WIFI_SSID="your-ssid"
+        export MAYONNAIOS_WIFI_PSK="your-psk"
     """
 end
 
@@ -91,8 +88,8 @@ config :vintage_net,
          networks: [
            %{
              key_mgmt: :wpa_psk,
-             ssid: wifi.("RG40XXV_WIFI_SSID"),
-             psk: wifi.("RG40XXV_WIFI_PSK")
+             ssid: wifi.("MAYONNAIOS_WIFI_SSID"),
+             psk: wifi.("MAYONNAIOS_WIFI_PSK")
            }
          ]
        },
@@ -410,7 +407,6 @@ config :mayonnaios, :bundles, %{
 # of a games card; see MayonnaiOS.GamesCard for what that costs on a
 # journal-less filesystem in a device that is switched off by pulling power.
 config :mayonnaios, :games_card,
-  device: "/dev/mmcblk2p1",
   mount_point: "/root/mnt/games",
   filesystems: ["exfat", "vfat"],
   options: "rw,nosuid,nodev,noexec",
@@ -609,6 +605,4 @@ config :mayonnaios, audio_test: true
 
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-# Uncomment to use target specific configurations
-
-# import_config "#{Mix.target()}.exs"
+import_config "#{Mix.target()}.exs"

--- a/lib/mayonnaios/application.ex
+++ b/lib/mayonnaios/application.ex
@@ -7,6 +7,10 @@ defmodule MayonnaiOS.Application do
 
   @impl true
   def start(_type, _args) do
+    # Fail with the missing board fact named, before starting any process that
+    # could otherwise degrade into a silent input, LED or power-supply fault.
+    MayonnaiOS.Device.load!()
+
     # Scenic is started on demand rather than from the supervision tree.
     #
     # If it fails during boot the whole application fails, StartupGuard never

--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -680,7 +680,7 @@ defmodule MayonnaiOS.Browser do
       %{kind: :category, id: :system, name: "System"}
     ]
 
-    level("RG40XXV", category_names, nil)
+    level(MayonnaiOS.Device.current!().name, category_names, nil)
   end
 
   defp expand(%{kind: :category, id: id, name: name}), do: category_level(id, name)

--- a/lib/mayonnaios/device.ex
+++ b/lib/mayonnaios/device.ex
@@ -1,0 +1,156 @@
+defmodule MayonnaiOS.Device do
+  @moduledoc """
+  The hardware facts for the device running MayonnaiOS.
+
+  A profile is configuration, not target detection. `MIX_TARGET` selects the
+  system that can boot a board; that target's config supplies the names and
+  mappings the application needs once it is running. Keeping those facts in
+  one validated struct prevents a missing key from degrading into a button or
+  LED that silently does nothing.
+  """
+
+  require Logger
+
+  @button_keys [
+    :launch,
+    :confirm,
+    :actions,
+    :full,
+    :poweroff_modifier,
+    :home,
+    :up,
+    :down,
+    :left,
+    :right,
+    :page_up,
+    :page_down,
+    :back,
+    :sleep
+  ]
+  @input_keys [:gamepad, :stick, :volume, :headphone, :power]
+
+  @enforce_keys [
+    :id,
+    :name,
+    :panel_size,
+    :inputs,
+    :buttons,
+    :leds,
+    :power_supplies,
+    :games_card_device,
+    :backlight,
+    :lid_switch,
+    :rtc?
+  ]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          id: atom(),
+          name: String.t(),
+          panel_size: {pos_integer(), pos_integer()},
+          inputs: %{required(atom()) => String.t()},
+          buttons: %{required(atom()) => atom()},
+          leds: %{green: String.t(), red: String.t()},
+          power_supplies: %{battery: String.t(), usb: String.t()},
+          games_card_device: String.t(),
+          backlight: String.t(),
+          lid_switch: nil | %{device: String.t(), key: atom()},
+          rtc?: boolean()
+        }
+
+  @doc "Read and validate the configured profile."
+  @spec current!() :: t()
+  def current! do
+    :mayonnaios
+    |> Application.fetch_env!(:device)
+    |> then(&struct!(__MODULE__, &1))
+    |> validate!()
+  end
+
+  @doc false
+  def load! do
+    profile = current!()
+
+    Logger.info(
+      "[device] #{profile.name} (#{profile.id}), #{format_size(profile.panel_size)}, " <>
+        "RTC #{present(profile.rtc?)}, lid switch #{present(profile.lid_switch != nil)}"
+    )
+
+    profile
+  end
+
+  @doc "Return one semantic button's evdev atom."
+  @spec button(atom()) :: atom()
+  def button(semantic), do: Map.fetch!(current!().buttons, semantic)
+
+  @doc "Return one input device's device-tree name."
+  @spec input(atom()) :: String.t()
+  def input(kind), do: Map.fetch!(current!().inputs, kind)
+
+  defp validate!(profile) do
+    require_keys!(profile.inputs, @input_keys, :inputs)
+    require_keys!(profile.buttons, @button_keys, :buttons)
+    require_keys!(profile.leds, [:green, :red], :leds)
+    require_keys!(profile.power_supplies, [:battery, :usb], :power_supplies)
+
+    unless is_atom(profile.id) and is_binary(profile.name) and profile.name != "" do
+      raise ArgumentError, "device :id must be an atom and :name must be a non-empty string"
+    end
+
+    unless match?(
+             {width, height}
+             when is_integer(width) and width > 0 and is_integer(height) and height > 0,
+             profile.panel_size
+           ) do
+      raise ArgumentError, "device :panel_size must contain two positive integers"
+    end
+
+    require_values!(profile.inputs, &is_binary/1, :inputs, "strings")
+    require_values!(profile.buttons, &is_atom/1, :buttons, "atoms")
+    require_values!(profile.leds, &is_binary/1, :leds, "strings")
+    require_values!(profile.power_supplies, &is_binary/1, :power_supplies, "strings")
+
+    unless is_binary(profile.games_card_device) and is_binary(profile.backlight) and
+             is_boolean(profile.rtc?) do
+      raise ArgumentError,
+            "device paths must be strings and :rtc? must be a boolean"
+    end
+
+    unless is_nil(profile.lid_switch) or
+             match?(
+               %{device: device, key: key} when is_binary(device) and is_atom(key),
+               profile.lid_switch
+             ) do
+      raise ArgumentError, "device :lid_switch must be nil or %{device: string, key: atom}"
+    end
+
+    viewport_size = get_in(Application.get_env(:mayonnaios, :viewport, []), [:size])
+
+    if viewport_size && viewport_size != profile.panel_size do
+      raise ArgumentError,
+            "device panel #{inspect(profile.panel_size)} does not match viewport #{inspect(viewport_size)}"
+    end
+
+    profile
+  end
+
+  defp require_keys!(map, keys, field) when is_map(map) do
+    case Enum.reject(keys, &Map.has_key?(map, &1)) do
+      [] -> :ok
+      missing -> raise ArgumentError, "device #{field} missing #{inspect(missing)}"
+    end
+  end
+
+  defp require_keys!(_value, _keys, field),
+    do: raise(ArgumentError, "device #{field} must be a map")
+
+  defp require_values!(map, predicate, field, expected) do
+    unless Enum.all?(Map.values(map), predicate) do
+      raise ArgumentError, "device #{field} values must be #{expected}"
+    end
+  end
+
+  defp format_size({width, height}), do: "#{width}x#{height}"
+  defp present(true), do: "present"
+  defp present(false), do: "absent"
+end

--- a/lib/mayonnaios/diagnostics.ex
+++ b/lib/mayonnaios/diagnostics.ex
@@ -57,16 +57,13 @@ defmodule MayonnaiOS.Diagnostics do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.Bluetooth.HCISocket
+  alias MayonnaiOS.{Device, Bluetooth.HCISocket}
 
   # Looked up by name at startup, and by name only -- no numbered fallbacks.
   # A number reached when the name is missing is a different device: `event1`
   # is the analog stick and `event2` is the gamepad, so a fallback would count
   # volume presses on a device that has no keys and query a jack switch on one
   # that has no switch. See `MayonnaiOS.Input`.
-  @volume_name "gpio-keys-volume"
-  @jack_name "H616 Audio Codec Headphone Jack"
-
   # The blob whose absence stops Bluetooth from initialising. See the long
   # comment against BR2_PACKAGE_LINUX_FIRMWARE_RTL_87XX_BT in nerves_defconfig.
   @bt_config "/lib/firmware/rtl_bt/rtl8821cs_config.bin"
@@ -133,8 +130,8 @@ defmodule MayonnaiOS.Diagnostics do
 
   @impl GenServer
   def init(_opts) do
-    open(@volume_name)
-    open(@jack_name)
+    open(Device.input(:volume))
+    open(Device.input(:headphone))
 
     # Without this the fdinfo engine counters stay at zero, which would look
     # exactly like a GPU doing nothing.
@@ -451,7 +448,7 @@ defmodule MayonnaiOS.Diagnostics do
   # means nil -- "nobody could ask", which is what nil already means for this
   # field and is not the same as "nothing is plugged in".
   defp query_jack do
-    case MayonnaiOS.Input.find(@jack_name) do
+    case MayonnaiOS.Input.find(Device.input(:headphone)) do
       nil ->
         nil
 

--- a/lib/mayonnaios/games_card.ex
+++ b/lib/mayonnaios/games_card.ex
@@ -41,7 +41,6 @@ defmodule MayonnaiOS.GamesCard do
   require Logger
 
   @defaults [
-    device: "/dev/mmcblk2p1",
     mount_point: "/root/mnt/games",
     filesystems: ["exfat", "vfat"],
     options: "rw,nosuid,nodev,noexec",
@@ -185,6 +184,8 @@ defmodule MayonnaiOS.GamesCard do
   end
 
   defp config do
-    Keyword.merge(@defaults, Application.get_env(:mayonnaios, :games_card, []))
+    [device: MayonnaiOS.Device.current!().games_card_device]
+    |> Keyword.merge(@defaults)
+    |> Keyword.merge(Application.get_env(:mayonnaios, :games_card, []))
   end
 end

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -201,23 +201,20 @@ defmodule MayonnaiOS.Launcher do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.{Browser, Input, Led, Panel, Sleep, Splash, Theme}
+  alias MayonnaiOS.{Browser, Device, Input, Led, Panel, Sleep, Splash, Theme}
 
   # The name the driver gives the gamepad, which is the only thing this module
   # knows about which device it is. There is no numbered fallback: /dev/input
   # numbering is probe order, and `event0` is the power key -- the one device
   # on the board with no gamepad buttons on it. See `MayonnaiOS.Input`.
-  @device_name "gpio-keys-gamepad"
 
   # The analog stick. Opened for the same reason as the power key -- evdev is
   # not a broadcast, so a device nobody holds open is a device whose events
   # nobody sees. The launcher itself does nothing with `ev_abs`: its own
   # handlers ignore them, and the one consumer is the controller app, which
   # gets them through the same forwarding as everything else.
-  @stick_name "adc-joystick"
 
   # See the moduledoc: this is physical A, not the atom's name.
-  @launch_button :btn_b
 
   # X and Y are swapped too, and the device tree does not admit it.
   #
@@ -233,17 +230,12 @@ defmodule MayonnaiOS.Launcher do
   # Y (:btn_x) is the second verb, and the panel says what it is: the actions
   # sheet in a directory, the delete on a confirmation, and
   # remove-a-character in the rename editor.
-  @confirm_button :btn_x
-  @actions_button :btn_x
 
   # Physical X, which the device tree's swap makes :btn_y -- the note above.
   # X toggles the full view: the wide column about the selected entry.
-  @full_button :btn_y
 
   # Menu, doing double duty: alone it is the way back to the home screen,
   # and held with Select it powers off. The chord is tested first.
-  @poweroff_modifier :btn_select
-  @home_button :btn_mode
 
   # The D-pad. Codes 544-547 are BTN_DPAD_UP..RIGHT, and InputEvent decodes
   # them to these atoms (deps/input_event types table). Unlike the face
@@ -252,27 +244,20 @@ defmodule MayonnaiOS.Launcher do
   # so the catch-all `bound/2` logs unhandled keys at debug: if up and down
   # turn out to be swapped, `log_attach_all(:debug)` on the device says so
   # immediately instead of leaving a menu that scrolls the wrong way.
-  @up_button :btn_dpad_up
-  @down_button :btn_dpad_down
 
   # Left and right walk the columns: right opens the selected entry as a new
   # column and left closes one. Right never launches -- A is the button that
   # commits -- so walking the tree with the directions cannot start a game.
-  @left_button :btn_dpad_left
-  @right_button :btn_dpad_right
 
   # The shoulders page the focused column a screenful at a time. Autorepeat
   # is dropped on this menu (each move re-roots the viewport), so a directory
   # of two hundred ROMs needs a faster step than one row per press, and the
   # shoulders are the two buttons a handheld rests fingers on anyway.
-  @page_up_button :btn_tl
-  @page_down_button :btn_tr
 
   # Physical B, which is BTN_SOUTH and therefore InputEvent's :btn_a -- the
   # table at the top of this module is the authority. The "back" gesture
   # everywhere: it clears an obituary, closes the full view, a sheet or a
   # column, and leaves the readout apps and diagnostics.
-  @back_button :btn_a
 
   # How many of a program's last lines the obituary keeps. Three is what the
   # panel has room to draw without pushing into the menu rows.
@@ -403,7 +388,12 @@ defmodule MayonnaiOS.Launcher do
       nil ->
         case Enum.uniq(
                Enum.reject(
-                 [Input.find(@device_name), Input.find(@stick_name), Sleep.device()],
+                 [
+                   Input.find(Device.input(:gamepad)),
+                   Input.find(Device.input(:stick)),
+                   Sleep.device(),
+                   lid_device()
+                 ],
                  &is_nil/1
                )
              ) do
@@ -454,6 +444,8 @@ defmodule MayonnaiOS.Launcher do
       app_error: nil,
       running: nil,
       held: MapSet.new(),
+      buttons: Keyword.get(opts, :buttons, Device.current!().buttons),
+      lid_switch: Keyword.get(opts, :lid_switch, Device.current!().lid_switch),
       scene: :home,
       # The home screen's column browser: which columns are open, which row
       # each cursor is on, and how many columns the panel draws. Here rather
@@ -553,18 +545,18 @@ defmodule MayonnaiOS.Launcher do
   # Releases are still tracked, and only a press wakes: the chord that put the
   # device to sleep is still held at that moment, and its release arriving a
   # moment later must not wake the device straight back up.
-  def handle_info({:input_event, _device, events}, %{asleep: true} = state) do
-    if Enum.any?(events, &match?({:ev_key, _key, 1}, &1)) do
-      {_result, state} = wake_up(state)
-      {:noreply, state}
-    else
-      state =
-        Enum.reduce(events, state, fn
-          {:ev_key, key, 0}, acc -> release(acc, key)
-          _, acc -> acc
-        end)
+  def handle_info({:input_event, _device, events}, state) do
+    case lid_transition(state, events) do
+      :closed ->
+        {_result, state} = enter_sleep(state)
+        {:noreply, state}
 
-      {:noreply, state}
+      :opened when state.asleep ->
+        {_result, state} = wake_up(state)
+        {:noreply, state}
+
+      _other ->
+        handle_input(events, state)
     end
   end
 
@@ -588,41 +580,6 @@ defmodule MayonnaiOS.Launcher do
   # Whole reports go across rather than single events, so a diagonal or a
   # button and a direction pressed in the same kernel report reach the app as
   # one thing and become one HID report.
-  def handle_info({:input_event, _device, events}, %{app: app} = state) when app != nil do
-    {state, slept?} = Enum.reduce(events, {state, false}, &app_event/2)
-
-    # B leaves the apps that do not claim it -- the readouts, where back
-    # should go back -- and is then held out of the report the way the sleep
-    # key is from everything: the press that closes a screen must not also
-    # act inside it. The apps that need B for themselves keep it whole; see
-    # claims_back?/1.
-    leaving? = not slept? and back_press?(events) and not claims_back?(app)
-
-    if not slept? and not leaving?, do: app_module(app).input(events)
-
-    state = if leaving?, do: state |> stop_app() |> go_home(), else: state
-
-    {:noreply, leave_app(state, events)}
-  end
-
-  def handle_info({:input_event, _device, events}, state) do
-    state =
-      Enum.reduce(events, state, fn
-        # value 1 is press and 0 is release; 2 is autorepeat and is ignored.
-        # Releases matter now: the power-off chord needs to know what is held.
-        #
-        # Dropping autorepeat means the D-pad does not scroll when held: one
-        # press, one row. That is a simplification, not an oversight -- each
-        # move re-roots the viewport, and holding down would queue a scene
-        # restart per repeat. Worth revisiting only if the list grows long.
-        {:ev_key, key, 1}, acc -> acc |> hold(key) |> press(key)
-        {:ev_key, key, 0}, acc -> release(acc, key)
-        _, acc -> acc
-      end)
-
-    {:noreply, state}
-  end
-
   # The program exited on its own. Name it from `running` rather than from the
   # cursor: the cursor may well have moved while the program had the screen,
   # and a log line that names the wrong binary is worse than none.
@@ -671,6 +628,73 @@ defmodule MayonnaiOS.Launcher do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
+  defp handle_input(events, %{asleep: true} = state) do
+    if Enum.any?(events, &match?({:ev_key, _key, 1}, &1)) do
+      {_result, state} = wake_up(state)
+      {:noreply, state}
+    else
+      state =
+        Enum.reduce(events, state, fn
+          {:ev_key, key, 0}, acc -> release(acc, key)
+          _, acc -> acc
+        end)
+
+      {:noreply, state}
+    end
+  end
+
+  defp handle_input(events, %{app: app} = state) when app != nil do
+    {state, slept?} = Enum.reduce(events, {state, false}, &app_event/2)
+
+    # B leaves the apps that do not claim it -- the readouts, where back
+    # should go back -- and is then held out of the report the way the sleep
+    # key is from everything: the press that closes a screen must not also
+    # act inside it. The apps that need B for themselves keep it whole; see
+    # claims_back?/1.
+    leaving? = not slept? and back_press?(state, events) and not claims_back?(app)
+
+    if not slept? and not leaving?, do: app_module(app).input(events)
+
+    state = if leaving?, do: state |> stop_app() |> go_home(), else: state
+
+    {:noreply, leave_app(state, events)}
+  end
+
+  defp handle_input(events, state) do
+    state =
+      Enum.reduce(events, state, fn
+        # value 1 is press and 0 is release; 2 is autorepeat and is ignored.
+        # Releases matter now: the power-off chord needs to know what is held.
+        #
+        # Dropping autorepeat means the D-pad does not scroll when held: one
+        # press, one row. That is a simplification, not an oversight -- each
+        # move re-roots the viewport, and holding down would queue a scene
+        # restart per repeat. Worth revisiting only if the list grows long.
+        {:ev_key, key, 1}, acc -> acc |> hold(key) |> press(key)
+        {:ev_key, key, 0}, acc -> release(acc, key)
+        _, acc -> acc
+      end)
+
+    {:noreply, state}
+  end
+
+  defp lid_transition(%{lid_switch: nil}, _events), do: nil
+
+  defp lid_transition(%{lid_switch: %{key: key}}, events) do
+    cond do
+      Enum.any?(events, &match?({:ev_sw, ^key, 1}, &1)) -> :closed
+      Enum.any?(events, &match?({:ev_sw, ^key, 0}, &1)) -> :opened
+      true -> nil
+    end
+  end
+
+  defp lid_device do
+    case Device.current!().lid_switch do
+      nil -> nil
+      %{device: name} -> Input.find(name)
+    end
+  end
+
   # What the panel will say about a program that died. Status zero is a
   # program that meant to exit and merits nothing; anything else is paired
   # with the last lines it wrote, because "exited (1)" without its dying
@@ -708,9 +732,9 @@ defmodule MayonnaiOS.Launcher do
   defp release(state, key), do: %{state | held: MapSet.delete(state.held, key)}
 
   # The held set is folded one event at a time and the trigger is asked after
-  # each press, exactly as the ordinary path does it, so that a `@binding` with
-  # a modifier in it would still see the set the way the user pressed it rather
-  # than the set the whole report leaves behind.
+  # each press, exactly as the ordinary path does it, so a future binding with
+  # a modifier would still see the set the way the user pressed it rather than
+  # the set the whole report leaves behind.
   #
   # The whole report is dropped when the sleep key is in it, not just that one
   # event. A report cannot span two devices and the sleep device carries one
@@ -735,8 +759,8 @@ defmodule MayonnaiOS.Launcher do
   # never be able to switch the device off, and someone holding Select while
   # using the controller is holding Select on purpose.
   defp leave_app(state, events) do
-    if Enum.any?(events, &match?({:ev_key, @home_button, 1}, &1)) do
-      if MapSet.member?(state.held, @poweroff_modifier) do
+    if pressed?(events, button(state, :home)) do
+      if MapSet.member?(state.held, button(state, :poweroff_modifier)) do
         poweroff(state, "Select+Menu")
       else
         state |> stop_app() |> go_home()
@@ -746,9 +770,7 @@ defmodule MayonnaiOS.Launcher do
     end
   end
 
-  defp back_press?(events) do
-    Enum.any?(events, &match?({:ev_key, @back_button, 1}, &1))
-  end
+  defp back_press?(state, events), do: pressed?(events, button(state, :back))
 
   # Whether the app keeps B for itself. The controller forwards it to the
   # host as a gamepad button and a pickle's script reads it as "b"; for
@@ -808,47 +830,62 @@ defmodule MayonnaiOS.Launcher do
   # rename editor. Everything goes to the browser except the two things that
   # must mean the same wherever they are pressed -- the power-off chord, and
   # Menu as the way home. The sleep key was already tested above.
-  defp overlay(state, @home_button) do
-    if MapSet.member?(state.held, @poweroff_modifier) do
+  defp overlay(state, key) do
+    if key == button(state, :home) do
+      overlay_home(state)
+    else
+      browse(state, Browser.overlay_input(state.browser, semantic(state, key)))
+    end
+  end
+
+  defp overlay_home(state) do
+    if MapSet.member?(state.held, button(state, :poweroff_modifier)) do
       poweroff(state, "Select+Menu")
     else
       go_home(state)
     end
-  end
-
-  defp overlay(state, key) do
-    browse(state, Browser.overlay_input(state.browser, semantic(key)))
   end
 
   # The full view has the buttons: scrolling to the browser, and the same two
   # exceptions as the sheets -- the power-off chord, and Menu as the way
   # home. The sleep key was already tested above.
-  defp full_view(state, @home_button) do
-    if MapSet.member?(state.held, @poweroff_modifier) do
+  defp full_view(state, key) do
+    if key == button(state, :home) do
+      full_home(state)
+    else
+      browse(state, Browser.full_input(state.browser, semantic(state, key)))
+    end
+  end
+
+  defp full_home(state) do
+    if MapSet.member?(state.held, button(state, :poweroff_modifier)) do
       poweroff(state, "Select+Menu")
     else
       go_home(state)
     end
   end
 
-  defp full_view(state, key) do
-    browse(state, Browser.full_input(state.browser, semantic(key)))
-  end
-
   # The browser speaks verbs, not scan codes: it should not have to know that
   # this board's device tree swaps A/B and X/Y, and `:other` still matters --
   # on the delete confirmation any unnamed button cancels.
-  defp semantic(@up_button), do: :up
-  defp semantic(@down_button), do: :down
-  defp semantic(@left_button), do: :left
-  defp semantic(@right_button), do: :right
-  defp semantic(@page_up_button), do: :l1
-  defp semantic(@page_down_button), do: :r1
-  defp semantic(@launch_button), do: :a
-  defp semantic(@back_button), do: :b
-  defp semantic(@confirm_button), do: :y
-  defp semantic(@full_button), do: :x
-  defp semantic(_key), do: :other
+  defp semantic(state, key) do
+    Enum.find_value(
+      [
+        up: :up,
+        down: :down,
+        left: :left,
+        right: :right,
+        page_up: :l1,
+        page_down: :r1,
+        launch: :a,
+        back: :b,
+        confirm: :y,
+        full: :x
+      ],
+      :other,
+      fn {binding, verb} -> if key == button(state, binding), do: verb end
+    )
+  end
 
   # Entering sleep only counts if the backlight write landed. A dark-panel
   # flag over a lit screen would swallow the next press for nothing, which is
@@ -884,19 +921,27 @@ defmodule MayonnaiOS.Launcher do
     {Sleep.wake(), %{state | asleep: false, held: MapSet.new()}}
   end
 
-  defp bound(state, @launch_button), do: do_launch(state)
-  defp bound(state, @up_button), do: move(state, -1)
-  defp bound(state, @down_button), do: move(state, +1)
-  defp bound(state, @left_button), do: browse(state, Browser.ascend(state.browser))
-  defp bound(state, @right_button), do: browse(state, Browser.descend(state.browser))
-  defp bound(state, @page_up_button), do: browse(state, Browser.page(state.browser, :up))
-  defp bound(state, @page_down_button), do: browse(state, Browser.page(state.browser, :down))
-  defp bound(state, @actions_button), do: browse(state, Browser.open_actions(state.browser))
+  defp bound(state, key) do
+    cond do
+      key == button(state, :launch) -> do_launch(state)
+      key == button(state, :up) -> move(state, -1)
+      key == button(state, :down) -> move(state, +1)
+      key == button(state, :left) -> browse(state, Browser.ascend(state.browser))
+      key == button(state, :right) -> browse(state, Browser.descend(state.browser))
+      key == button(state, :page_up) -> browse(state, Browser.page(state.browser, :up))
+      key == button(state, :page_down) -> browse(state, Browser.page(state.browser, :down))
+      key == button(state, :actions) -> browse(state, Browser.open_actions(state.browser))
+      key == button(state, :full) -> full(state)
+      key == button(state, :back) -> back(state)
+      key == button(state, :home) -> home(state)
+      true -> unhandled(state, key)
+    end
+  end
 
   # X: the full view of the selected entry -- except the process monitors,
   # whose detailed view is the readout app itself, so X opens it the way A
   # does. `MayonnaiOS.Browser` owns every other shape of the full view.
-  defp bound(state, @full_button) do
+  defp full(state) do
     case Browser.selected(state.browser) do
       %{kind: :program, program: %{app: {MayonnaiOS.Top, _which}} = program} ->
         start_program(program, state)
@@ -906,22 +951,20 @@ defmodule MayonnaiOS.Launcher do
     end
   end
 
-  defp bound(state, @back_button), do: back(state)
-
   # Menu: back to the home screen, or -- with Select held -- power off.
   #
   # The chord is checked first, so the modifier is not decorative: a bare
   # Menu must never be able to shut the device down, because it is the key
   # someone reaches for to get out of a game.
-  defp bound(state, @home_button) do
-    if MapSet.member?(state.held, @poweroff_modifier) do
+  defp home(state) do
+    if MapSet.member?(state.held, button(state, :poweroff_modifier)) do
       poweroff(state, "Select+Menu")
     else
       go_home(state)
     end
   end
 
-  defp bound(state, key) do
+  defp unhandled(state, key) do
     # Debug, not info: this fires for every unbound button on the pad. It
     # exists because the D-pad codes are inherited from the device tree and
     # this board's device tree has been wrong before -- if up and down feel
@@ -929,6 +972,9 @@ defmodule MayonnaiOS.Launcher do
     Logger.debug("[launcher] unhandled key #{inspect(key)}")
     state
   end
+
+  defp button(state, semantic), do: Map.fetch!(state.buttons, semantic)
+  defp pressed?(events, key), do: Enum.any?(events, &match?({:ev_key, ^key, 1}, &1))
 
   # B: on the diagnostics screen there is no column to close, so back is the
   # way out -- the same press that leaves the readout apps. Only with nothing

--- a/lib/mayonnaios/led.ex
+++ b/lib/mayonnaios/led.ex
@@ -51,9 +51,6 @@ defmodule MayonnaiOS.Led do
 
   # The emitters by sysfs name. See the moduledoc: the names describe the
   # device tree's opinion, the comments describe the light.
-  @green "green:power"
-  @red "green:status"
-
   # Flash cadences, in milliseconds on/off. Quick reads as activity, slow as
   # a device at rest, and the red blink sits between them -- fast enough to
   # look wrong, slow enough to count.
@@ -102,11 +99,14 @@ defmodule MayonnaiOS.Led do
     end
   end
 
-  defp apply_state(:starting), do: combine(off(@red), flash(@green, @quick))
-  defp apply_state(:running), do: combine(off(@red), solid(@green))
-  defp apply_state(:sleeping), do: combine(off(@red), flash(@green, @slow))
-  defp apply_state(:failure), do: combine(off(@green), flash(@red, @blink))
-  defp apply_state(:off), do: combine(off(@red), off(@green))
+  defp apply_state(:starting), do: combine(off(red()), flash(green(), @quick))
+  defp apply_state(:running), do: combine(off(red()), solid(green()))
+  defp apply_state(:sleeping), do: combine(off(red()), flash(green(), @slow))
+  defp apply_state(:failure), do: combine(off(green()), flash(red(), @blink))
+  defp apply_state(:off), do: combine(off(red()), off(green()))
+
+  defp green, do: MayonnaiOS.Device.current!().leds.green
+  defp red, do: MayonnaiOS.Device.current!().leds.red
 
   # Both emitters are always written; the first error is the one returned,
   # after every write has been attempted, so one refused file does not leave

--- a/lib/mayonnaios/power.ex
+++ b/lib/mayonnaios/power.ex
@@ -32,9 +32,6 @@ defmodule MayonnaiOS.Power do
   # on the directory name is what the rest of this project does; see the note
   # about regulator indices in the journal for why matching on a number would
   # be worse.
-  @battery "/sys/class/power_supply/axp20x-battery"
-  @usb "/sys/class/power_supply/axp20x-usb"
-
   @type values :: %{
           capacity: non_neg_integer() | nil,
           status: String.t() | nil,
@@ -62,8 +59,9 @@ defmodule MayonnaiOS.Power do
   """
   @spec values(keyword()) :: values()
   def values(opts \\ []) do
-    battery = Keyword.get(opts, :battery, @battery)
-    usb = Keyword.get(opts, :usb, @usb)
+    supplies = MayonnaiOS.Device.current!().power_supplies
+    battery = Keyword.get(opts, :battery, supplies.battery)
+    usb = Keyword.get(opts, :usb, supplies.usb)
 
     %{
       capacity: read_int("#{battery}/capacity"),

--- a/lib/mayonnaios/scene/diagnostics.ex
+++ b/lib/mayonnaios/scene/diagnostics.ex
@@ -120,7 +120,7 @@ defmodule MayonnaiOS.Scene.Diagnostics do
     Graph.build(font: :roboto, font_size: 14)
     |> rect({@width, @height}, fill: {:color, @bg})
     |> StatusBar.mount()
-    |> text("RG40XXV diagnostics",
+    |> text("#{MayonnaiOS.Device.current!().name} diagnostics",
       font_size: 20,
       fill: {:color, @title},
       translate: {20, @title_y}

--- a/lib/mayonnaios/sleep.ex
+++ b/lib/mayonnaios/sleep.ex
@@ -88,9 +88,9 @@ defmodule MayonnaiOS.Sleep do
 
   Sleep is this button's only trigger. A trigger has to be written down in
   this moduledoc, in the launcher's binding list, in the README, in
-  `MayonnaiOS.Keyboard` and in the application's supervision comment, and
-  `@binding` below is one tuple precisely so that there is one place where
-  any of that is written down.
+  `MayonnaiOS.Keyboard` and in the application's supervision comment. The
+  device profile keeps the input name and key together with the rest of the
+  board's controls.
 
   `MayonnaiOS.Input.find/1` looks the device up by the name its driver gives
   it, and firmware without the option gets `nil` and a warning naming every
@@ -100,34 +100,14 @@ defmodule MayonnaiOS.Sleep do
 
   require Logger
 
-  alias MayonnaiOS.Input
+  alias MayonnaiOS.{Device, Input}
 
   # The brightness file. Configurable rather than written out at each use, so
   # a test can point it at a temp file and so a panel wired differently is a
   # config line instead of a patch.
-  @default_path "/sys/class/backlight/backlight/brightness"
-
   # max_brightness is 1; see the moduledoc.
   @off "0"
   @on "1"
-
-  # `{device name, {modifier, key}}`.
-  #
-  # The power button, on its own. `nil` for the modifier means the key alone
-  # is the trigger; the chord shape is still supported and still resolved at
-  # compile time below, so sleep moving back onto the pad -- or onto whatever
-  # key the next shell puts it on -- stays a change to this one line.
-  #
-  # There is no path in here. A fallback would be a number, and a
-  # number reached because the name was missing is a different device; see
-  # `MayonnaiOS.Input`.
-  @binding {"axp20x-pek", {nil, :key_power}}
-
-  # Taken apart at compile time, so the one line above stays the only place
-  # any of it is written down.
-  @device_name elem(@binding, 0)
-  @modifier @binding |> elem(1) |> elem(0)
-  @key @binding |> elem(1) |> elem(1)
 
   @doc """
   The sysfs file that turns the backlight off and on.
@@ -135,7 +115,8 @@ defmodule MayonnaiOS.Sleep do
   From `config :mayonnaios, :backlight_brightness`, defaulting to the panel's.
   """
   @spec path() :: String.t()
-  def path, do: Application.get_env(:mayonnaios, :backlight_brightness, @default_path)
+  def path,
+    do: Application.get_env(:mayonnaios, :backlight_brightness, Device.current!().backlight)
 
   @doc """
   The input device the sleep key arrives on, or `nil` when there is none.
@@ -147,7 +128,7 @@ defmodule MayonnaiOS.Sleep do
   has already logged which devices there were instead. See `MayonnaiOS.Input`.
   """
   @spec device() :: String.t() | nil
-  def device, do: Input.find(@device_name)
+  def device, do: Input.find(Device.input(:power))
 
   @doc """
   Whether this press is the sleep trigger, given what is currently held.
@@ -156,19 +137,7 @@ defmodule MayonnaiOS.Sleep do
   thing that knows about button state and this stays a pure predicate.
   """
   @spec trigger?(MapSet.t(atom()), atom()) :: boolean()
-  def trigger?(held, key), do: triggered?(held, key)
-
-  # Which of the two shapes this is, is decided when the module is compiled: a
-  # nil modifier -- which is what the power key wants -- makes the key alone
-  # the trigger, and then nothing looks at the held set at all. The chord
-  # clause is compiled only when `@binding` names a modifier, so a `held` set
-  # is still threaded through `trigger?/2` by every caller: that argument is
-  # what keeps moving the binding back onto the pad a one-line change.
-  if @modifier do
-    defp triggered?(held, key), do: key == @key and MapSet.member?(held, @modifier)
-  else
-    defp triggered?(_held, key), do: key == @key
-  end
+  def trigger?(_held, key), do: key == Device.button(:sleep)
 
   @doc """
   The binding, for a log line or a help screen that wants to name it.
@@ -176,7 +145,7 @@ defmodule MayonnaiOS.Sleep do
   `{nil, key}` when the key is the whole trigger, which is what it is now.
   """
   @spec binding() :: {atom() | nil, atom()}
-  def binding, do: {@modifier, @key}
+  def binding, do: {nil, Device.button(:sleep)}
 
   @doc """
   Backlight off. `{:error, reason}` when the write does not land.

--- a/lib/mayonnaios/volume.ex
+++ b/lib/mayonnaios/volume.ex
@@ -103,15 +103,13 @@ defmodule MayonnaiOS.Volume do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.Audio
+  alias MayonnaiOS.{Audio, Device}
 
   # The name the driver gives the rocker, and the only thing this module knows
   # about which device it is. There is no numbered fallback: /dev/input
   # numbering is probe order, and a fallback that opens the analog stick and
   # waits for `KEY_VOLUMEUP` is the rocker doing nothing with nothing in the
   # log. See `MayonnaiOS.Input`.
-  @device_name "gpio-keys-volume"
-
   # Read off the hardware, not the device tree: these are the atoms
   # `InputEvent` decodes KEY_VOLUMEUP (115) and KEY_VOLUMEDOWN (114) to, and
   # they are the atoms the diagnostics counters have been incrementing on real
@@ -143,7 +141,8 @@ defmodule MayonnaiOS.Volume do
   def init(opts) do
     # get_lazy, so an injected device does not also run a lookup whose warning
     # would then be about a device this process was never going to open.
-    device = Keyword.get_lazy(opts, :device, fn -> MayonnaiOS.Input.find(@device_name) end)
+    device =
+      Keyword.get_lazy(opts, :device, fn -> MayonnaiOS.Input.find(Device.input(:volume)) end)
 
     case open_device(device) do
       {:ok, _pid} ->
@@ -155,7 +154,9 @@ defmodule MayonnaiOS.Volume do
         # name is the thing that has to change in a device tree for this to
         # happen. `MayonnaiOS.Input.find/1` has already logged what was there
         # instead.
-        Logger.warning("[volume] no #{@device_name} input device; the rocker does nothing")
+        Logger.warning(
+          "[volume] no #{Device.input(:volume)} input device; the rocker does nothing"
+        )
 
       {:error, reason} ->
         Logger.warning("[volume] #{device} unavailable: #{inspect(reason)}")

--- a/lib/mayonnaios/web/page.ex
+++ b/lib/mayonnaios/web/page.ex
@@ -19,18 +19,20 @@ defmodule MayonnaiOS.Web.Page do
   def render, do: html()
 
   defp html do
+    device_name = MayonnaiOS.Device.current!().name
+
     """
     <!doctype html>
     <html lang="en">
     <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>RG40XXV</title>
+    <title>#{device_name}</title>
     <style>#{css()}</style>
     </head>
     <body>
     <header>
-      <h1>RG40XXV</h1>
+      <h1>#{device_name}</h1>
       <p id="free"></p>
     </header>
 

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -146,7 +146,7 @@ defmodule MayonnaiOS.BrowserTest do
 
       # Directories first is Files.list/1's order; the browser keeps it.
       assert names(browser) == ["backup", "snes", "readme.txt"]
-      assert Browser.trail(browser) == ["RG40XXV", "Files", root]
+      assert Browser.trail(browser) == [MayonnaiOS.Device.current!().name, "Files", root]
     end
 
     test "a directory keeps opening columns, and ascend walks back" do
@@ -195,7 +195,8 @@ defmodule MayonnaiOS.BrowserTest do
     end
 
     test "panes/1 at the root: nothing above, so the left is blank" do
-      assert %{left: nil, center: %{title: "RG40XXV"}} = Browser.panes(Browser.new())
+      assert %{left: nil, center: %{title: title}} = Browser.panes(Browser.new())
+      assert title == MayonnaiOS.Device.current!().name
     end
   end
 

--- a/test/device_test.exs
+++ b/test/device_test.exs
@@ -1,0 +1,33 @@
+defmodule MayonnaiOS.DeviceTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.Device
+
+  test "the host profile is complete and agrees with the viewport" do
+    profile = Device.current!()
+
+    assert profile.id == :host
+    assert profile.panel_size == {640, 480}
+    assert profile.panel_size == get_in(Application.fetch_env!(:mayonnaios, :viewport), [:size])
+    assert Device.input(:gamepad) == "host-gamepad"
+    assert Device.button(:launch) == :btn_b
+    assert profile.lid_switch == nil
+    assert profile.rtc?
+  end
+
+  test "an incomplete profile fails with the missing hardware facts named" do
+    previous = Application.fetch_env!(:mayonnaios, :device)
+    Application.put_env(:mayonnaios, :device, Map.delete(previous, :buttons))
+    on_exit(fn -> Application.put_env(:mayonnaios, :device, previous) end)
+
+    assert_raise ArgumentError, ~r/keys must also be given.*:buttons/, &Device.current!/0
+  end
+
+  test "a profile cannot disagree with the configured viewport" do
+    previous = Application.fetch_env!(:mayonnaios, :device)
+    Application.put_env(:mayonnaios, :device, %{previous | panel_size: {320, 240}})
+    on_exit(fn -> Application.put_env(:mayonnaios, :device, previous) end)
+
+    assert_raise ArgumentError, ~r/does not match viewport/, &Device.current!/0
+  end
+end

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -80,7 +80,10 @@ defmodule MayonnaiOS.LauncherTest do
 
       browser = Browser.new() |> Browser.descend()
 
-      assert Enum.any?(texts(Home.graph(browser)), &(&1 =~ "RG40XXV > Games"))
+      assert Enum.any?(
+               texts(Home.graph(browser)),
+               &(&1 =~ "#{MayonnaiOS.Device.current!().name} > Games")
+             )
     end
 
     test "windows the rows so the selection is always drawn" do
@@ -240,6 +243,41 @@ defmodule MayonnaiOS.LauncherTest do
 
       assert log =~ "no input devices found"
     end
+
+    test "bindings can be replaced by a device profile without code changes" do
+      buttons = %{MayonnaiOS.Device.current!().buttons | down: :key_volumedown}
+      start_supervised!({Launcher, device: "/nonexistent/event0", buttons: buttons})
+
+      send(
+        Launcher,
+        {:input_event, "/nonexistent/event0", [{:ev_key, :key_volumedown, 1}]}
+      )
+
+      assert Launcher.selected() == 1
+    end
+
+    test "a configured lid switch sleeps on close and wakes on open" do
+      path = Path.join(System.tmp_dir!(), "lid-backlight-#{System.unique_integer([:positive])}")
+      File.write!(path, "1")
+      Application.put_env(:mayonnaios, :backlight_brightness, path)
+
+      on_exit(fn ->
+        Application.delete_env(:mayonnaios, :backlight_brightness)
+        File.rm(path)
+      end)
+
+      lid = %{device: "gpio-lid", key: :sw_lid}
+
+      start_supervised!({Launcher, device: "/nonexistent/event0", lid_switch: lid})
+
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_sw, :sw_lid, 1}]})
+      assert Launcher.asleep?()
+      assert File.read!(path) == "0"
+
+      send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_sw, :sw_lid, 0}]})
+      refute Launcher.asleep?()
+      assert File.read!(path) == "1"
+    end
   end
 
   describe "the D-pad binding" do
@@ -302,7 +340,7 @@ defmodule MayonnaiOS.LauncherTest do
 
       browser = Launcher.browser()
       assert Browser.depth(browser) == 2
-      assert Browser.trail(browser) == ["RG40XXV", "Games"]
+      assert Browser.trail(browser) == [MayonnaiOS.Device.current!().name, "Games"]
       assert Enum.map(List.last(browser.levels).entries, & &1.name) == ["a", "b", "c"]
 
       press(:btn_a)

--- a/test/volume_test.exs
+++ b/test/volume_test.exs
@@ -354,7 +354,7 @@ defmodule MayonnaiOS.VolumeTest do
           start_supervised!({Volume, mixer: FakeMixer})
         end)
 
-      assert log =~ "gpio-keys-volume"
+      assert log =~ MayonnaiOS.Device.input(:volume)
       refute log =~ "/dev/input/event"
     end
   end


### PR DESCRIPTION
Closes #48

The physical RG35XXSP BSP/boot work was split into #62 as requested. This PR handles the application-side refactor without claiming a target that cannot boot yet.

## Summary
- add a boot-validated `MayonnaiOS.Device` struct for identity, panel, inputs, physical button mapping, LEDs, power supplies, storage, backlight, lid switch, and RTC presence
- add explicit host and RG40XXV profiles and import target-specific config
- route the launcher, volume, sleep, diagnostics, LEDs, battery, games card, browser, diagnostics title, and web heading through the profile
- support a configured lid switch closing to sleep and opening to wake
- rename build credentials to `MAYONNAIOS_WIFI_SSID` / `MAYONNAIOS_WIFI_PSK`
- keep shared programs, bundles, cores, systems, paths, and geometry in shared target config

## Verification
- `mix compile --warnings-as-errors`
- `mix test` (1035/1036; only the existing process-liveness timing assertion at `test/launcher_test.exs:762` failed)
- focused device consumers: 156 tests, 0 failures
- RG40XXV cross-target `mix compile --warnings-as-errors` passed using the local BSP checkout
- alternate button profile and synthetic lid close/open regression tests pass