### PR TITLE
Keep game browser stable on non-ROM files

### DIFF
--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -748,8 +748,11 @@ defmodule MayonnaiOS.Browser do
 
   defp system_level(%{key: key, name: name, core: core}) do
     rows =
-      for entry <- Library.entries(key) do
-        {:ok, path} = Library.find(key, entry.name)
+      # The card can be removed, or a file deleted, between enumeration and
+      # resolution. A stale row is skipped rather than crashing the Scenic
+      # root while the cursor is merely previewing this system.
+      for entry <- Library.entries(key),
+          {:ok, path} <- [Library.find(key, entry.name)] do
         %{kind: :rom, name: entry.name, entry: entry, system: key, path: path}
       end
 

--- a/lib/mayonnaios/library.ex
+++ b/lib/mayonnaios/library.ex
@@ -126,10 +126,16 @@ defmodule MayonnaiOS.Library do
         {:error, _} -> []
       end
     end)
-    |> Enum.reject(fn {name, _} -> String.starts_with?(name, ".") end)
     |> Enum.flat_map(fn {name, path} ->
-      case File.stat(path) do
-        {:ok, %{type: :regular, size: size}} -> [%{name: name, size: size}]
+      # A system directory can contain metadata, cover art or files copied by
+      # another OS. Only return names this system can actually launch. Besides
+      # keeping the browser honest, this guarantees that a row returned here
+      # is accepted by `find/2` when the preview resolves it below.
+      with {:ok, name} <- safe_name(name),
+           :ok <- check_extension(sys, name),
+           {:ok, %{type: :regular, size: size}} <- File.stat(path) do
+        [%{name: name, size: size}]
+      else
         _ -> []
       end
     end)

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -86,6 +86,16 @@ defmodule MayonnaiOS.GameTest do
     assert %{kind: :rom, name: "chrono.sfc", system: "snes"} = Browser.selected(roms)
   end
 
+  test "previewing a system ignores regular files that are not ROMs", context do
+    File.write!(Path.join(Path.dirname(context.rom), "notes.txt"), "not a ROM")
+
+    games = Browser.new() |> Browser.descend()
+    assert Browser.selected(games).name == "Super Nintendo"
+
+    assert %{kind: :level, level: %{entries: [entry]}} = Browser.preview(games)
+    assert %{kind: :rom, name: "chrono.sfc", system: "snes"} = entry
+  end
+
   test "builds a direct RetroArch launch from the first available matching core", context do
     assert {:ok, program} = Game.program("snes", context.rom)
     assert program.path == context.retroarch


### PR DESCRIPTION
## Summary
- filter system listings to safe filenames with supported ROM extensions
- skip entries removed between enumeration and preview resolution
- add a Super Nintendo preview regression test with an unsupported regular file

## Verification
- 
22:11:14.128 [info] [device] MayonnaiOS host (host), 640x480, RTC present, lid switch absent
Running ExUnit with seed: 182321, max_cases: 24

.......
22:11:14.282 [info] [library] deleted dup.sfc

22:11:14.282 [info] [library] deleted dup.sfc
.......
22:11:14.309 [info] [library] deleted chrono.sfc
....
22:11:14.408 [info] [library] stored game.sfc (9 bytes)
......
22:11:14.423 [warning] [library] rejected game.sfc: {:read, :closed}
...
22:11:14.429 [info] [library] stored game.sfc (1 bytes)
.....
22:11:14.438 [warning] [library] rejected game.sfc: :too_large
..
22:11:14.442 [info] [library] stored game.sfc (4 bytes)

22:11:14.444 [info] [library] stored game.sfc (2 bytes)
.
22:11:14.447 [info] [library] deleted a.sfc
.
22:11:14.451 [info] [library] stored game.sfc (1 bytes)
......
22:11:14.480 [warning] [launcher] /nonexistent/event0 unavailable: :enoent

22:11:14.481 [info] [launcher] launching /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-644/retroarch --appendconfig shared.cfg -L /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-644/cores/fake_libretro.so /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-644/roms/snes/chrono.sfc

22:11:14.482 [warning] [launcher] udev unavailable: {:missing, "/sbin/udevd"}

22:11:14.817 [info] [chrono.sfc] --appendconfig

22:11:14.817 [info] [chrono.sfc] shared.cfg

22:11:14.817 [info] [chrono.sfc] -L

22:11:14.817 [info] [chrono.sfc] /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-644/cores/fake_libretro.so

22:11:14.817 [info] [chrono.sfc] /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-644/roms/snes/chrono.sfc

22:11:14.817 [info] [launcher] chrono.sfc exited (3)
...
22:11:14.874 [warning] [launcher] /nonexistent/event0 unavailable: :enoent

22:11:14.889 [info] [launcher] launching /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-772/retroarch --appendconfig shared.cfg -L /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-772/cores/fake_libretro.so /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-772/roms/snes/chrono.sfc

22:11:14.889 [warning] [launcher] udev unavailable: {:missing, "/sbin/udevd"}

22:11:15.187 [info] [chrono.sfc] --appendconfig

22:11:15.187 [info] [chrono.sfc] shared.cfg

22:11:15.187 [info] [chrono.sfc] -L

22:11:15.187 [info] [chrono.sfc] /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-772/cores/fake_libretro.so

22:11:15.187 [info] [chrono.sfc] /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/game-test-772/roms/snes/chrono.sfc

22:11:15.188 [info] [launcher] chrono.sfc exited (3)
..........................
22:11:15.376 [info] [files] moved /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/browser-test-2437/readme.txt -> /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/browser-test-2437/backup/readme.txt
............
22:11:15.454 [info] [files] deleted file /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/browser-test-3397/readme.txt
........
22:11:15.511 [warning] [files] delete /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/browser-test-11330/snes failed: :not_empty
.
22:11:15.534 [info] [files] copied /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/browser-test-3589/readme.txt -> /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/browser-test-3589/backup/readme.txt (2 bytes)
......
22:11:15.578 [info] [files] renamed /var/folders/7s/vmg5631s0w58sr3c8_fq14m00000gq/T/browser-test-11842/readme.txt -> seadme.txt
............
Finished in 1.4 seconds (0.2s async, 1.2s sync)

Result: 110 passed — 110 passed
- full suite — 1074/1078 passed; three unrelated cross-suite configuration failures pass in isolation, and the existing launcher SIGTERM timing test remains flaky