### PR TITLE
Browse and launch ROMs directly from Games

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -567,6 +567,11 @@ config :mayonnaios, :cores, %{
   }
 }
 
+# When more than one installed core can play a system, the first available
+# entry wins. Explicit rather than map enumeration order, so a config edit is
+# the only thing that changes which emulator A launches.
+config :mayonnaios, core_priority: [:fceumm, :snes9x2010, :gambatte, :mgba, :"2048"]
+
 # The upload page. Port 80 so the address is just the hostname:
 #
 #     http://nerves-5322903c.local/

--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -20,12 +20,10 @@ defmodule MayonnaiOS.Browser do
   ## The tree
 
   The root column is fixed: Games, Files, Apps, System. What each one
-  contains is classified out of the one `config :mayonnaios, :programs` list
-  the launcher already reads, so a row added to config appears in the right
-  column with no code change here:
+  contains comes from the ROM library and the configured programs:
 
-    * a `:path` entry is a game or program to run -- **Games**
-    * a pickle's row (`{MayonnaiOS.Pickles.App, name}`) -- **Apps**
+    * systems and their ROMs -- **Games**
+    * an external `:path` entry, or a pickle -- **Apps**
     * any other app, and every `:action` -- **System**
 
   A row can also name its column outright with `:category`, which overrides
@@ -69,7 +67,7 @@ defmodule MayonnaiOS.Browser do
   Inside a directory column, Y -- and only Y -- opens the **actions sheet**:
   what can be done to the selected entry, plus pasting whatever the clipboard
   holds. A never opens it: A is the button that *opens things* -- it enters a
-  directory, launches a program, views a file -- and a button that sometimes
+  directory, launches a program or recognized ROM, and views any other file -- and a button that sometimes
   opens and sometimes asks is two buttons wearing one cap. The sheet is drawn
   as one more column, because in this UI "a list to pick from" and "a column"
   are the same thing.
@@ -97,12 +95,12 @@ defmodule MayonnaiOS.Browser do
   cursor.
   """
 
-  alias MayonnaiOS.{Files, Pickles, Programs}
+  alias MayonnaiOS.{Files, Game, Library, Pickles, Programs}
   alias MayonnaiOS.Browser.View
 
   @typedoc "One entry in a column."
   @type node_ :: %{
-          required(:kind) => :category | :place | :dir | :file | :program,
+          required(:kind) => :category | :place | :dir | :file | :program | :system | :rom,
           required(:name) => String.t(),
           optional(atom()) => term()
         }
@@ -231,7 +229,7 @@ defmodule MayonnaiOS.Browser do
   sheet.
   """
   @spec expandable?(node_() | nil) :: boolean()
