### PR TITLE
Add persisted automatic sleep toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Software:
 - Sleep on the power button, or after three minutes idle in the launcher: the
   backlight goes off, the renderer stops, WiFi goes down and three of the four
   cores go offline; any button brings it all back. The idle timer pauses while
-  charging and while a program or app is active. Not suspend — this board has
-  no suspend-to-RAM at all, and `MayonnaiOS.Sleep` and `MayonnaiOS.LowPower`
-  have the analysis and measurements
+  charging and while a program or app is active. **Automatic sleep: on/off**
+  under System disables that timer for development and remembers the choice
+  across reboots; the power button and explicit Sleep row still work. Not
+  suspend — this board has no suspend-to-RAM at all, and `MayonnaiOS.Sleep`
+  and `MayonnaiOS.LowPower` have the analysis and measurements
 - A NeXTSTEP-style column launcher: Games, Files, Apps and System open
   as columns, three on screen, and Files browses the whole filesystem in
   place

--- a/lib/mayonnaios/auto_sleep.ex
+++ b/lib/mayonnaios/auto_sleep.ex
@@ -1,0 +1,67 @@
+defmodule MayonnaiOS.AutoSleep do
+  @moduledoc """
+  The persisted switch for automatic idle sleep.
+
+  Manual sleep remains available through the power key and the System menu.
+  This switch only decides whether an idle launcher arms its three-minute
+  timer, so disabling it keeps a development device reachable over SSH.
+
+  The choice lives on the writable application partition rather than in the
+  firmware or VM state, and therefore survives both a reboot and a firmware
+  update. Unknown or unreadable contents fall back to configuration; a torn
+  setting must never silently change the device's policy.
+  """
+
+  @default_path "/root/.config/mayonnaios/auto_sleep"
+
+  @doc "Where the persisted switch is stored. Injectable for host tests."
+  @spec path() :: String.t()
+  def path, do: Application.get_env(:mayonnaios, :auto_sleep_path, @default_path)
+
+  @doc "Whether inactivity may put the launcher to sleep. Defaults to on."
+  @spec enabled?() :: boolean()
+  def enabled? do
+    case File.read(path()) do
+      {:ok, value} -> decode(value, configured_default())
+      {:error, _reason} -> configured_default()
+    end
+  end
+
+  @doc "Persist a new automatic-sleep policy."
+  @spec set(boolean()) :: :ok | {:error, File.posix()}
+  def set(enabled) when is_boolean(enabled) do
+    path = path()
+    temporary = path <> ".tmp"
+
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         :ok <- File.write(temporary, if(enabled, do: "enabled\n", else: "disabled\n")),
+         :ok <- File.rename(temporary, path) do
+      :ok
+    else
+      {:error, _reason} = error ->
+        File.rm(temporary)
+        error
+    end
+  end
+
+  @doc "Flip and persist the policy, returning its new value."
+  @spec toggle() :: {:ok, boolean()} | {:error, File.posix()}
+  def toggle do
+    enabled = not enabled?()
+
+    case set(enabled) do
+      :ok -> {:ok, enabled}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp configured_default, do: Application.get_env(:mayonnaios, :auto_sleep, true)
+
+  defp decode(value, fallback) do
+    case String.trim(value) do
+      "enabled" -> true
+      "disabled" -> false
+      _other -> fallback
+    end
+  end
+end

--- a/lib/mayonnaios/browser.ex
+++ b/lib/mayonnaios/browser.ex
@@ -95,7 +95,7 @@ defmodule MayonnaiOS.Browser do
   cursor.
   """
 
-  alias MayonnaiOS.{Files, Game, Library, Pickles, Programs}
+  alias MayonnaiOS.{AutoSleep, Files, Game, Library, Pickles, Programs}
   alias MayonnaiOS.Browser.View
 
   @typedoc "One entry in a column."
@@ -257,6 +257,19 @@ defmodule MayonnaiOS.Browser do
 
   def ascend(%{levels: levels} = browser) do
     %{browser | levels: Enum.drop(levels, -1), message: nil}
+  end
+
+  @doc "Rebuild the focused column from its parent, preserving its cursor."
+  @spec refresh(t()) :: t()
+  def refresh(%{levels: [_root]} = browser), do: browser
+
+  def refresh(%{levels: levels} = browser) do
+    parent = Enum.at(levels, -2)
+    current = List.last(levels)
+    node = Enum.at(parent.entries, parent.cursor)
+    fresh = expand(node)
+    cursor = current.cursor |> min(length(fresh.entries) - 1) |> max(0)
+    %{browser | levels: List.replace_at(levels, -1, %{fresh | cursor: cursor})}
   end
 
   @doc """
@@ -724,6 +737,12 @@ defmodule MayonnaiOS.Browser do
         [
           program_node(builtin("Diagnostics", :diagnostics)),
           program_node(builtin("Sleep", :sleep)),
+          program_node(
+            builtin(
+              "Automatic sleep: #{if(AutoSleep.enabled?(), do: "on", else: "off")}",
+              :toggle_auto_sleep
+            )
+          ),
           program_node(builtin("Theme", :cycle_theme))
         ] ++
         Enum.map(actions, &program_node/1)
@@ -747,10 +766,10 @@ defmodule MayonnaiOS.Browser do
   defp classify(_program), do: if(Library.systems() == [], do: :games, else: :apps)
 
   defp system_level(%{key: key, name: name, core: core}) do
+    # The card can be removed, or a file deleted, between enumeration and
+    # resolution. A stale row is skipped rather than crashing the Scenic
+    # root while the cursor is merely previewing this system.
     rows =
-      # The card can be removed, or a file deleted, between enumeration and
-      # resolution. A stale row is skipped rather than crashing the Scenic
-      # root while the cursor is merely previewing this system.
       for entry <- Library.entries(key),
           {:ok, path} <- [Library.find(key, entry.name)] do
         %{kind: :rom, name: entry.name, entry: entry, system: key, path: path}

--- a/lib/mayonnaios/launcher.ex
+++ b/lib/mayonnaios/launcher.ex
@@ -211,6 +211,7 @@ defmodule MayonnaiOS.Launcher do
   require Logger
 
   alias MayonnaiOS.{
+    AutoSleep,
     Browser,
     Device,
     Files,
@@ -505,6 +506,10 @@ defmodule MayonnaiOS.Launcher do
       kill_timeout: Keyword.get(opts, :kill_timeout, @kill_timeout),
       poll_ms: Keyword.get(opts, :poll_ms, @poll_ms),
       idle_sleep_ms: Keyword.get(opts, :idle_sleep_ms, @idle_sleep_ms),
+      # Read the persisted development switch once per Launcher lifetime.
+      # Button presses reset this timer, so reading the filesystem from every
+      # press would put a cold path in the hottest input path for no benefit.
+      auto_sleep: Keyword.get_lazy(opts, :auto_sleep, &AutoSleep.enabled?/0),
       idle_timer: nil,
       power_state:
         Keyword.get(opts, :power_state, fn ->
@@ -804,7 +809,9 @@ defmodule MayonnaiOS.Launcher do
     do: Enum.any?(events, &match?({:ev_key, _key, 1}, &1))
 
   defp idle_eligible?(state),
-    do: not state.asleep and state.port == nil and state.app == nil and state.scene == :home
+    do:
+      state.auto_sleep and not state.asleep and state.port == nil and state.app == nil and
+        state.scene == :home
 
   defp reset_idle_timer(state) do
     state = cancel_idle_timer(state)
@@ -1283,6 +1290,32 @@ defmodule MayonnaiOS.Launcher do
   defp start_program(%{action: :sleep}, state) do
     {_result, state} = enter_sleep(state)
     state
+  end
+
+  # Persisted development switch: automatic idle sleep is disabled without
+  # weakening either explicit route to sleep (the power key and row above).
+  defp start_program(%{action: :toggle_auto_sleep}, state) do
+    case AutoSleep.toggle() do
+      {:ok, enabled} ->
+        browser =
+          state.browser
+          |> Browser.refresh()
+          |> Browser.put_message(
+            :ok,
+            "Automatic sleep #{if(enabled, do: "enabled", else: "disabled")}."
+          )
+
+        state = %{state | browser: browser, auto_sleep: enabled}
+        state = if enabled, do: reset_idle_timer(state), else: cancel_idle_timer(state)
+        show(:home, state)
+        state
+
+      {:error, reason} ->
+        browse(
+          state,
+          Browser.put_message(state.browser, :error, "Could not save setting: #{inspect(reason)}")
+        )
+    end
   end
 
   # The Theme row: advances `MayonnaiOS.Theme` to the next built-in theme and

--- a/test/auto_sleep_test.exs
+++ b/test/auto_sleep_test.exs
@@ -1,0 +1,46 @@
+defmodule MayonnaiOS.AutoSleepTest do
+  use ExUnit.Case, async: false
+
+  alias MayonnaiOS.AutoSleep
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "auto-sleep-#{System.unique_integer([:positive])}")
+    path = Path.join(root, "nested/auto_sleep")
+    previous_path = Application.get_env(:mayonnaios, :auto_sleep_path)
+    previous_default = Application.get_env(:mayonnaios, :auto_sleep)
+    Application.put_env(:mayonnaios, :auto_sleep_path, path)
+    Application.put_env(:mayonnaios, :auto_sleep, true)
+
+    on_exit(fn ->
+      restore(:auto_sleep_path, previous_path)
+      restore(:auto_sleep, previous_default)
+      File.rm_rf(root)
+    end)
+
+    %{path: path}
+  end
+
+  test "defaults to configuration when no choice has been stored" do
+    assert AutoSleep.enabled?()
+    Application.put_env(:mayonnaios, :auto_sleep, false)
+    refute AutoSleep.enabled?()
+  end
+
+  test "set and toggle survive fresh reads", %{path: path} do
+    assert AutoSleep.set(false) == :ok
+    assert File.read!(path) == "disabled\n"
+    refute AutoSleep.enabled?()
+
+    assert AutoSleep.toggle() == {:ok, true}
+    assert AutoSleep.enabled?()
+  end
+
+  test "unknown contents fall back instead of changing policy", %{path: path} do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, "unfinished")
+    assert AutoSleep.enabled?()
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:mayonnaios, key)
+  defp restore(key, value), do: Application.put_env(:mayonnaios, key, value)
+end

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -96,6 +96,7 @@ defmodule MayonnaiOS.BrowserTest do
                "WiFi",
                "Diagnostics",
                "Sleep",