-  def expandable?(%{kind: kind}), do: kind in [:category, :place, :dir]
+  def expandable?(%{kind: kind}), do: kind in [:category, :place, :dir, :system]
   def expandable?(nil), do: false
 
   @doc """
@@ -686,10 +684,26 @@ defmodule MayonnaiOS.Browser do
   defp expand(%{kind: :category, id: id, name: name}), do: category_level(id, name)
   defp expand(%{kind: :place} = node), do: place_level(node)
   defp expand(%{kind: :dir} = node), do: dir_level(node)
+  defp expand(%{kind: :system} = node), do: system_level(node)
 
   defp category_level(:games, name) do
-    rows = for program <- classified(:games), do: program_node(program)
-    level(name, rows, "Nothing to run. Install a bundle, or check the config.")
+    systems = Library.systems()
+
+    rows =
+      if systems == [] do
+        for program <- classified(:games), do: program_node(program)
+      else
+        for system <- systems do
+          %{kind: :system, name: system.name, key: system.key, core: Game.core_for(system.key)}
+        end
+      end
+
+    empty_note =
+      if systems == [],
+        do: "Nothing to run. Install a bundle, or check the config.",
+        else: "No game systems configured."
+
+    level(name, rows, empty_note)
   end
 
   defp category_level(:apps, name) do
@@ -730,7 +744,24 @@ defmodule MayonnaiOS.Browser do
   defp classify(%{action: action}) when action != nil, do: :system
   defp classify(%{app: {Pickles.App, _name}}), do: :apps
   defp classify(%{app: app}) when app != nil, do: :system
-  defp classify(_program), do: :games
+  defp classify(_program), do: if(Library.systems() == [], do: :games, else: :apps)
+
+  defp system_level(%{key: key, name: name, core: core}) do
+    rows =
+      for entry <- Library.entries(key) do
+        {:ok, path} = Library.find(key, entry.name)
+        %{kind: :rom, name: entry.name, entry: entry, system: key, path: path}
+      end
+
+    note =
+      cond do
+        rows == [] -> "No ROMs found."
+        match?({:error, :no_core}, core) -> "No installed core. Install one from the web page."
+        true -> nil
+      end
+
+    level(name, rows, note)
+  end
 
   # A verb of the launcher's own, shaped like a config row so the launcher's
   # `start_program/2` needs no second vocabulary for it.
@@ -822,6 +853,10 @@ defmodule MayonnaiOS.Browser do
       space: nil
     }
   end
+
+  @doc "Put a result or failure on the launcher's status line."
+  def put_message(browser, level, words) when level in [:ok, :error],
+    do: %{browser | message: {level, words}}
 
   # -- words for the panel --------------------------------------------------------
 

--- a/lib/mayonnaios/browser/view.ex
+++ b/lib/mayonnaios/browser/view.ex
@@ -112,6 +112,18 @@ defmodule MayonnaiOS.Browser.View do
     %{kind: :info, title: name, lines: program_lines(program)}
   end
 
+  def preview(%{kind: :system, name: name, core: {:ok, core}}, _column) do
+    %{kind: :info, title: name, lines: ["A opens the ROM library", "Core: #{core.label}"]}
+  end
+
+  def preview(%{kind: :system, name: name}, _column) do
+    %{kind: :info, title: name, lines: ["No installed core", "Install one from the web page"]}
+  end
+
+  def preview(%{kind: :rom, name: name, entry: entry}, _column) do
+    %{kind: :info, title: name, lines: ["A launches this ROM", bytes(entry.size)]}
+  end
+
   def preview(_node, _column), do: nil
 
   # What the entry *is*, before what it contains: its links, its size, its

--- a/lib/mayonnaios/game.ex
+++ b/lib/mayonnaios/game.ex
@@ -1,0 +1,54 @@
+defmodule MayonnaiOS.Game do
+  @moduledoc "Joins ROM-library entries to an installed RetroArch core and program."
+
+  alias MayonnaiOS.{Cores, Library, Programs}
+
+  @spec core_for(String.t()) :: {:ok, map()} | {:error, :no_core}
+  def core_for(system) do
+    available = Map.new(Cores.list(), &{&1.key, &1})
+
+    core =
+      :mayonnaios
+      |> Application.get_env(:core_priority, Cores.catalogue() |> Map.keys() |> Enum.sort())
+      |> Enum.find_value(fn key ->
+        case available[to_string(key)] do
+          %{available: true, systems: systems} = core -> if system in systems, do: core
+          _ -> nil
+        end
+      end)
+
+    case core do
+      nil -> {:error, :no_core}
+      core -> {:ok, Map.put(core, :path, Path.join(Cores.dir(), "#{core.name}_libretro.so"))}
+    end
+  end
+
+  @spec system_for(String.t()) :: map() | nil
+  def system_for(name) do
+    extension = name |> Path.extname() |> String.downcase()
+    Enum.find(Library.systems(), &(extension in &1.extensions))
+  end
+
+  @spec program(String.t(), String.t()) :: {:ok, map()} | {:error, atom()}
+  def program(system, rom_path) do
+    with {:ok, core} <- core_for(system),
+         %{} = retroarch <- retroarch() do
+      {:ok,
+       %{
+         retroarch
+         | name: Path.basename(rom_path),
+           args: retroarch.args ++ ["-L", core.path, rom_path]
+       }}
+    else
+      nil -> {:error, :no_retroarch}
+      error -> error
+    end
+  end
+
+  defp retroarch do
+    Enum.find(Programs.list(), fn program ->
+      program.name == "RetroArch" or
+        (is_binary(program.path) and Path.basename(program.path) == "retroarch")
+    end)
+  end
+end

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -201,7 +201,7 @@ defmodule MayonnaiOS.Launcher do
   use GenServer
   require Logger
 
-  alias MayonnaiOS.{Browser, Input, Led, Panel, Sleep, Splash, Theme}
+  alias MayonnaiOS.{Browser, Files, Game, Input, Led, Panel, Sleep, Splash, Theme}
 
   # The name the driver gives the gamepad, which is the only thing this module
   # knows about which device it is. There is no numbered fallback: /dev/input
@@ -1057,7 +1057,8 @@ defmodule MayonnaiOS.Launcher do
       Browser.full?(state.browser) -> state
       Browser.expandable?(node) -> browse(state, Browser.descend(state.browser))
       match?(%{kind: :program}, node) -> start_program(node.program, state)
-      match?(%{kind: :file}, node) -> browse(state, Browser.open_full(state.browser))
+      match?(%{kind: :rom}, node) -> launch_game(node.system, node.path, state)
+      match?(%{kind: :file}, node) -> launch_file(node, state)
       true -> state
     end
   end
@@ -1065,6 +1066,32 @@ defmodule MayonnaiOS.Launcher do
   defp do_launch(state) do
     Logger.info("[launcher] already running")
     state
+  end
+
+  defp launch_file(node, state) do
+    with %{} = system <- Game.system_for(node.name),
+         {:ok, location} <- Files.descend(Browser.focused(state.browser).location, node.name),
+         {:ok, path} <- Files.resolve(location) do
+      launch_game(system.key, path, state)
+    else
+      _ -> browse(state, Browser.open_full(state.browser))
+    end
+  end
+
+  defp launch_game(system, path, state) do
+    case Game.program(system, path) do
+      {:ok, program} ->
+        start_program(program, state)
+
+      {:error, :no_core} ->
+        browse(
+          state,
+          Browser.put_message(state.browser, :error, "No installed core for this system.")
+        )
+
+      {:error, :no_retroarch} ->
+        browse(state, Browser.put_message(state.browser, :error, "RetroArch is not configured."))
+    end
   end
 
   defp start_program(%{installed?: false} = program, state) do

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -1,0 +1,146 @@
+defmodule MayonnaiOS.GameTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.{Browser, Game, Launcher, Panel}
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "game-test-#{System.unique_integer([:positive])}")
+    core_dir = Path.join(root, "cores")
+    rom_root = Path.join(root, "roms")
+    retroarch = Path.join(root, "retroarch")
+    File.mkdir_p!(core_dir)
+    File.mkdir_p!(Path.join(rom_root, "snes"))
+    File.write!(Path.join(core_dir, "fake_libretro.so"), "core")
+    File.write!(Path.join(rom_root, "snes/chrono.sfc"), "rom")
+    File.write!(retroarch, "#!/bin/sh\nprintf '%s\\n' \"$@\"\nexit 3\n")
+    File.chmod!(retroarch, 0o755)
+
+    pickles_root = Path.join(root, "pickles")
+    File.mkdir_p!(pickles_root)
+
+    keys = [
+      :systems,
+      :rom_roots,
+      :file_roots,
+      :cores,
+      :core_dir,
+      :core_root,
+      :core_priority,
+      :programs,
+      :pickles_root
+    ]
+
+    previous = Map.new(keys, &{&1, Application.get_env(:mayonnaios, &1)})
+
+    Application.put_env(:mayonnaios, :systems, [
+      %{key: "snes", name: "Super Nintendo", extensions: [".sfc"]}
+    ])
+
+    Application.put_env(:mayonnaios, :rom_roots, [rom_root])
+
+    Application.put_env(:mayonnaios, :file_roots, [
+      %{key: "roms", path: Path.join(rom_root, "snes"), note: "test ROMs"}
+    ])
+
+    Application.put_env(:mayonnaios, :core_dir, core_dir)
+    Application.put_env(:mayonnaios, :core_root, Path.join(root, "core-bundles"))
+    Application.put_env(:mayonnaios, :core_priority, [:fake])
+    Application.put_env(:mayonnaios, :pickles_root, pickles_root)
+
+    Application.put_env(:mayonnaios, :cores, %{
+      fake: %{name: "fake", label: "Fake Core", systems: ["snes"], version: "1"}
+    })
+
+    Application.put_env(:mayonnaios, :programs, [
+      %{
+        name: "RetroArch",
+        path: retroarch,
+        args: ["--appendconfig", "shared.cfg"],
+        needs_udev: true
+      },
+      %{name: "Moonlight", path: "/nonexistent/moonlight"}
+    ])
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {key, nil} -> Application.delete_env(:mayonnaios, key)
+        {key, value} -> Application.put_env(:mayonnaios, key, value)
+      end)
+
+      File.rm_rf(root)
+      Panel.release()
+    end)
+
+    %{
+      core: Path.join(core_dir, "fake_libretro.so"),
+      retroarch: retroarch,
+      rom: Path.join(rom_root, "snes/chrono.sfc")
+    }
+  end
+
+  test "Games browses systems and merged library ROMs" do
+    games = Browser.new() |> Browser.descend()
+    assert Browser.selected(games).name == "Super Nintendo"
+
+    roms = Browser.descend(games)
+    assert %{kind: :rom, name: "chrono.sfc", system: "snes"} = Browser.selected(roms)
+  end
+
+  test "builds a direct RetroArch launch from the first available matching core", context do
+    assert {:ok, program} = Game.program("snes", context.rom)
+    assert program.path == context.retroarch
+    assert program.needs_udev
+    assert program.args == ["--appendconfig", "shared.cfg", "-L", context.core, context.rom]
+  end
+
+  test "A on a library ROM uses the ordinary external-program path", context do
+    start_supervised!({Launcher, device: "/nonexistent/event0"})
+
+    # Games -> Super Nintendo -> chrono.sfc -> launch.
+    Launcher.launch()
+    Launcher.launch()
+    Launcher.launch()
+
+    assert eventually(fn -> Launcher.obituary() end)
+    assert %{status: 3, lines: lines} = Launcher.obituary()
+    assert "-L" in lines
+    assert context.core in lines
+    assert context.rom in lines
+  end
+
+  test "A on a recognized ROM in Files launches it too", context do
+    start_supervised!({Launcher, device: "/nonexistent/event0"})
+
+    send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, :btn_dpad_down, 1}]})
+    Launcher.selected()
+    Launcher.launch()
+    Launcher.launch()
+    Launcher.launch()
+
+    assert eventually(fn -> Launcher.obituary() end)
+    assert %{lines: lines} = Launcher.obituary()
+    assert context.core in lines
+    assert context.rom in lines
+  end
+
+  test "external programs move to Apps when Games is a library" do
+    apps = Browser.new() |> Browser.move(2) |> Browser.descend()
+    assert Enum.map(Browser.focused(apps).entries, & &1.name) == ["RetroArch", "Moonlight"]
+  end
+
+  test "a recognized extension and missing core are explicit" do
+    assert Game.system_for("anything.sfc").key == "snes"
+    File.rm!(Path.join(Application.fetch_env!(:mayonnaios, :core_dir), "fake_libretro.so"))
+    assert Game.program("snes", "/tmp/chrono.sfc") == {:error, :no_core}
+  end
+
+  defp eventually(fun, attempts \\ 100)
+  defp eventually(_fun, 0), do: false
+
+  defp eventually(fun, attempts) do
+    case fun.() do
+      nil -> Process.sleep(10) && eventually(fun, attempts - 1)
+      value -> value
+    end
+  end
+end


### PR DESCRIPTION
Closes #44

## Summary
- make Games browse configured systems and the merged ROM library
- move configured external programs such as RetroArch and Moonlight to Apps
- resolve system to the first available core in explicit `:core_priority` order
- launch ROMs with the existing RetroArch program spec plus `-L <core> <rom>`
- give recognized ROM files the same A-button launch behavior in Files
- show distinct empty-library and missing-core states instead of opening a black screen

## Verification
- `mix compile --warnings-as-errors`
- `mix test` (1036/1037; only the existing process-liveness timing assertion at `test/launcher_test.exs:724` failed)
- new end-to-end tests execute a fake RetroArch from both Games and Files and assert the inherited append config, selected core, ROM path, udev flag, exit status, and obituary output