+               "Automatic sleep: on",
                "Theme",
                "Power off"
              ]
@@ -121,7 +122,15 @@ defmodule MayonnaiOS.BrowserTest do
       actions =
         for node <- List.last(system.levels).entries, do: node.program.action
 
-      assert actions == [nil, nil, :diagnostics, :sleep, :cycle_theme, :poweroff]
+      assert actions == [
+               nil,
+               nil,
+               :diagnostics,
+               :sleep,
+               :toggle_auto_sleep,
+               :cycle_theme,
+               :poweroff
+             ]
     end
   end
 

--- a/test/launcher_test.exs
+++ b/test/launcher_test.exs
@@ -1,7 +1,7 @@
 defmodule MayonnaiOS.LauncherTest do
   use ExUnit.Case, async: false
 
-  alias MayonnaiOS.{Browser, Launcher, Programs, Theme}
+  alias MayonnaiOS.{AutoSleep, Browser, Launcher, Programs, Theme}
   alias MayonnaiOS.Scene.Home
 
   # No viewport, no driver, no framebuffer. Everything here runs on the host,
@@ -545,12 +545,17 @@ defmodule MayonnaiOS.LauncherTest do
       path =
         Path.join(System.tmp_dir!(), "launcher-idle-sleep-#{System.unique_integer([:positive])}")
 
+      setting = path <> "-setting"
+
       File.write!(path, "1")
       Application.put_env(:mayonnaios, :backlight_brightness, path)
+      Application.put_env(:mayonnaios, :auto_sleep_path, setting)
 
       on_exit(fn ->
         Application.delete_env(:mayonnaios, :backlight_brightness)
+        Application.delete_env(:mayonnaios, :auto_sleep_path)
         File.rm(path)
+        File.rm(setting)
         Application.delete_env(:mayonnaios, :programs)
       end)
 
@@ -576,6 +581,18 @@ defmodule MayonnaiOS.LauncherTest do
       refute Launcher.asleep?()
       assert {_timer, next_token} = :sys.get_state(Launcher).idle_timer
       assert next_token != first_token
+    end
+
+    test "a disabled policy arms no timer but manual sleep still works", %{backlight: path} do
+      start_idle_launcher(:discharging, auto_sleep: false)
+
+      assert :sys.get_state(Launcher).idle_timer == nil
+      send(Launcher, {:idle_sleep, make_ref()})
+      refute Launcher.asleep?()
+
+      assert Launcher.sleep() == :ok
+      assert Launcher.asleep?()
+      assert File.read!(path) == "0"
     end
 
     test "a real press resets the timer but autorepeat does not" do
@@ -617,10 +634,14 @@ defmodule MayonnaiOS.LauncherTest do
       assert {_timer, _token} = :sys.get_state(Launcher).idle_timer
     end
 
-    defp start_idle_launcher(power_state) do
+    defp start_idle_launcher(power_state, opts \\ []) do
       start_supervised!(
         {Launcher,
-         device: "/nonexistent/event0", idle_sleep_ms: 60_000, power_state: fn -> power_state end}
+         [
+           device: "/nonexistent/event0",
+           idle_sleep_ms: 60_000,
+           power_state: fn -> power_state end
+         ] ++ opts}
       )
     end
 
@@ -634,6 +655,53 @@ defmodule MayonnaiOS.LauncherTest do
       send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 1}]})
       send(Launcher, {:input_event, "/nonexistent/event0", [{:ev_key, key, 0}]})
       Launcher.selected()
+    end
+  end
+
+  describe "the Automatic sleep row" do
+    setup do
+      path = Path.join(System.tmp_dir!(), "auto-sleep-row-#{System.unique_integer([:positive])}")
+      Application.put_env(:mayonnaios, :auto_sleep_path, path)
+
+      on_exit(fn ->
+        Application.delete_env(:mayonnaios, :auto_sleep_path)
+        File.rm(path)
+      end)
+
+      start_supervised!(
+        {Launcher, device: "/nonexistent/event0", idle_sleep_ms: 60_000, auto_sleep: true}
+      )
+
+      # System is one press up from Games. Diagnostics, Sleep, then the toggle.
+      tap(:btn_dpad_up)
+      tap(:btn_b)
+      tap(:btn_dpad_down)
+      tap(:btn_dpad_down)
+
+      assert Browser.selected(Launcher.browser()).name == "Automatic sleep: on"
+      :ok
+    end
+
+    test "A persists off, updates the row, and cancels the active timer" do
+      assert {_timer, _token} = :sys.get_state(Launcher).idle_timer
+
+      tap(:btn_b)
+
+      refute AutoSleep.enabled?()
+      refute :sys.get_state(Launcher).auto_sleep
+      assert :sys.get_state(Launcher).idle_timer == nil
+      assert Browser.selected(Launcher.browser()).name == "Automatic sleep: off"
+      assert Launcher.browser().message == {:ok, "Automatic sleep disabled."}
+    end
+
+    test "A twice persists on again and rearms the timer" do
+      tap(:btn_b)
+      tap(:btn_b)
+
+      assert AutoSleep.enabled?()
+      assert :sys.get_state(Launcher).auto_sleep
+      assert {_timer, _token} = :sys.get_state(Launcher).idle_timer
+      assert Browser.selected(Launcher.browser()).name == "Automatic sleep: on"
     end
   end
 
@@ -652,10 +720,11 @@ defmodule MayonnaiOS.LauncherTest do
          poweroff: fn -> send(test, :powered_off) end}
       )
 
-      # Into System -- the last category -- and down past Diagnostics, Sleep
-      # and Theme onto the Power off row, which sits last on purpose.
+      # Into System -- the last category -- and down past Diagnostics, Sleep,
+      # Automatic sleep and Theme onto the Power off row, which sits last.
       tap(:btn_dpad_up)
       tap(:btn_b)
+      tap(:btn_dpad_down)
       tap(:btn_dpad_down)
       tap(:btn_dpad_down)
       tap(:btn_dpad_down)
@@ -696,10 +765,11 @@ defmodule MayonnaiOS.LauncherTest do
 
       start_supervised!({Launcher, device: "/nonexistent/event0"})
 
-      # Into System -- the last category -- and down past Diagnostics and
-      # Sleep onto the Theme row.
+      # Into System -- the last category -- and down past Diagnostics, Sleep
+      # and Automatic sleep onto the Theme row.
       tap(:btn_dpad_up)
       tap(:btn_b)
+      tap(:btn_dpad_down)
       tap(:btn_dpad_down)
       tap(:btn_dpad_down)
 


### PR DESCRIPTION
Closes #65

## Summary
- add an Automatic sleep on/off row under System
- persist the choice across restarts and firmware updates
- cancel or rearm the launcher idle timer immediately when toggled
- keep manual sleep through the power key and Sleep row unchanged

## Verification
- 71 targeted persistence, browser, idle-timer, manual-sleep, and neighboring System-row tests passed
-  passed